### PR TITLE
Call join in destructors if it wasn't called yet

### DIFF
--- a/tensorpipe/core/context.h
+++ b/tensorpipe/core/context.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <string>
 #include <thread>
@@ -24,9 +25,13 @@ class Context final {
 
   Context(ConstructorToken, const std::vector<std::string>&);
 
+  ~Context();
+
   void join();
 
  private:
+  std::atomic<bool> done_{false};
+
   std::unordered_map<std::string, std::shared_ptr<transport::Context>>
       contexts_;
 

--- a/tensorpipe/transport/shm/loop.cc
+++ b/tensorpipe/transport/shm/loop.cc
@@ -69,6 +69,12 @@ Loop::Loop(ConstructorToken /* unused */) {
 }
 
 Loop::~Loop() {
+  if (!done_) {
+    TP_LOG_WARNING()
+        << "The loop is being destroyed but join() wasn't called on it. "
+        << "Perhaps a scope exited prematurely, possibly due to an exception?";
+    join();
+  }
   TP_DCHECK(done_);
   TP_DCHECK(!thread_.joinable());
 }


### PR DESCRIPTION
We typically use shared_ptrs as "loose" unique_ptrs, which have one
"moral" owner, but for which we need to be able to hold additional
references for example in callbacks. (These references are stored as
weak_ptrs to avoid objects being kept artificially alive and thus
preventing leaks, and are only converted back to shared_ptrs when
needed). Because of this, however, when the "moral" owner resets its
shared_ptr it isn't guaranteed to immediately trigger the destruction
of the object, which may be delyed by these other short-lived
references. The join method is thus used to synchronously wait for
everything to be shut down, making the object "dead", even if the
object isn't destroyed yet.

Until now the user was always supposed to call the join method
manually just before destorying its pointer. However in cases where
the scope exited early, for example due to exceptions, this caused
issues. Namely, the exception handling would call the object's
destructor without having called join, which would cause an assert
to fail and thus a runtime_error to be raised from the destructor,
which would then cause the object's members to be destroyed, which
include a condition_variable on which a *non-joined* thread was
waiting. This manifested itself as a data race under tsan. This
hid the original error and made debugging very hard.