### PR TITLE
Add reactor thread for shm transport

### DIFF
--- a/tensorpipe/test/transport/shm/CMakeLists.txt
+++ b/tensorpipe/test/transport/shm/CMakeLists.txt
@@ -9,6 +9,7 @@ add_tensorpipe_test(transport_shm_test
   context_test.cc
   listener_test.cc
   loop_test.cc
+  reactor_test.cc
   sockaddr_test.cc
   )
 target_link_libraries(transport_shm_test tensorpipe_shm)

--- a/tensorpipe/test/transport/shm/reactor_test.cc
+++ b/tensorpipe/test/transport/shm/reactor_test.cc
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <tensorpipe/common/defs.h>
+#include <tensorpipe/common/queue.h>
+#include <tensorpipe/transport/shm/reactor.h>
+#include <tensorpipe/transport/shm/socket.h>
+
+#include <gtest/gtest.h>
+
+using namespace tensorpipe::transport::shm;
+
+namespace {
+
+void run(std::function<void(int)> fn1, std::function<void(int)> fn2) {
+  int fds[2];
+
+  {
+    auto rv = socketpair(AF_UNIX, SOCK_STREAM, 0, fds);
+    if (rv != 0) {
+      TP_THROW_SYSTEM(errno) << "Failed to create socket pair";
+    }
+  }
+
+  {
+    auto pid = fork();
+    TP_DCHECK_GE(pid, 0);
+    if (pid == 0) {
+      close(fds[0]);
+      fn2(fds[1]);
+      close(fds[1]);
+      exit(0);
+    }
+  }
+
+  close(fds[1]);
+  fn1(fds[0]);
+  close(fds[0]);
+  wait(nullptr);
+}
+
+} // namespace
+
+TEST(Reactor, Basic) {
+  run(
+      [](int fd) {
+        tensorpipe::Queue<int> queue;
+        auto reactor = std::make_shared<Reactor>();
+        auto token = reactor->add([&] { queue.push(1); });
+
+        // Share reactor fds and token with other process.
+        {
+          auto socket = Socket(fd);
+          auto fds = reactor->fds();
+          auto error = socket.sendPayloadAndFds(
+              token, std::get<0>(fds), std::get<1>(fds));
+          ASSERT_FALSE(error) << error.what();
+        }
+
+        // Wait for other process to run trigger.
+        queue.pop();
+      },
+      [](int fd) {
+        Reactor::TToken token;
+        Fd header;
+        Fd data;
+
+        // Wait for other process to share reactor fds and token.
+        {
+          auto socket = Socket(fd);
+          auto error = socket.recvPayloadAndFds(token, header, data);
+          ASSERT_FALSE(error) << error.what();
+        }
+
+        // Create and run trigger. This should wake up the other
+        // process and run the registered function.
+        Reactor::Trigger trigger(std::move(header), std::move(data), token);
+        trigger.run();
+      });
+}
+
+TEST(Reactor, TokenReuse) {
+  tensorpipe::Queue<int> queue(3);
+  auto reactor = std::make_shared<Reactor>();
+  auto t1 = reactor->add([&] { queue.push(1); });
+  auto t2 = reactor->add([&] { queue.push(2); });
+  auto t3 = reactor->add([&] { queue.push(3); });
+
+  // Check that they're monotonically increasing.
+  ASSERT_GT(t2, t1);
+  ASSERT_GT(t3, t2);
+
+  // Remove token and check that it is reused.
+  reactor->remove(t1);
+  auto t4 = reactor->add([&] { queue.push(4); });
+  ASSERT_EQ(t4, t1);
+
+  // Remove multiple tokens and check that they're reused in order.
+  reactor->remove(t2);
+  reactor->remove(t3);
+  auto t5 = reactor->add([&] { queue.push(5); });
+  auto t6 = reactor->add([&] { queue.push(6); });
+  ASSERT_EQ(t5, t2);
+  ASSERT_EQ(t6, t3);
+}

--- a/tensorpipe/transport/shm/CMakeLists.txt
+++ b/tensorpipe/transport/shm/CMakeLists.txt
@@ -4,5 +4,5 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-add_library(tensorpipe_shm context.cc connection.cc fd.cc listener.cc loop.cc socket.cc)
+add_library(tensorpipe_shm context.cc connection.cc fd.cc listener.cc loop.cc reactor.cc socket.cc)
 target_link_libraries(tensorpipe_shm tensorpipe)

--- a/tensorpipe/transport/shm/reactor.cc
+++ b/tensorpipe/transport/shm/reactor.cc
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/transport/shm/reactor.h>
+
+#include <tensorpipe/util/ringbuffer/shm.h>
+
+namespace tensorpipe {
+namespace transport {
+namespace shm {
+
+namespace {
+
+void writeToken(TReactorProducer& producer, Reactor::TToken token) {
+  for (;;) {
+    auto rv = producer.write(token);
+    if (rv == -EAGAIN) {
+      std::this_thread::yield();
+      continue;
+    }
+    TP_DCHECK_EQ(rv, sizeof(token));
+    break;
+  }
+}
+
+} // namespace
+
+Reactor::Reactor() {
+  int headerFd;
+  int dataFd;
+  std::shared_ptr<TReactorRingBuffer> rb;
+  std::tie(headerFd, dataFd, rb) =
+      util::ringbuffer::shm::create<TReactorRingBuffer>(kSize);
+  headerFd_ = Fd(headerFd);
+  dataFd_ = Fd(dataFd);
+  consumer_.emplace(rb);
+  producer_.emplace(rb);
+  thread_ = std::thread(&Reactor::run, this);
+}
+
+Reactor::~Reactor() {
+  done_.store(true);
+  thread_.join();
+}
+
+Reactor::TToken Reactor::add(TFunction fn) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  TToken token;
+
+  // Either reuse a token or generate a new one.
+  auto it = reusableTokens_.begin();
+  if (it != reusableTokens_.end()) {
+    token = *it;
+    reusableTokens_.erase(it);
+  } else {
+    // If there are no reusable tokens, the next token is always equal
+    // to the number of tokens in use + 1.
+    token = functions_.size();
+  }
+
+  // Ensure there is enough space in the functions vector.
+  if (functions_.size() <= token) {
+    functions_.resize(token + 1);
+  }
+
+  functions_[token] = std::move(fn);
+  return token;
+}
+
+void Reactor::remove(TToken token) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  functions_[token] = nullptr;
+  reusableTokens_.insert(token);
+}
+
+void Reactor::trigger(TToken token) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  writeToken(producer_.value(), token);
+}
+
+std::tuple<int, int> Reactor::fds() const {
+  return std::make_tuple(headerFd_.fd(), dataFd_.fd());
+}
+
+void Reactor::run() {
+  while (!done_.load()) {
+    uint32_t token;
+    auto ret = consumer_->copy(token);
+    if (ret == -ENODATA) {
+      std::this_thread::yield();
+      continue;
+    }
+
+    TFunction fn;
+
+    // Make copy of std::function so we don't need
+    // to hold the lock while executing it.
+    {
+      std::unique_lock<std::mutex> lock(mutex_);
+      TP_DCHECK_LT(token, functions_.size());
+      fn = functions_[token];
+    }
+
+    if (fn) {
+      fn();
+    }
+  }
+}
+
+Reactor::Trigger::Trigger(Fd&& headerFd, Fd&& dataFd, TToken token)
+    : producer_(util::ringbuffer::shm::load<TReactorRingBuffer>(
+          // The header and data segment objects take over ownership
+          // of file descriptors. Release them to avoid double close.
+          headerFd.release(),
+          dataFd.release())),
+      token_(token) {}
+
+void Reactor::Trigger::run() {
+  writeToken(producer_, token_);
+}
+
+} // namespace shm
+} // namespace transport
+} // namespace tensorpipe

--- a/tensorpipe/transport/shm/reactor.h
+++ b/tensorpipe/transport/shm/reactor.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <functional>
+#include <mutex>
+#include <set>
+#include <thread>
+#include <vector>
+
+#include <tensorpipe/common/optional.h>
+#include <tensorpipe/transport/shm/fd.h>
+#include <tensorpipe/util/ringbuffer/consumer.h>
+#include <tensorpipe/util/ringbuffer/producer.h>
+
+namespace tensorpipe {
+namespace transport {
+namespace shm {
+
+// Extra data stored in ring buffer header.
+struct ReactorRingBufferExtraData {};
+
+using TReactorRingBuffer =
+    util::ringbuffer::RingBuffer<ReactorRingBufferExtraData>;
+using TReactorProducer = util::ringbuffer::Producer<ReactorRingBufferExtraData>;
+using TReactorConsumer = util::ringbuffer::Consumer<ReactorRingBufferExtraData>;
+
+// Reactor loop.
+//
+// Companion class to the event loop in `loop.h` that executes
+// functions on triggers. The triggers are posted to a shared memory
+// ring buffer, so this can be done by other processes on the same
+// machine. It uses extra data in the ring buffer header to store a
+// mutex and condition variable to avoid a busy loop.
+//
+class Reactor final : public std::enable_shared_from_this<Reactor> {
+  // This allows for buffering 2k triggers (at 4 bytes a piece).
+  static constexpr auto kSize = 8192;
+
+ public:
+  using TFunction = std::function<void()>;
+  using TToken = uint32_t;
+
+  explicit Reactor();
+
+  ~Reactor();
+
+  // Add function to the reactor.
+  // Returns token that can be used to trigger it.
+  TToken add(TFunction fn);
+
+  // Removes function associated with token from reactor.
+  void remove(TToken token);
+
+  // Trigger reactor with specified token.
+  void trigger(TToken token);
+
+  // Returns the file descriptors for the underlying ring buffer.
+  std::tuple<int, int> fds() const;
+
+ private:
+  Fd headerFd_;
+  Fd dataFd_;
+  optional<TReactorConsumer> consumer_;
+  optional<TReactorProducer> producer_;
+
+  std::mutex mutex_;
+  std::thread thread_;
+  std::atomic_bool done_{false};
+
+  // Reactor thread entry point.
+  void run();
+
+  // Tokens are placed in this set if they can be reused.
+  std::set<TToken> reusableTokens_;
+
+  // Map reactor tokens to functions.
+  //
+  // The tokens are reused so we don't worry about unbounded growth
+  // and comfortably use a std::vector here.
+  //
+  std::vector<TFunction> functions_;
+
+ public:
+  class Trigger {
+   public:
+    Trigger(Fd&& header, Fd&& data, TToken token);
+
+    void run();
+
+   private:
+    TReactorProducer producer_;
+    TToken token_;
+  };
+};
+
+} // namespace shm
+} // namespace transport
+} // namespace tensorpipe


### PR DESCRIPTION
Busy poll a ring buffer for tokens and executes std::function
associated with every incoming token. The process hosting the reactor
can share the file descriptors of its ring buffer together with a
token to let another process trigger a specific std::function.