### PR TITLE
Add test for large writes with uv transport

### DIFF
--- a/tensorpipe/test/transport/uv/connection_test.cc
+++ b/tensorpipe/test/transport/uv/connection_test.cc
@@ -55,28 +55,22 @@ TEST(Connection, Initialization) {
   auto loop = uv::Loop::create();
   auto addr = uv::Sockaddr::createInetSockAddr("127.0.0.1");
   constexpr size_t numBytes = 13;
+  std::array<char, numBytes> garbage;
 
   initializePeers(
       loop,
       addr,
       [&](std::shared_ptr<Connection> conn) {
-        Queue<size_t> reads;
-        conn->read([&](const Error& error, const void* ptr, size_t len) {
+        conn->read([&, conn](const Error& error, const void* ptr, size_t len) {
           ASSERT_FALSE(error) << error.what();
-          reads.push(len);
+          ASSERT_EQ(garbage.size(), len);
         });
-        // Wait for the read callback to be called.
-        ASSERT_EQ(numBytes, reads.pop());
       },
       [&](std::shared_ptr<Connection> conn) {
-        Queue<bool> writes;
-        std::array<char, numBytes> garbage;
-        conn->write(garbage.data(), garbage.size(), [&](const Error& error) {
-          ASSERT_FALSE(error) << error.what();
-          writes.push(true);
-        });
-        // Wait for the write callback to be called.
-        writes.pop();
+        conn->write(
+            garbage.data(), garbage.size(), [&, conn](const Error& error) {
+              ASSERT_FALSE(error) << error.what();
+            });
       });
 
   loop->join();
@@ -93,12 +87,9 @@ TEST(Connection, InitializationError) {
         // Closes connection
       },
       [&](std::shared_ptr<Connection> conn) {
-        Queue<Error> errors;
-        conn->read([&](const Error& error, const void* ptr, size_t len) {
-          errors.push(error);
+        conn->read([&, conn](const Error& error, const void* ptr, size_t len) {
+          ASSERT_TRUE(error);
         });
-        auto error = errors.pop();
-        ASSERT_TRUE(error);
       });
 
   loop->join();


### PR DESCRIPTION
+ Add test that sends a 16MB message through UV and ensures it is received properly.
+ Simplify other tests by capturing connection in callback rather than using a queue.