### PR TITLE
Fix build

### DIFF
--- a/tensorpipe/benchmark/CMakeLists.txt
+++ b/tensorpipe/benchmark/CMakeLists.txt
@@ -4,12 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-add_library(benchmark_lib options.cc)
-
-add_executable(benchmark benchmark.cc)
+add_executable(benchmark benchmark.cc options.cc)
 target_link_libraries("benchmark"
   -Wl,--no-whole-archive
-  benchmark_lib
   tensorpipe
   tensorpipe_shm
   tensorpipe_uv)

--- a/tensorpipe/benchmark/benchmark.cc
+++ b/tensorpipe/benchmark/benchmark.cc
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <ctime>
 
+using tensorpipe::Error;
 using namespace tensorpipe::benchmark;
 using namespace tensorpipe::transport;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#77 Fix build**

Two issues:

1. The benchmark commit didn't setup the correct include path for
   options.h. By moving compilation to the executable, the include
   path is now setup through the top level `tensorpipe` target.
2. Multiple error classes were consolidated into one in e0f3a19a,
   which raced with the benchmark commit.

Differential Revision: [D19854131](https://our.internmc.facebook.com/intern/diff/D19854131)