### PR TITLE
Add base class for channel factories and channels

### DIFF
--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TENSORPIPE_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/common/address.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/common/system.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/core/channel.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/core/context.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/core/error.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/core/listener.cc
@@ -17,6 +18,7 @@ set(TENSORPIPE_HEADERS
   ${CMAKE_CURRENT_SOURCE_DIR}/common/optional.h
   ${CMAKE_CURRENT_SOURCE_DIR}/common/queue.h
   ${CMAKE_CURRENT_SOURCE_DIR}/common/system.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/core/channel.h
   ${CMAKE_CURRENT_SOURCE_DIR}/core/context.h
   ${CMAKE_CURRENT_SOURCE_DIR}/core/error.h
   ${CMAKE_CURRENT_SOURCE_DIR}/core/listener.h

--- a/tensorpipe/core/channel.cc
+++ b/tensorpipe/core/channel.cc
@@ -1,0 +1,35 @@
+#include <tensorpipe/core/channel.h>
+
+namespace tensorpipe {
+
+ChannelFactory::ChannelFactory(std::string name) : name_(std::move(name)) {}
+
+ChannelFactory::~ChannelFactory() {}
+
+const std::string& ChannelFactory::name() const {
+  return name_;
+}
+
+std::pair<Channel::TDescriptor, std::future<void>> Channel::send(
+    const void* ptr,
+    size_t length) {
+  auto promise = std::make_shared<std::promise<void>>();
+  auto future = promise->get_future();
+  auto descriptor = send(
+      ptr, length, [promise{std::move(promise)}] { promise->set_value(); });
+  return {std::move(descriptor), std::move(future)};
+}
+
+std::future<void> Channel::recv(
+    TDescriptor descriptor,
+    void* ptr,
+    size_t length) {
+  auto promise = std::make_shared<std::promise<void>>();
+  auto future = promise->get_future();
+  recv(std::move(descriptor), ptr, length, [promise{std::move(promise)}] {
+    promise->set_value();
+  });
+  return future;
+}
+
+} // namespace tensorpipe

--- a/tensorpipe/core/channel.h
+++ b/tensorpipe/core/channel.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include <future>
+#include <memory>
+#include <vector>
+
+#include <tensorpipe/common/optional.h>
+#include <tensorpipe/transport/connection.h>
+
+// Channels are an out of band mechanism to transfer data between
+// processes. Examples include a direct address space to address space
+// memory copy on the same machine, or a GPU-to-GPU memory copy.
+//
+// Construction of a channel happens as follows.
+//
+//   1) During initialization of a pipe, the connecting peer sends its
+//      list of channel factories and their domain descriptors. The
+//      domain descriptor is used to determine whether or not a
+//      channel can be used by a pair of peers.
+//   2) The listening side of the pipe compares the list it received
+//      its own list to determine the list of channels should be used
+//      for the peers.
+//   3) For every channel that should be constructed, the listening
+//      side registers a slot with its low level listener. These slots
+//      uniquely identify inbound connections on this listener (by
+//      sending a word-sized indentifier immediately after connecting)
+//      and can be used to construct new connections. These slots are
+//      sent to the connecting side of the pipe, which then attempts
+//      to establish a new connection for every token.
+//   4) At this time, we have a new control connection for every
+//      channel that is about to be constructed. Both sides of the
+//      pipe can now create the channel instance using the newly
+//      created connection. Further initialization that needs to
+//      happen is defered to the channel implementation. We assume the
+//      channel is usable from the moment it is constructed.
+//
+namespace tensorpipe {
+
+// Abstract base class for channel classes.
+class Channel {
+ public:
+  using TDescriptor = std::vector<uint8_t>;
+  using TSendCallback = std::function<void()>;
+  using TRecvCallback = std::function<void()>;
+
+  // Send memory region to peer.
+  virtual TDescriptor send(
+      const void* ptr,
+      size_t length,
+      TSendCallback callback) = 0;
+
+  // Receive memory region from peer.
+  virtual void recv(
+      TDescriptor descriptor,
+      void* ptr,
+      size_t length,
+      TRecvCallback callback) = 0;
+
+  // Send memory region to peer (but return a future).
+  [[nodiscard]] std::pair<TDescriptor, std::future<void>> send(
+      const void* ptr,
+      size_t length);
+
+  // Receive memory region from peer (but return a future).
+  [[nodiscard]] std::future<void> recv(
+      TDescriptor descriptor,
+      void* ptr,
+      size_t length);
+};
+
+// Abstract base class for channel factory classes.
+//
+// Instances of these classes are expected to be registered with a
+// context. All registered instances are assumed to be eligible
+// channels for all pairs.
+//
+class ChannelFactory {
+ public:
+  explicit ChannelFactory(std::string name);
+
+  virtual ~ChannelFactory();
+
+  // Return the factory's name.
+  const std::string& name() const;
+
+  // Return string to describe the domain for this channel.
+  //
+  // Two processes with a channel factory of the same type whose
+  // domain descriptors are identical can connect to each other.
+  //
+  virtual const std::string& domainDescriptor() const = 0;
+
+  // Return newly created channel using the specified connection.
+  //
+  // It is up to the channel to either use this connection for further
+  // initialization, or use it directly. Either way, the returned
+  // channel should be immediately usable. If the channel isn't fully
+  // initialized yet, take care to queue these operations to execute
+  // as soon as initialization has completed.
+  //
+  virtual std::shared_ptr<Channel> createChannel(
+      std::shared_ptr<transport::Connection>) = 0;
+
+ private:
+  std::string name_;
+};
+
+} // namespace tensorpipe

--- a/tensorpipe/test/core/CMakeLists.txt
+++ b/tensorpipe/test/core/CMakeLists.txt
@@ -2,3 +2,6 @@ add_tensorpipe_test(core_context_test context_test.cc)
 target_link_libraries(core_context_test tensorpipe)
 target_link_libraries(core_context_test tensorpipe_shm)
 target_link_libraries(core_context_test tensorpipe_uv)
+
+add_tensorpipe_test(core_channel_test channel_test.cc)
+target_link_libraries(core_context_test tensorpipe)

--- a/tensorpipe/test/core/channel_test.cc
+++ b/tensorpipe/test/core/channel_test.cc
@@ -1,0 +1,262 @@
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <thread>
+#include <unordered_map>
+
+#include <tensorpipe/common/callback.h>
+#include <tensorpipe/common/defs.h>
+#include <tensorpipe/common/queue.h>
+#include <tensorpipe/core/channel.h>
+#include <tensorpipe/transport/error.h>
+#include <tensorpipe/transport/uv/context.h>
+
+#include <gtest/gtest.h>
+
+using namespace tensorpipe;
+
+namespace {
+
+template <
+    typename T,
+    typename std::enable_if<std::is_trivially_copyable<T>::value, bool>::type =
+        false>
+T bufferToType(const void* ptr, size_t len) {
+  T ret;
+  TP_DCHECK_EQ(len, sizeof(ret));
+  std::memcpy(&ret, ptr, len);
+  return ret;
+}
+
+template <
+    typename T,
+    typename std::enable_if<std::is_trivially_copyable<T>::value, bool>::type =
+        false>
+T bufferToType(std::vector<uint8_t> buf) {
+  T ret;
+  TP_DCHECK_EQ(buf.size(), sizeof(ret));
+  std::memcpy(&ret, buf.data(), buf.size());
+  return ret;
+}
+
+template <
+    typename T,
+    typename std::enable_if<std::is_trivially_copyable<T>::value, bool>::type =
+        false>
+std::vector<uint8_t> typeToBuffer(const T& t) {
+  std::vector<uint8_t> ret(sizeof(t));
+  std::memcpy(ret.data(), &t, sizeof(t));
+  return ret;
+}
+
+// Forward declaration.
+class TestChannelFactory;
+
+// Implementation of tensorpipe::Channel for test purposes.
+class TestChannel : public Channel,
+                    public std::enable_shared_from_this<TestChannel> {
+  // Store pointer and length in descriptor.
+  // This test runs in a single process so we can use memcpy directly.
+  struct Descriptor {
+    const void* ptr{nullptr};
+    size_t length{0};
+  };
+
+  // Message sent by receiver when recv has completed.
+  struct DoneMessage {
+    bool done{true};
+  };
+
+ public:
+  explicit TestChannel(std::shared_ptr<transport::Connection> connection)
+      : connection_(std::move(connection)) {}
+
+  TDescriptor send(const void* ptr, size_t length, TSendCallback callback)
+      override {
+    std::unique_lock<std::mutex> lock(mutex_);
+    sendCallbacks_.emplace_back(std::move(callback));
+    return typeToBuffer(Descriptor{ptr, length});
+  }
+
+  void recv(
+      TDescriptor descriptorBuffer,
+      void* ptr,
+      size_t length,
+      TRecvCallback callback) override {
+    const auto descriptor = bufferToType<Descriptor>(descriptorBuffer);
+    TP_DCHECK_EQ(length, descriptor.length);
+    std::memcpy(ptr, descriptor.ptr, length);
+
+    // Send message to peer that the recv is done.
+    auto vec = std::make_shared<std::vector<uint8_t>>();
+    *vec = typeToBuffer(DoneMessage());
+    connection_->write(
+        vec->data(),
+        vec->size(),
+        [callback{std::move(callback)}](const transport::Error& error) {
+          TP_LOG_WARNING_IF(error) << error.what();
+          callback();
+        });
+  }
+
+ private:
+  void init_() {
+    nextRead_();
+  }
+
+  void nextRead_() {
+    connection_->read(runIfAlive(
+        *this,
+        std::function<void(
+            TestChannel&, const transport::Error&, const void*, size_t)>(
+            [](TestChannel& channel,
+               const transport::Error& error,
+               const void* ptr,
+               size_t len) {
+              TP_LOG_WARNING_IF(error) << error.what();
+              channel.onDoneMessage_(bufferToType<DoneMessage>(ptr, len));
+            })));
+  }
+
+  void onDoneMessage_(DoneMessage /* unused */) {
+    TSendCallback callback;
+
+    {
+      std::unique_lock<std::mutex> lock(mutex_);
+      callback = std::move(sendCallbacks_.front());
+      sendCallbacks_.pop_front();
+    }
+
+    callback();
+    nextRead_();
+  }
+
+  friend class TestChannelFactory;
+
+ private:
+  std::mutex mutex_;
+
+  // Control connection for this channel.
+  // Used only to send acknowledgment of receipt to sender in this test.
+  std::shared_ptr<transport::Connection> connection_;
+
+  // Keep ordered list of send callbacks.
+  // This assumes that send and recv are called in the same order.
+  std::deque<TSendCallback> sendCallbacks_;
+};
+
+class TestChannelFactory : public ChannelFactory {
+ public:
+  TestChannelFactory() : ChannelFactory("TestChannelFactory") {
+    std::ostringstream oss;
+    oss << name() << ":" << getpid();
+    domainDescriptor_ = oss.str();
+  }
+
+  ~TestChannelFactory() override {}
+
+  const std::string& domainDescriptor() const override {
+    return domainDescriptor_;
+  }
+
+  std::shared_ptr<Channel> createChannel(
+      std::shared_ptr<transport::Connection> conn) override {
+    auto channel = std::make_shared<TestChannel>(std::move(conn));
+    channel->init_();
+    return channel;
+  }
+
+ private:
+  std::string domainDescriptor_;
+};
+
+void testConnectionPair(
+    std::function<void(std::shared_ptr<transport::Connection>)> f1,
+    std::function<void(std::shared_ptr<transport::Connection>)> f2) {
+  auto context = std::make_shared<transport::uv::Context>();
+  auto addr = "::1";
+
+  {
+    Queue<std::shared_ptr<transport::Connection>> q1, q2;
+
+    // Listening side.
+    auto listener = context->listen(addr);
+    listener->accept([&](std::shared_ptr<transport::Connection> connection) {
+      q1.push(std::move(connection));
+    });
+
+    // Connecting side.
+    q2.push(context->connect(listener->addr()));
+
+    // Run user specified functions.
+    std::thread t1([&] { f1(q1.pop()); });
+    std::thread t2([&] { f2(q2.pop()); });
+    t1.join();
+    t2.join();
+  }
+
+  context->join();
+}
+
+} // namespace
+
+TEST(ChannelFactory, Name) {
+  std::shared_ptr<ChannelFactory> factory =
+      std::make_shared<TestChannelFactory>();
+  EXPECT_EQ(factory->name(), "TestChannelFactory");
+}
+
+TEST(ChannelFactory, DomainDescriptor) {
+  std::shared_ptr<ChannelFactory> factory1 =
+      std::make_shared<TestChannelFactory>();
+  std::shared_ptr<ChannelFactory> factory2 =
+      std::make_shared<TestChannelFactory>();
+  EXPECT_FALSE(factory1->domainDescriptor().empty());
+  EXPECT_FALSE(factory2->domainDescriptor().empty());
+  EXPECT_EQ(factory1->domainDescriptor(), factory2->domainDescriptor());
+}
+
+TEST(ChannelFactory, CreateChannel) {
+  std::shared_ptr<ChannelFactory> factory1 =
+      std::make_shared<TestChannelFactory>();
+  std::shared_ptr<ChannelFactory> factory2 =
+      std::make_shared<TestChannelFactory>();
+  constexpr auto dataSize = 256;
+  Queue<Channel::TDescriptor> descriptorQueue;
+
+  testConnectionPair(
+      [&](std::shared_ptr<transport::Connection> conn) {
+        auto channel = factory1->createChannel(std::move(conn));
+
+        // Initialize with sequential values.
+        std::vector<uint8_t> data(256);
+        for (auto i = 0; i < data.size(); i++) {
+          data[i] = i;
+        }
+
+        // Perform send and wait for completion.
+        Channel::TDescriptor descriptor;
+        std::future<void> future;
+        std::tie(descriptor, future) = channel->send(data.data(), data.size());
+        descriptorQueue.push(std::move(descriptor));
+        future.wait();
+      },
+      [&](std::shared_ptr<transport::Connection> conn) {
+        auto channel = factory2->createChannel(std::move(conn));
+
+        // Initialize with zeroes.
+        std::vector<uint8_t> data(256);
+        for (auto i = 0; i < data.size(); i++) {
+          data[i] = 0;
+        }
+
+        // Perform recv and wait for completion.
+        channel->recv(descriptorQueue.pop(), data.data(), data.size()).wait();
+
+        // Validate contents of vector.
+        for (auto i = 0; i < data.size(); i++) {
+          EXPECT_EQ(data[i], i);
+        }
+      });
+}


### PR DESCRIPTION
The API is tested with a dummy implementation in
`tensorpipe/test/core/channel_test.cc`. Implementation of actual
channels to be committed to `tensorpipe/channels`.