### PR TITLE
Update in-tree shm and ringbuffer readme's

### DIFF
--- a/tensorpipe/util/ringbuffer/README.md
+++ b/tensorpipe/util/ringbuffer/README.md
@@ -1,7 +1,10 @@
 # ringbuffer
 
 > This code was written by David Carrillo Cisneros (davidca@fb.com).
+>
 > Modified to work with C++14 by Pieter Noordhuis (pietern@fb.com)
+>
+> For further changes, refer to the source control history.
 
 ## Usage
 
@@ -14,7 +17,7 @@ The resulting ringbuffer can be used to create multiple Producers and Consumers.
 
 Producers can only write data while Consumers can only read data. API for both
 is transactional. A succesful transaction will produce/consume data, while an
-unsuccesful will have no effect. Only one producer can have an active write
+unsuccessful will have no effect. Only one producer can have an active write
 transaction at any given time. Similarly, only one consumer can have an active
 read transaction at any given time.
 
@@ -25,10 +28,9 @@ they only write/read to the ringbuffer corresponding to the CPU where they
 are running. That way, at any given time, only one producer (or consumer) is
 accessing one ringbuffer.
 
-
 ## Design Guidelines
 
- The following use use cases shaped the design:
+The following use use cases shaped the design:
 
   1. Split control (buffer's header) and data sections. Shared memory
      segments can be loaded with distinct protection policies and/or

--- a/tensorpipe/util/shm/README.md
+++ b/tensorpipe/util/shm/README.md
@@ -1,28 +1,24 @@
 # shared memory
 
 > This code was written by David Carrillo Cisneros (davidca@fb.com).
+>
 > Modified to work with C++14 by Pieter Noordhuis (pietern@fb.com)
+>
+> For further changes, refer to the source control history.
 
 A wrapper around Linux's shared-memory mechanisms to create, load,
 link and unlink shared memory regions.
 
-Current version is hardcode to work create files and subfolders
-inside /dev/shm/tensorpipe/ .
-
-Permissions for shared memory follow Linux file system permissions.
-E.g. an authorized users can inspect memory content by dumping the
-content of the shared memory file content with:
-
-```
-$ xxd /dev/shm/tensorpipe/<your file>
-```
+Current version uses `O_TMPFILE` to use unnamed regular files for
+shared memory segments. Because the segments are not mapped to regular
+files, the user must use a separate mechanism to share access (e.g.
+through sharing their file descriptors).
 
 ## Design choices
 
 1. Decided against using Boost's shared memory to leverage Linux-only such as:
-  a. directory structure inside of shared memory,
-  b. huge TLB pages
-  c. fine-tuned memory write-only/read-only page modes
+  a. huge TLB pages
+  b. fine-tuned memory write-only/read-only page modes
   (e.g. allow segments as write only, reducing cache contention).
 
 2. Support load at any memory address. To simplify user experience,


### PR DESCRIPTION
The files were still `.rst`'s while they are formatted as `.md`.