### PR TITLE
Simplify transport tests.

### DIFF
--- a/tensorpipe/test/transport/shm/connection_test.cc
+++ b/tensorpipe/test/transport/shm/connection_test.cc
@@ -8,15 +8,15 @@
 
 #include <tensorpipe/test/transport/shm/shm_test.h>
 
+#include <tensorpipe/transport/shm/connection.h>
+
 #include <gtest/gtest.h>
 
 using namespace tensorpipe;
 using namespace tensorpipe::transport;
 
-using SHMTransportTest = TransportTest<SHMTransportTestHelper>;
-
 // NOTE: This test is disabled until chunking is implemented.
-TEST_F(SHMTransportTest, DISABLED_LargeWrite) {
+TEST_P(TransportTest, DISABLED_LargeWrite) {
   // This is larger than the default ring buffer size.
   const int kMsgSize = 2 * shm::Connection::kDefaultSize;
   std::string msg(kMsgSize, 0x42);
@@ -39,7 +39,7 @@ TEST_F(SHMTransportTest, DISABLED_LargeWrite) {
       });
 }
 
-TEST_F(SHMTransportTest, QueueWrites) {
+TEST_P(TransportTest, QueueWrites) {
   // This is large enough that two of those will not fit in the ring buffer at
   // the same time.
   constexpr size_t numBytes = (3 * shm::Connection::kDefaultSize) / 4;

--- a/tensorpipe/test/transport/shm/shm_test.cc
+++ b/tensorpipe/test/transport/shm/shm_test.cc
@@ -10,4 +10,6 @@
 
 #include <tensorpipe/test/transport/transport_test.h>
 
-INSTANTIATE_TYPED_TEST_CASE_P(Shm, TransportTest, SHMTransportTestHelper);
+SHMTransportTestHelper helper;
+
+INSTANTIATE_TEST_CASE_P(Shm, TransportTest, ::testing::Values(&helper));

--- a/tensorpipe/test/transport/shm/shm_test.h
+++ b/tensorpipe/test/transport/shm/shm_test.h
@@ -9,40 +9,16 @@
 #pragma once
 
 #include <tensorpipe/test/transport/transport_test.h>
-#include <tensorpipe/transport/shm/connection.h>
-#include <tensorpipe/transport/shm/listener.h>
-#include <tensorpipe/transport/shm/loop.h>
+
+#include <tensorpipe/transport/shm/context.h>
 
 class SHMTransportTestHelper : public TransportTestHelper {
  public:
-  SHMTransportTestHelper()
-      : loop_(tensorpipe::transport::shm::Loop::create()) {}
-
-  ~SHMTransportTestHelper() override {
-    loop_->join();
+  std::shared_ptr<tensorpipe::transport::Context> getContext() override {
+    return std::make_shared<tensorpipe::transport::shm::Context>();
   }
 
-  std::shared_ptr<tensorpipe::transport::Listener> getListener() override {
-    auto addr =
-        tensorpipe::transport::shm::Sockaddr::createAbstractUnixAddr(kUnixAddr);
-    return tensorpipe::transport::shm::Listener::create(loop_, addr);
+  std::string defaultAddr() override {
+    return "foobar";
   }
-
-  std::shared_ptr<tensorpipe::transport::Connection> connect(
-      const std::string& addr) override {
-    auto socket = tensorpipe::transport::shm::Socket::createForFamily(AF_UNIX);
-    auto saddr =
-        tensorpipe::transport::shm::Sockaddr::createAbstractUnixAddr(addr);
-    socket->connect(saddr);
-    return tensorpipe::transport::shm::Connection::create(
-        loop_, std::move(socket));
-  }
-
-  static std::string transportName() {
-    return "shm";
-  }
-
- private:
-  const std::string kUnixAddr = "foobar";
-  std::shared_ptr<tensorpipe::transport::shm::Loop> loop_;
 };

--- a/tensorpipe/test/transport/transport_test.cc
+++ b/tensorpipe/test/transport/transport_test.cc
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/test/transport/transport_test.h>
+
+using namespace tensorpipe;
+using namespace tensorpipe::transport;
+
+TEST_P(TransportTest, Initialization) {
+  constexpr size_t numBytes = 13;
+  std::array<char, numBytes> garbage;
+
+  this->test_connection(
+      [&](std::shared_ptr<Connection> conn) {
+        conn->read(
+            [&, conn](
+                const Error& error, const void* /* unused */, size_t len) {
+              ASSERT_FALSE(error) << error.what();
+              ASSERT_EQ(len, garbage.size());
+            });
+      },
+      [&](std::shared_ptr<Connection> conn) {
+        conn->write(
+            garbage.data(), garbage.size(), [&, conn](const Error& error) {
+              ASSERT_FALSE(error) << error.what();
+            });
+      });
+}
+
+TEST_P(TransportTest, InitializationError) {
+  this->test_connection(
+      [&](std::shared_ptr<Connection> /* unused */) {
+        // Closes connection
+      },
+      [&](std::shared_ptr<Connection> conn) {
+        conn->read([conn](
+                       const Error& error,
+                       const void* /* unused */,
+                       size_t /* unused */) { ASSERT_TRUE(error); });
+      });
+}
+
+TEST_P(TransportTest, DestroyConnectionFromCallback) {
+  this->test_connection(
+      [&](std::shared_ptr<Connection> /* unused */) {
+        // Closes connection
+      },
+      [&](std::shared_ptr<Connection> conn) {
+        // This should be the only connection instance.
+        EXPECT_EQ(conn.use_count(), 1);
+        // Move connection instance to lambda scope, so we can destroy
+        // the only instance we have from the callback itself. This
+        // tests that the transport keeps the connection alive as long
+        // as it's executing a callback.
+        conn->read([conn](
+                       const Error& /* unused */,
+                       const void* /* unused */,
+                       size_t /* unused */) mutable {
+          // Destroy connection from within callback.
+          EXPECT_GT(conn.use_count(), 1);
+          conn.reset();
+        });
+      });
+}
+
+TEST_P(TransportTest, AcceptCallbacksAreQueued) {
+  auto ctx = GetParam()->getContext();
+  auto addr = GetParam()->defaultAddr();
+
+  {
+    auto listener = ctx->listen(addr);
+    int numAccepts = 0;
+    std::promise<void> donePromise;
+    for (int i = 0; i < 10; i += 1) {
+      listener->accept([&, i](const Error& error, std::shared_ptr<Connection>) {
+        if (error) {
+          donePromise.set_exception(
+              std::make_exception_ptr(std::runtime_error(error.what())));
+        } else {
+          EXPECT_EQ(i, numAccepts);
+          numAccepts++;
+          if (numAccepts == 10) {
+            donePromise.set_value();
+          }
+        }
+      });
+    }
+    for (int i = 0; i < 10; i += 1) {
+      ctx->connect(listener->addr());
+    }
+
+    donePromise.get_future().get();
+  }
+
+  ctx->join();
+}
+
+TEST_P(TransportTest, IncomingConnectionsAreQueued) {
+  auto ctx = GetParam()->getContext();
+  auto addr = GetParam()->defaultAddr();
+
+  {
+    auto listener = ctx->listen(addr);
+    int numAccepts = 0;
+    std::promise<void> donePromise;
+    for (int i = 0; i < 10; i += 1) {
+      ctx->connect(listener->addr());
+    }
+    for (int i = 0; i < 10; i += 1) {
+      listener->accept([&, i](const Error& error, std::shared_ptr<Connection>) {
+        if (error) {
+          donePromise.set_exception(
+              std::make_exception_ptr(std::runtime_error(error.what())));
+        } else {
+          EXPECT_EQ(i, numAccepts);
+          numAccepts++;
+          if (numAccepts == 10) {
+            donePromise.set_value();
+          }
+        }
+      });
+    }
+
+    donePromise.get_future().get();
+  }
+
+  ctx->join();
+}

--- a/tensorpipe/test/transport/transport_test.h
+++ b/tensorpipe/test/transport/transport_test.h
@@ -14,185 +14,53 @@
 
 #include <tensorpipe/common/queue.h>
 #include <tensorpipe/transport/connection.h>
+#include <tensorpipe/transport/context.h>
 #include <tensorpipe/transport/listener.h>
 
 #include <gtest/gtest.h>
 
 class TransportTestHelper {
  public:
+  virtual std::shared_ptr<tensorpipe::transport::Context> getContext() = 0;
+  virtual std::string defaultAddr() = 0;
   virtual ~TransportTestHelper() = default;
-  virtual std::shared_ptr<tensorpipe::transport::Listener> getListener() = 0;
-  virtual std::shared_ptr<tensorpipe::transport::Connection> connect(
-      const std::string& addr) = 0;
 };
 
-template <class T>
-class TransportTest : public ::testing::Test {
+class TransportTest : public ::testing::TestWithParam<TransportTestHelper*> {
  public:
   void test_connection(
       std::function<void(std::shared_ptr<tensorpipe::transport::Connection>)>
           listeningFn,
       std::function<void(std::shared_ptr<tensorpipe::transport::Connection>)>
           connectingFn) {
-    std::unique_ptr<TransportTestHelper> helper = std::make_unique<T>();
+    using namespace tensorpipe::transport;
 
-    auto listener = helper->getListener();
-    tensorpipe::Queue<std::shared_ptr<tensorpipe::transport::Connection>> queue;
-    listener->accept(
-        [&](const tensorpipe::Error& error,
-            std::shared_ptr<tensorpipe::transport::Connection> conn) {
-          ASSERT_FALSE(error) << error.what();
-          queue.push(std::move(conn));
-        });
+    auto ctx = GetParam()->getContext();
+    auto addr = GetParam()->defaultAddr();
+    {
+      auto listener = ctx->listen(addr);
+      tensorpipe::Queue<std::shared_ptr<Connection>> queue;
+      listener->accept([&](const tensorpipe::Error& error,
+                           std::shared_ptr<Connection> conn) {
+        ASSERT_FALSE(error) << error.what();
+        queue.push(std::move(conn));
+      });
 
-    // Start thread for listening side.
-    std::thread listeningThread([&]() { listeningFn(queue.pop()); });
+      // Start thread for listening side.
+      std::thread listeningThread([&]() { listeningFn(queue.pop()); });
 
-    // Capture real listener address.
-    const std::string listenerAddr = listener->addr();
+      // Capture real listener address.
+      const std::string listenerAddr = listener->addr();
 
-    // Start thread for connecting side.
-    std::thread connectingThread(
-        [&]() { connectingFn(helper->connect(listenerAddr)); });
+      // Start thread for connecting side.
+      std::thread connectingThread(
+          [&]() { connectingFn(ctx->connect(listenerAddr)); });
 
-    // Wait for completion.
-    listeningThread.join();
-    connectingThread.join();
+      // Wait for completion.
+      listeningThread.join();
+      connectingThread.join();
+    }
+
+    ctx->join();
   }
 };
-
-class ConnectionTypeNames {
- public:
-  template <class T>
-  static std::string GetName(int /* unused */) {
-    return T::transportName();
-  }
-};
-
-// NOTE: When upgrading googletest, the following will allow nicer reported test
-// names.
-//
-// TYPED_TEST_SUITE_P(TransportTest, ConnectionTypeNames);
-TYPED_TEST_CASE_P(TransportTest);
-
-TYPED_TEST_P(TransportTest, Initialization) {
-  constexpr size_t numBytes = 13;
-  std::array<char, numBytes> garbage;
-
-  this->test_connection(
-      [&](std::shared_ptr<tensorpipe::transport::Connection> conn) {
-        conn->read([&, conn](
-                       const tensorpipe::Error& error,
-                       const void* /* unused */,
-                       size_t len) {
-          ASSERT_FALSE(error) << error.what();
-          ASSERT_EQ(len, garbage.size());
-        });
-      },
-      [&](std::shared_ptr<tensorpipe::transport::Connection> conn) {
-        conn->write(
-            garbage.data(),
-            garbage.size(),
-            [&, conn](const tensorpipe::Error& error) {
-              ASSERT_FALSE(error) << error.what();
-            });
-      });
-}
-
-TYPED_TEST_P(TransportTest, InitializationError) {
-  this->test_connection(
-      [&](std::shared_ptr<tensorpipe::transport::Connection> /* unused */) {
-        // Closes connection
-      },
-      [&](std::shared_ptr<tensorpipe::transport::Connection> conn) {
-        conn->read([conn](
-                       const tensorpipe::Error& error,
-                       const void* /* unused */,
-                       size_t /* unused */) { ASSERT_TRUE(error); });
-      });
-}
-
-TYPED_TEST_P(TransportTest, DestroyConnectionFromCallback) {
-  this->test_connection(
-      [&](std::shared_ptr<tensorpipe::transport::Connection> /* unused */) {
-        // Closes connection
-      },
-      [&](std::shared_ptr<tensorpipe::transport::Connection> conn) {
-        // This should be the only connection instance.
-        EXPECT_EQ(conn.use_count(), 1);
-        // Move connection instance to lambda scope, so we can destroy
-        // the only instance we have from the callback itself. This
-        // tests that the transport keeps the connection alive as long
-        // as it's executing a callback.
-        conn->read([conn](
-                       const tensorpipe::Error& /* unused */,
-                       const void* /* unused */,
-                       size_t /* unused */) mutable {
-          // Destroy connection from within callback.
-          EXPECT_GT(conn.use_count(), 1);
-          conn.reset();
-        });
-      });
-}
-
-TYPED_TEST_P(TransportTest, AcceptCallbacksAreQueued) {
-  TypeParam helper;
-  auto listener = helper.getListener();
-  int numAccepts = 0;
-  std::promise<void> donePromise;
-  for (int i = 0; i < 10; i += 1) {
-    listener->accept([&, i](
-                         const tensorpipe::Error& error,
-                         std::shared_ptr<tensorpipe::transport::Connection>) {
-      if (error) {
-        donePromise.set_exception(
-            std::make_exception_ptr(std::runtime_error(error.what())));
-      } else {
-        EXPECT_EQ(i, numAccepts);
-        numAccepts++;
-        if (numAccepts == 10) {
-          donePromise.set_value();
-        }
-      }
-    });
-  }
-  for (int i = 0; i < 10; i += 1) {
-    helper.connect(listener->addr());
-  }
-  donePromise.get_future().get();
-}
-
-TYPED_TEST_P(TransportTest, IncomingConnectionsAreQueued) {
-  TypeParam helper;
-  auto listener = helper.getListener();
-  int numAccepts = 0;
-  std::promise<void> donePromise;
-  for (int i = 0; i < 10; i += 1) {
-    helper.connect(listener->addr());
-  }
-  for (int i = 0; i < 10; i += 1) {
-    listener->accept([&, i](
-                         const tensorpipe::Error& error,
-                         std::shared_ptr<tensorpipe::transport::Connection>) {
-      if (error) {
-        donePromise.set_exception(
-            std::make_exception_ptr(std::runtime_error(error.what())));
-      } else {
-        EXPECT_EQ(i, numAccepts);
-        numAccepts++;
-        if (numAccepts == 10) {
-          donePromise.set_value();
-        }
-      }
-    });
-  }
-  donePromise.get_future().get();
-}
-
-REGISTER_TYPED_TEST_CASE_P(
-    TransportTest,
-    Initialization,
-    InitializationError,
-    DestroyConnectionFromCallback,
-    AcceptCallbacksAreQueued,
-    IncomingConnectionsAreQueued);

--- a/tensorpipe/test/transport/uv/connection_test.cc
+++ b/tensorpipe/test/transport/uv/connection_test.cc
@@ -13,9 +13,7 @@
 using namespace tensorpipe;
 using namespace tensorpipe::transport;
 
-using UVTransportTest = TransportTest<UVTransportTestHelper>;
-
-TEST_F(UVTransportTest, LargeWrite) {
+TEST_P(TransportTest, LargeWrite) {
   constexpr int kMsgSize = 16 * 1024 * 1024;
   std::string msg(kMsgSize, 0x42);
 

--- a/tensorpipe/test/transport/uv/uv_test.cc
+++ b/tensorpipe/test/transport/uv/uv_test.cc
@@ -10,4 +10,6 @@
 
 #include <tensorpipe/test/transport/transport_test.h>
 
-INSTANTIATE_TYPED_TEST_CASE_P(Uv, TransportTest, UVTransportTestHelper);
+UVTransportTestHelper helper;
+
+INSTANTIATE_TEST_CASE_P(Uv, TransportTest, ::testing::Values(&helper));

--- a/tensorpipe/test/transport/uv/uv_test.h
+++ b/tensorpipe/test/transport/uv/uv_test.h
@@ -9,35 +9,15 @@
 #pragma once
 
 #include <tensorpipe/test/transport/transport_test.h>
-#include <tensorpipe/transport/uv/connection.h>
-#include <tensorpipe/transport/uv/listener.h>
-#include <tensorpipe/transport/uv/loop.h>
+#include <tensorpipe/transport/uv/context.h>
 
 class UVTransportTestHelper : public TransportTestHelper {
  public:
-  UVTransportTestHelper() : loop_(tensorpipe::transport::uv::Loop::create()) {}
-
-  ~UVTransportTestHelper() override {
-    loop_->join();
+  std::shared_ptr<tensorpipe::transport::Context> getContext() override {
+    return std::make_shared<tensorpipe::transport::uv::Context>();
   }
 
-  std::shared_ptr<tensorpipe::transport::Listener> getListener() override {
-    auto addr =
-        tensorpipe::transport::uv::Sockaddr::createInetSockAddr(kIPAddr);
-    return tensorpipe::transport::uv::Listener::create(loop_, addr);
+  std::string defaultAddr() override {
+    return "127.0.0.1";
   }
-
-  std::shared_ptr<tensorpipe::transport::Connection> connect(
-      const std::string& addr) override {
-    auto saddr = tensorpipe::transport::uv::Sockaddr::createInetSockAddr(addr);
-    return tensorpipe::transport::uv::Connection::create(loop_, saddr);
-  }
-
-  static std::string transportName() {
-    return "uv";
-  }
-
- private:
-  const std::string kIPAddr = "127.0.0.1";
-  std::shared_ptr<tensorpipe::transport::uv::Loop> loop_;
 };


### PR DESCRIPTION
Summary: Further simplify generic transport tests leveraging `tensorpipe::transport::Context` and using value-parameterized (rather than type-parameterized) tests.

Reviewed By: lerks

Differential Revision: D19942444

