### PR TITLE
Implement write queueing for SHM.

### DIFF
--- a/tensorpipe/test/transport/shm/connection_test.cc
+++ b/tensorpipe/test/transport/shm/connection_test.cc
@@ -15,7 +15,8 @@ using namespace tensorpipe::transport;
 
 using SHMConnectionTest = ConnectionTest<SHMConnectionTestHelper>;
 
-TEST_F(SHMConnectionTest, LargeWrite) {
+// NOTE: This test is disabled until chunking is implemented.
+TEST_F(SHMConnectionTest, DISABLED_LargeWrite) {
   // This is larger than the default ring buffer size.
   const int kMsgSize = 2 * shm::Connection::kDefaultSize;
   std::string msg(kMsgSize, 0x42);
@@ -35,5 +36,39 @@ TEST_F(SHMConnectionTest, LargeWrite) {
           ASSERT_TRUE(error);
           ASSERT_EQ(error.what().substr(0, 11), "short write");
         });
+      });
+}
+
+TEST_F(SHMConnectionTest, QueueWrites) {
+  // This is large enough that two of those will not fit in the ring buffer at
+  // the same time.
+  constexpr size_t numBytes = (3 * shm::Connection::kDefaultSize) / 4;
+  std::array<char, numBytes> garbage;
+
+  tensorpipe::Queue<bool> queue;
+
+  this->test_connection(
+      [&](std::shared_ptr<Connection> conn) {
+        // Wait before both writes have been registered before attempting to
+        // read.
+        queue.pop();
+
+        for (int i = 0; i < 2; ++i) {
+          conn->read(
+              [&, conn](const Error& error, const void* ptr, size_t len) {
+                ASSERT_FALSE(error) << error.what();
+                ASSERT_EQ(len, numBytes);
+              });
+        }
+      },
+      [&](std::shared_ptr<Connection> conn) {
+        for (int i = 0; i < 2; ++i) {
+          conn->write(
+              garbage.data(), garbage.size(), [conn](const Error& error) {
+                ASSERT_FALSE(error) << error.what();
+              });
+        }
+
+        queue.push(true);
       });
 }

--- a/tensorpipe/transport/shm/connection.cc
+++ b/tensorpipe/transport/shm/connection.cc
@@ -52,8 +52,11 @@ void Connection::start() {
       util::ringbuffer::shm::create<TRingBuffer>(kDefaultSize);
   inbox_.emplace(std::move(inboxRingBuffer));
 
-  // Register to be called when our peer writes to our inbox.
+  // Register method to be called when our peer writes to our inbox.
   inboxReactorToken_ = reactor_->add([this] { handleInboxReadable(); });
+
+  // Register method to be called when our peer reads from our outbox.
+  outboxReactorToken_ = reactor_->add([this] { handleOutboxWritable(); });
 
   // We're sending file descriptors first, so wait for writability.
   state_ = SEND_FDS;
@@ -129,11 +132,13 @@ void Connection::handleEventIn(std::unique_lock<std::mutex> lock) {
     Fd reactorDataFd;
     Fd outboxHeaderFd;
     Fd outboxDataFd;
-    Reactor::TToken reactorToken;
+    Reactor::TToken peerInboxReactorToken;
+    Reactor::TToken peerOutboxReactorToken;
 
     // Receive the reactor token, reactor fds, and inbox fds.
     auto err = socket_->recvPayloadAndFds(
-        reactorToken,
+        peerInboxReactorToken,
+        peerOutboxReactorToken,
         reactorHeaderFd,
         reactorDataFd,
         outboxHeaderFd,
@@ -147,9 +152,12 @@ void Connection::handleEventIn(std::unique_lock<std::mutex> lock) {
     outbox_.emplace(util::ringbuffer::shm::load<TRingBuffer>(
         outboxHeaderFd.release(), outboxDataFd.release()));
 
-    // Initialize remote reactor trigger for outbox writes.
-    outboxTrigger_.emplace(
-        std::move(reactorHeaderFd), std::move(reactorDataFd), reactorToken);
+    // Initialize remote reactor trigger.
+    peerReactorTrigger_.emplace(
+        std::move(reactorHeaderFd), std::move(reactorDataFd));
+
+    peerInboxReactorToken_ = peerInboxReactorToken;
+    peerOutboxReactorToken_ = peerOutboxReactorToken;
 
     // The connection is usable now.
     state_ = ESTABLISHED;
@@ -179,6 +187,7 @@ void Connection::handleEventOut(std::unique_lock<std::mutex> lock) {
     // Send our reactor token, reactor fds, and inbox fds.
     auto err = socket_->sendPayloadAndFds(
         inboxReactorToken_.value(),
+        outboxReactorToken_.value(),
         reactorHeaderFd,
         reactorDataFd,
         inboxHeaderFd_,
@@ -215,6 +224,11 @@ void Connection::handleInboxReadable() {
   processReadOperations(std::move(lock));
 }
 
+void Connection::handleOutboxWritable() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  processWriteOperations(std::move(lock));
+}
+
 void Connection::triggerProcessReadOperations() {
   loop_->defer([ptr{shared_from_this()}, this] {
     std::unique_lock<std::mutex> lock(mutex_);
@@ -247,6 +261,7 @@ void Connection::processReadOperations(std::unique_lock<std::mutex> lock) {
 
   for (auto& readOperation : operationsToRead) {
     readOperation.handleRead(*inbox_);
+    peerReactorTrigger_->run(peerOutboxReactorToken_.value());
   }
 
   for (auto& readOperation : operationsToError) {
@@ -283,9 +298,21 @@ void Connection::processWriteOperations(std::unique_lock<std::mutex> lock) {
   // without requiring reentrant locking.
   lock.unlock();
 
+  int nbSuccessful = 0;
   for (auto& writeOperation : operationsToWrite) {
-    writeOperation.handleWrite(*outbox_);
-    outboxTrigger_->run();
+    bool writeSuccess = writeOperation.handleWrite(*outbox_);
+    if (!writeSuccess) {
+      lock.lock();
+      writeOperations_.insert(
+          writeOperations_.begin(),
+          operationsToWrite.begin() + nbSuccessful,
+          operationsToWrite.end());
+      lock.unlock();
+      return;
+    }
+
+    ++nbSuccessful;
+    peerReactorTrigger_->run(peerInboxReactorToken_.value());
   }
 
   for (auto& writeOperation : operationsToError) {
@@ -320,6 +347,10 @@ void Connection::closeHoldingMutex() {
   if (inboxReactorToken_.has_value()) {
     reactor_->remove(inboxReactorToken_.value());
     inboxReactorToken_.reset();
+  }
+  if (outboxReactorToken_.has_value()) {
+    reactor_->remove(outboxReactorToken_.value());
+    outboxReactorToken_.reset();
   }
   if (socket_) {
     loop_->unregisterDescriptor(socket_->fd());
@@ -382,13 +413,13 @@ Connection::WriteOperation::WriteOperation(
     write_callback_fn fn)
     : ptr_(ptr), len_(len), fn_(std::move(fn)) {}
 
-void Connection::WriteOperation::handleWrite(TProducer& outbox) {
+bool Connection::WriteOperation::handleWrite(TProducer& outbox) {
   // Attempting to write a message larger than the ring buffer. We might want to
   // chunk it in the future.
   const int buf_size = outbox.getHeader().kDataPoolByteSize;
   if (len_ > buf_size) {
     fn_(TP_CREATE_ERROR(ShortWriteError, len_, buf_size));
-    return;
+    return false;
   }
 
   ssize_t ret;
@@ -406,11 +437,19 @@ void Connection::WriteOperation::handleWrite(TProducer& outbox) {
   }
 
   ret = outbox.writeInTxWithSize<uint32_t>(len_, ptr_);
+  if (ret == -ENOSPC) {
+    ret = outbox.cancelTx();
+    TP_THROW_SYSTEM_IF(ret < 0, -ret);
+    return false;
+  }
+
   TP_THROW_SYSTEM_IF(ret < 0, -ret);
   ret = outbox.commitTx();
   TP_THROW_SYSTEM_IF(ret < 0, -ret);
 
   fn_(Error::kSuccess);
+
+  return true;
 }
 
 void Connection::WriteOperation::handleError(const Error& error) {

--- a/tensorpipe/transport/shm/reactor.cc
+++ b/tensorpipe/transport/shm/reactor.cc
@@ -112,16 +112,15 @@ void Reactor::run() {
   }
 }
 
-Reactor::Trigger::Trigger(Fd&& headerFd, Fd&& dataFd, TToken token)
+Reactor::Trigger::Trigger(Fd&& headerFd, Fd&& dataFd)
     : producer_(util::ringbuffer::shm::load<TReactorRingBuffer>(
           // The header and data segment objects take over ownership
           // of file descriptors. Release them to avoid double close.
           headerFd.release(),
-          dataFd.release())),
-      token_(token) {}
+          dataFd.release())) {}
 
-void Reactor::Trigger::run() {
-  writeToken(producer_, token_);
+void Reactor::Trigger::run(TToken token) {
+  writeToken(producer_, token);
 }
 
 } // namespace shm

--- a/tensorpipe/transport/shm/reactor.h
+++ b/tensorpipe/transport/shm/reactor.h
@@ -91,13 +91,12 @@ class Reactor final : public std::enable_shared_from_this<Reactor> {
  public:
   class Trigger {
    public:
-    Trigger(Fd&& header, Fd&& data, TToken token);
+    Trigger(Fd&& header, Fd&& data);
 
-    void run();
+    void run(TToken token);
 
    private:
     TReactorProducer producer_;
-    TToken token_;
   };
 };
 


### PR DESCRIPTION
Summary:
Leverage reactors and triggers to signal a peer that its outbox has been read from, and hence has more available space for potential subsequent writes.
This involves each peer to have two reactor tokens, that both need to be exchanged.

Differential Revision: D19884014

