### PR TITLE
Fix deadlock in UV loop

### DIFF
--- a/tensorpipe/transport/uv/connection.h
+++ b/tensorpipe/transport/uv/connection.h
@@ -159,8 +159,9 @@ class Connection : public transport::Connection,
   void writeCallback(int status);
 
   // Note: the containers below must never invalidate references.
-  std::mutex operationsMutex_;
+  std::mutex readOperationsMutex_;
   std::deque<ReadOperation> readOperations_;
+  std::mutex writeOperationsMutex_;
   std::deque<WriteOperation> writeOperations_;
 
   friend class Listener;


### PR DESCRIPTION
Here's how a deadlock could happen. Thread A is used code, thread B
is the loop.
- [A] calls uv::Connection::read() which acquires the operationsMutex_
- [B] starts handling a completed write (issued earlier)
- [A] calls uv::Loop::run() in order to call uv_read_start,
      which is queued to be run after the handling of the above write
      but thread A will blockingly wait for this to happen
- [B] calls uv::Connection::writeCallback() to handle the write,
      which tries to acquire the operationsMutex_, and deadlocks

A simple fix to this specific problem is to use separate mutexes for
reads and writes, which I'm doing here, but it's not a complete fix
because the same problem could occur with the loop handling a read
callback instead of a write callback.

We can't release the readOperationsMutex_ while we call
StreamHandle::readStart or StreamHandle::readStop because the following
could happen:
- [B] starts handling a completed read
- [B] calls uv::Connection::readCallback, which acquires the
      readOperationsMutex_, removes the ReadOperation, realizing it
      was the last one, so it releases the mutex and is about to
      call readStop when it's preempted
- [A] calls uv::Connection::read, which acquires the readOperationsMutex_,
      adds the ReadOperation, realizing it's the first one, so it
      releases the mutex and calls readStart
- [B] calls readStop
Now we have a read operation pending but reading is stopped.

Similarly we can't release the writeOperationsMutex_ while we call
StreamHandle::write as this could cause the uv_write calls to be in
a different order than the pending WriteOperations (meaning we send
data in the bad order and we call the wrong callbacks).

The only thing we care about is to issue the uv_read_start/_stop and
the uv_write operations in the same order as the manipulations on the
Read/WriteOperations. For that we just need to schedule these calls
into the Loop's queue in the right order. No need to wait for them to
actually run. So we can call Loop::defer instead of Loop::run, while
keeping the mutex locked.