### PR TITLE
Fix race condition in SHM loop shutdown

### DIFF
--- a/tensorpipe/transport/shm/loop.cc
+++ b/tensorpipe/transport/shm/loop.cc
@@ -109,6 +109,11 @@ void Loop::unregisterDescriptor(int fd) {
       handlerCount_--;
     }
     handlers_[fd].reset();
+    // Maybe we're done and the event loop is waiting for the last handlers to
+    // be unregistered before terminating, so just in case we wake it up.
+    if (handlerCount_ == 1) {
+      wakeup();
+    }
   }
 }
 


### PR DESCRIPTION
The join method on the loop set the done_ flag to true and woke up
the loop for it to see that and shut down, but it would only do so
if there were no outstanding handlers, which wasn't always the case
due to the "delayed destruction" caused by our use of shared_ptrs.
However, when these last handlers were unregistered, they didn't
wake up the loop, which would thus miss the fact that its shutdown
condition had been reached and would deadlock.