### PR TITLE
Add channel that uses process_vm_readv

### DIFF
--- a/tensorpipe/channel/process_vm_readv.cc
+++ b/tensorpipe/channel/process_vm_readv.cc
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/channel/process_vm_readv.h>
+
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+#include <algorithm>
+
+#include <tensorpipe/channel/helpers.h>
+#include <tensorpipe/common/callback.h>
+#include <tensorpipe/common/defs.h>
+#include <tensorpipe/common/system.h>
+#include <tensorpipe/core/error_macros.h>
+
+namespace tensorpipe {
+
+namespace {
+
+const std::string kChannelName{"process_vm_readv"};
+
+std::string generateDomainDescriptor() {
+  std::ostringstream oss;
+  auto bootID = getBootID();
+  TP_THROW_ASSERT_IF(!bootID) << "Unable to read boot_id";
+
+  // Combine boot ID, effective UID, and effective GID.
+  oss << kChannelName;
+  oss << ":" << bootID.value();
+  oss << "/" << geteuid();
+  oss << "/" << getegid();
+  return oss.str();
+}
+
+} // namespace
+
+ProcessVmReadvChannelFactory::ProcessVmReadvChannelFactory()
+    : ChannelFactory(kChannelName),
+      domainDescriptor_(generateDomainDescriptor()) {}
+
+ProcessVmReadvChannelFactory::~ProcessVmReadvChannelFactory() {}
+
+const std::string& ProcessVmReadvChannelFactory::domainDescriptor() const {
+  return domainDescriptor_;
+}
+
+std::shared_ptr<Channel> ProcessVmReadvChannelFactory::createChannel(
+    std::shared_ptr<transport::Connection> connection) {
+  auto channel = std::make_shared<ProcessVmReadvChannel>(
+      ProcessVmReadvChannel::ConstructorToken(), std::move(connection));
+  channel->init_();
+  return channel;
+}
+
+ProcessVmReadvChannel::ProcessVmReadvChannel(
+    ConstructorToken /* unused */,
+    std::shared_ptr<transport::Connection> connection)
+    : connection_(std::move(connection)) {
+  // The factory calls `init_()` after construction so that we can use
+  // `shared_from_this()`. The shared_ptr that refers to the object
+  // itself isn't usable when the constructor is still being executed.
+}
+
+ProcessVmReadvChannel::TDescriptor ProcessVmReadvChannel::send(
+    const void* ptr,
+    size_t length,
+    TSendCallback callback) {
+  proto::ProcessVmReadvChannelOperation op;
+
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    const auto id = id_++;
+    op.set_operation_id(id);
+    op.set_pid(getpid());
+    op.set_iov_base(reinterpret_cast<uint64_t>(ptr));
+    op.set_iov_len(length);
+    sendOperations_.emplace_back(SendOperation{id, std::move(callback)});
+  }
+
+  return saveDescriptor(op);
+}
+
+// Receive memory region from peer.
+void ProcessVmReadvChannel::recv(
+    TDescriptor descriptor,
+    void* ptr,
+    size_t length,
+    TRecvCallback callback) {
+  const auto op =
+      loadDescriptor<proto::ProcessVmReadvChannelOperation>(descriptor);
+  const auto id = op.operation_id();
+
+  // The descriptor encodes the size in bytes for this operation. Make
+  // sure that the size the sender will send is equal to the size of
+  // the memory region passed to this function. If they are not, this
+  // is a programming error.
+  TP_THROW_ASSERT_IF(length != op.iov_len())
+      << ": recv was called with length " << length
+      << ", whereas the descriptor encoded length " << op.iov_len() << ".";
+
+  // Perform copy.
+  struct iovec local {
+    .iov_base = ptr, .iov_len = length
+  };
+  struct iovec remote {
+    .iov_base = reinterpret_cast<void*>(op.iov_base()), .iov_len = op.iov_len()
+  };
+  auto nread = process_vm_readv(op.pid(), &local, 1, &remote, 1, 0);
+  TP_THROW_ASSERT_IF(length != op.iov_len());
+
+  // Let peer know we've completed the copy.
+  proto::ProcessVmReadvChannelPacket packet;
+  *packet.mutable_notification() = op;
+  connection_->write(packet, wrapWriteCallback_());
+  return;
+}
+
+void ProcessVmReadvChannel::init_() {
+  readPacket_();
+}
+
+void ProcessVmReadvChannel::readPacket_() {
+  connection_->read(wrapReadProtoCallback_(
+      [](ProcessVmReadvChannel& channel,
+         const proto::ProcessVmReadvChannelPacket& packet) {
+        channel.onPacket_(packet);
+      }));
+}
+
+void ProcessVmReadvChannel::onPacket_(
+    const proto::ProcessVmReadvChannelPacket& packet) {
+  if (packet.has_notification()) {
+    onNotification_(packet.notification());
+  } else {
+    TP_THROW_ASSERT() << "Packet type not handled.";
+  }
+}
+
+void ProcessVmReadvChannel::onNotification_(
+    const proto::ProcessVmReadvChannelOperation& notification) {
+  std::unique_lock<std::mutex> lock(mutex_);
+
+  // Find the send operation matching the notification's operation ID.
+  const auto id = notification.operation_id();
+  auto it = std::find_if(
+      sendOperations_.begin(), sendOperations_.end(), [id](const auto& op) {
+        return op.id == id;
+      });
+  TP_THROW_ASSERT_IF(it == sendOperations_.end())
+      << "Expected send operation with ID " << id << " to exist.";
+
+  // Move operation to stack.
+  auto op = std::move(*it);
+  sendOperations_.erase(it);
+
+  // Arm connection to wait for next packet.
+  readPacket_();
+
+  // Release lock before executing callback.
+  lock.unlock();
+
+  // Execute send completion callback.
+  op.callback();
+}
+
+ProcessVmReadvChannel::TReadProtoCallback ProcessVmReadvChannel::
+    wrapReadProtoCallback_(TBoundReadProtoCallback fn) {
+  return runIfAlive(
+      *this,
+      std::function<void(
+          ProcessVmReadvChannel&,
+          const transport::Error&,
+          const proto::ProcessVmReadvChannelPacket&)>(
+          [fn{std::move(fn)}](
+              ProcessVmReadvChannel& channel,
+              const transport::Error& error,
+              const proto::ProcessVmReadvChannelPacket& packet) {
+            channel.readProtoCallbackEntryPoint_(error, packet, std::move(fn));
+          }));
+}
+
+ProcessVmReadvChannel::TWriteCallback ProcessVmReadvChannel::wrapWriteCallback_(
+    TBoundWriteCallback fn) {
+  return runIfAlive(
+      *this,
+      std::function<void(ProcessVmReadvChannel&, const transport::Error&)>(
+          [fn{std::move(fn)}](
+              ProcessVmReadvChannel& channel, const transport::Error& error) {
+            channel.writeCallbackEntryPoint_(error, std::move(fn));
+          }));
+}
+
+void ProcessVmReadvChannel::readProtoCallbackEntryPoint_(
+    const transport::Error& error,
+    const proto::ProcessVmReadvChannelPacket& packet,
+    TBoundReadProtoCallback fn) {
+  if (processTransportError(error)) {
+    return;
+  }
+  if (fn) {
+    fn(*this, packet);
+  }
+}
+
+void ProcessVmReadvChannel::writeCallbackEntryPoint_(
+    const transport::Error& error,
+    TBoundWriteCallback fn) {
+  if (processTransportError(error)) {
+    return;
+  }
+  if (fn) {
+    fn(*this);
+  }
+}
+
+bool ProcessVmReadvChannel::processTransportError(
+    const transport::Error& error) {
+  std::unique_lock<std::mutex> lock(mutex_);
+
+  // Ignore if an error was already set.
+  if (error_) {
+    return true;
+  }
+
+  // If this is the first callback with an error, make sure that all
+  // pending user specified callbacks get called with that same error.
+  // Once the channel is in an error state it doesn't recover.
+  if (error) {
+    error_ = TP_CREATE_ERROR(TransportError, error);
+
+    // Move pending operations to stack.
+    auto sendOperations = std::move(sendOperations_);
+
+    // Release lock before executing callbacks.
+    lock.unlock();
+
+    // Notify pending send callbacks of error.
+    for (auto& op : sendOperations) {
+      // TODO(pietern): pass error.
+      op.callback();
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
+} // namespace tensorpipe

--- a/tensorpipe/channel/process_vm_readv.h
+++ b/tensorpipe/channel/process_vm_readv.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <list>
+
+#include <tensorpipe/core/channel.h>
+#include <tensorpipe/core/error.h>
+#include <tensorpipe/proto/all.pb.h>
+
+namespace tensorpipe {
+
+class ProcessVmReadvChannelFactory : public ChannelFactory {
+ public:
+  explicit ProcessVmReadvChannelFactory();
+
+  ~ProcessVmReadvChannelFactory() override;
+
+  const std::string& domainDescriptor() const override;
+
+  std::shared_ptr<Channel> createChannel(
+      std::shared_ptr<transport::Connection>) override;
+
+ private:
+  std::string domainDescriptor_;
+};
+
+class ProcessVmReadvChannel
+    : public Channel,
+      public std::enable_shared_from_this<ProcessVmReadvChannel> {
+  struct ConstructorToken {};
+
+ public:
+  ProcessVmReadvChannel(
+      ConstructorToken,
+      std::shared_ptr<transport::Connection> connection);
+
+  // Send memory region to peer.
+  TDescriptor send(const void* ptr, size_t length, TSendCallback callback)
+      override;
+
+  // Receive memory region from peer.
+  void recv(
+      TDescriptor descriptor,
+      void* ptr,
+      size_t length,
+      TRecvCallback callback) override;
+
+ private:
+  // Called by factory class after construction.
+  void init_();
+
+  // Arm connection to read next protobuf packet.
+  void readPacket_();
+
+  // Called when a protobuf packet was received.
+  void onPacket_(const proto::ProcessVmReadvChannelPacket& packet);
+
+  // Called when protobuf packet is a notification.
+  void onNotification_(
+      const proto::ProcessVmReadvChannelOperation& notification);
+
+  // Allow factory class to call `init_()`.
+  friend class ProcessVmReadvChannelFactory;
+
+ private:
+  std::mutex mutex_;
+  std::shared_ptr<transport::Connection> connection_;
+  Error error_{Error::kSuccess};
+
+  // Increasing identifier for send operations.
+  uint64_t id_{0};
+
+  // State capturing a single send operation.
+  struct SendOperation {
+    const uint64_t id;
+    TSendCallback callback;
+  };
+
+  std::list<SendOperation> sendOperations_;
+
+ protected:
+  // Callback types used by the transport.
+  using TReadProtoCallback = transport::Connection::read_proto_callback_fn<
+      proto::ProcessVmReadvChannelPacket>;
+  using TWriteCallback = transport::Connection::write_callback_fn;
+
+  // Callback types used in this class (in case of success).
+  using TBoundReadProtoCallback = std::function<
+      void(ProcessVmReadvChannel&, const proto::ProcessVmReadvChannelPacket&)>;
+  using TBoundWriteCallback = std::function<void(ProcessVmReadvChannel&)>;
+
+  // Generate callback to use with the underlying connection. The
+  // wrapped callback ensures that the channel stays alive while it
+  // is called and calls into `readCallbackEntryPoint_` such that
+  // all error handling can be consolidated.
+  //
+  // Note: the bound callback is only called if the read from the
+  // connection completed successfully.
+  //
+
+  // Read protobuf packet.
+  TReadProtoCallback wrapReadProtoCallback_(
+      TBoundReadProtoCallback fn = nullptr);
+
+  // Generic write (for both bytes and protobuf packets).
+  TWriteCallback wrapWriteCallback_(TBoundWriteCallback fn = nullptr);
+
+  // Called when callback returned by `wrapReadCallback_` gets called.
+  void readProtoCallbackEntryPoint_(
+      const transport::Error& error,
+      const proto::ProcessVmReadvChannelPacket& packet,
+      TBoundReadProtoCallback fn);
+
+  // Called when callback returned by `wrapWriteCallback_` gets called.
+  void writeCallbackEntryPoint_(
+      const transport::Error& error,
+      TBoundWriteCallback fn);
+
+  // Helper function to process transport error.
+  // Shared between read and write callback entry points.
+  bool processTransportError(const transport::Error& error);
+};
+
+} // namespace tensorpipe

--- a/tensorpipe/test/channel/process_vm_readv_test.cc
+++ b/tensorpipe/test/channel/process_vm_readv_test.cc
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/channel/process_vm_readv.h>
+#include <tensorpipe/common/queue.h>
+#include <tensorpipe/transport/uv/context.h>
+
+#include <gtest/gtest.h>
+
+using namespace tensorpipe;
+
+namespace {
+
+void testConnectionPair(
+    std::function<void(std::shared_ptr<transport::Connection>)> f1,
+    std::function<void(std::shared_ptr<transport::Connection>)> f2) {
+  auto context = std::make_shared<transport::uv::Context>();
+  auto addr = "::1";
+
+  {
+    Queue<std::shared_ptr<transport::Connection>> q1, q2;
+
+    // Listening side.
+    auto listener = context->listen(addr);
+    listener->accept([&](const transport::Error& error,
+                         std::shared_ptr<transport::Connection> connection) {
+      ASSERT_FALSE(error) << error.what();
+      q1.push(std::move(connection));
+    });
+
+    // Connecting side.
+    q2.push(context->connect(listener->addr()));
+
+    // Run user specified functions.
+    std::thread t1([&] { f1(q1.pop()); });
+    std::thread t2([&] { f2(q2.pop()); });
+    t1.join();
+    t2.join();
+  }
+
+  context->join();
+}
+
+} // namespace
+
+TEST(ProcessVmReadvChannel, Operation) {
+  std::shared_ptr<ChannelFactory> factory1 =
+      std::make_shared<ProcessVmReadvChannelFactory>();
+  std::shared_ptr<ChannelFactory> factory2 =
+      std::make_shared<ProcessVmReadvChannelFactory>();
+  constexpr auto dataSize = 256;
+  Queue<Channel::TDescriptor> descriptorQueue;
+
+  testConnectionPair(
+      [&](std::shared_ptr<transport::Connection> conn) {
+        auto channel = factory1->createChannel(std::move(conn));
+
+        // Initialize with sequential values.
+        std::vector<uint8_t> data(dataSize);
+        for (auto i = 0; i < data.size(); i++) {
+          data[i] = i;
+        }
+
+        // Perform send and wait for completion.
+        Channel::TDescriptor descriptor;
+        std::future<void> future;
+        std::tie(descriptor, future) = channel->send(data.data(), data.size());
+        descriptorQueue.push(std::move(descriptor));
+        future.wait();
+      },
+      [&](std::shared_ptr<transport::Connection> conn) {
+        auto channel = factory2->createChannel(std::move(conn));
+
+        // Initialize with zeroes.
+        std::vector<uint8_t> data(dataSize);
+        for (auto i = 0; i < data.size(); i++) {
+          data[i] = 0;
+        }
+
+        // Perform recv and wait for completion.
+        channel->recv(descriptorQueue.pop(), data.data(), data.size()).wait();
+
+        // Validate contents of vector.
+        for (auto i = 0; i < data.size(); i++) {
+          ASSERT_EQ(data[i], i);
+        }
+      });
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#79 Add channel that uses process_vm_readv**

Warning: do not merge this commit.

This commit has NOT been updated to:

1. Move the channel code to its own directory.
2. Add the proper proto files.
3. Fix CMake for build and test.

```
message ProcessVmReadvChannelOperation {
  // Uniquely identifies this send/recv operation.
  uint64 operation_id = 1;

  // Arguments to process_vm_readv(2) on receiver side.
  uint32 pid = 10;
  uint64 iov_base = 11;
  uint64 iov_len = 12;
}

message ProcessVmReadvChannelPacket {
  oneof type {
    // Sent by receiver when process_vm_readv(2) has finished.
    ProcessVmReadvChannelOperation notification = 1;
  }
}
```

Differential Revision: [D19854605](https://our.internmc.facebook.com/intern/diff/D19854605)