### PR TITLE
Run compilers with -Werror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,8 @@ jobs:
             mkdir build
             cd build
             cmake ../ \
+              -DCMAKE_C_FLAGS="-Werror -Wno-deprecated-declarations" \
+              -DCMAKE_CXX_FLAGS="-Werror -Wno-deprecated-declarations" \
               -DCMAKE_C_COMPILER=<< parameters.c_compiler >> \
               -DCMAKE_CXX_COMPILER=<< parameters.cxx_compiler >> \
               << parameters.cmake_args >>


### PR DESCRIPTION
Commandeering @pietern's #30.

This currently blocks because of deprecated googletest macros.