### PR TITLE
Fix missing error argument to accept callback

### DIFF
--- a/tensorpipe/test/core/channel_test.cc
+++ b/tensorpipe/test/core/channel_test.cc
@@ -190,7 +190,9 @@ void testConnectionPair(
 
     // Listening side.
     auto listener = context->listen(addr);
-    listener->accept([&](std::shared_ptr<transport::Connection> connection) {
+    listener->accept([&](const transport::Error& error,
+                         std::shared_ptr<transport::Connection> connection) {
+      ASSERT_FALSE(error) << error.what();
       q1.push(std::move(connection));
     });
 


### PR DESCRIPTION
This was caused by a merge race between 026f8103 and 78cd4117.