### PR TITLE
Generate domain descriptor for transport context

### DIFF
--- a/tensorpipe/common/system.cc
+++ b/tensorpipe/common/system.cc
@@ -259,4 +259,15 @@ CpuId getCpu() {
   return static_cast<CpuId>(ret);
 }
 
+optional<std::string> getBootID() {
+  std::ifstream f{"/proc/sys/kernel/random/boot_id"};
+  if (!f.is_open()) {
+    return nullopt;
+  }
+  std::string v;
+  getline(f, v);
+  f.close();
+  return v;
+}
+
 } // namespace tensorpipe

--- a/tensorpipe/common/system.h
+++ b/tensorpipe/common/system.h
@@ -217,4 +217,7 @@ constexpr uint64_t maxPow2LessEqualThan(uint64_t n) noexcept {
   return nextPow2(n) >> 1;
 }
 
+// Return contents of /proc/sys/kernel/random/boot_id.
+optional<std::string> getBootID();
+
 } // namespace tensorpipe

--- a/tensorpipe/test/transport/shm/context_test.cc
+++ b/tensorpipe/test/transport/shm/context_test.cc
@@ -36,3 +36,14 @@ TEST(Context, Basics) {
 
   context->join();
 }
+
+TEST(Context, DomainDescriptor) {
+  auto context = std::make_shared<shm::Context>();
+
+  {
+    const auto& domainDescriptor = context->domainDescriptor();
+    EXPECT_FALSE(domainDescriptor.empty());
+  }
+
+  context->join();
+}

--- a/tensorpipe/test/transport/uv/context_test.cc
+++ b/tensorpipe/test/transport/uv/context_test.cc
@@ -36,3 +36,14 @@ TEST(Context, Basics) {
 
   context->join();
 }
+
+TEST(Context, DomainDescriptor) {
+  auto context = std::make_shared<uv::Context>();
+
+  {
+    const auto& domainDescriptor = context->domainDescriptor();
+    EXPECT_FALSE(domainDescriptor.empty());
+  }
+
+  context->join();
+}

--- a/tensorpipe/transport/context.h
+++ b/tensorpipe/transport/context.h
@@ -18,6 +18,19 @@ class Context {
   virtual std::shared_ptr<Connection> connect(address_t addr) = 0;
 
   virtual std::shared_ptr<Listener> listen(address_t addr) = 0;
+
+  // Return string to describe the domain for this context.
+  //
+  // Two processes with a context of the same type whose domain
+  // descriptors are identical can connect to each other.
+  //
+  // For example, for a transport that leverages TCP/IP, this may be
+  // as simple as the address family (assuming we can route between
+  // any two processes). For a transport that leverages shared memory,
+  // this descriptor must uniquely identify the machine, such that
+  // only co-located processes generate the same domain descriptor.
+  //
+  virtual const std::string& domainDescriptor() const = 0;
 };
 
 } // namespace transport

--- a/tensorpipe/transport/shm/context.h
+++ b/tensorpipe/transport/shm/context.h
@@ -19,8 +19,11 @@ class Context final : public transport::Context {
 
   std::shared_ptr<transport::Listener> listen(address_t addr) override;
 
+  const std::string& domainDescriptor() const override;
+
  private:
   std::shared_ptr<Loop> loop_;
+  std::string domainDescriptor_;
 };
 
 } // namespace shm

--- a/tensorpipe/transport/uv/context.cc
+++ b/tensorpipe/transport/uv/context.cc
@@ -7,7 +7,20 @@ namespace tensorpipe {
 namespace transport {
 namespace uv {
 
-Context::Context() : loop_(Loop::create()) {}
+namespace {
+
+// Prepend descriptor with transport name so it's easy to
+// disambiguate descriptors when debugging.
+const std::string kDomainDescriptorPrefix{"uv:"};
+
+std::string generateDomainDescriptor() {
+  return kDomainDescriptorPrefix + "*";
+}
+
+} // namespace
+
+Context::Context()
+    : loop_(Loop::create()), domainDescriptor_(generateDomainDescriptor()) {}
 
 Context::~Context() {}
 
@@ -21,6 +34,10 @@ std::shared_ptr<transport::Connection> Context::connect(address_t addr) {
 
 std::shared_ptr<transport::Listener> Context::listen(address_t addr) {
   return Listener::create(loop_, Sockaddr::createInetSockAddr(addr));
+}
+
+const std::string& Context::domainDescriptor() const {
+  return domainDescriptor_;
 }
 
 } // namespace uv

--- a/tensorpipe/transport/uv/context.h
+++ b/tensorpipe/transport/uv/context.h
@@ -19,8 +19,11 @@ class Context final : public transport::Context {
 
   std::shared_ptr<transport::Listener> listen(address_t addr) override;
 
+  const std::string& domainDescriptor() const override;
+
  private:
   std::shared_ptr<Loop> loop_;
+  std::string domainDescriptor_;
 };
 
 } // namespace uv


### PR DESCRIPTION
This can be used to determine if two peers can use a transport of a
particular type to connect to each other.