### PR TITLE
Call the listener's callbacks inline

### DIFF
--- a/tensorpipe/core/context.h
+++ b/tensorpipe/core/context.h
@@ -66,13 +66,6 @@ class Context final {
   std::shared_ptr<transport::Context> getContextForTransport_(std::string);
   std::shared_ptr<channel::ChannelFactory> getChannelFactory_(std::string);
 
-  std::thread callbackCaller_;
-  Queue<optional<std::function<void()>>> callbackQueue_;
-
-  void start_();
-  void runCallbackCaller_();
-  void callCallback_(std::function<void()>);
-
   friend class Listener;
   friend class Pipe;
 };

--- a/tensorpipe/core/listener.h
+++ b/tensorpipe/core/listener.h
@@ -99,9 +99,14 @@ class Listener final : public std::enable_shared_from_this<Listener> {
       listeners_;
   std::map<std::string, transport::address_t> addresses_;
   RearmableCallbackWithExternalLock<
-      std::function<void(const Error&, std::shared_ptr<Pipe>, TLock)>,
+      std::function<void(
+          const Error&,
+          std::string,
+          std::shared_ptr<transport::Connection>,
+          TLock)>,
       const Error&,
-      std::shared_ptr<Pipe>>
+      std::string,
+      std::shared_ptr<transport::Connection>>
       acceptCallback_;
 
   // Needed to keep them alive.
@@ -146,7 +151,8 @@ class Listener final : public std::enable_shared_from_this<Listener> {
   void triggerAcceptCallback_(
       accept_callback_fn,
       const Error&,
-      std::shared_ptr<Pipe>,
+      std::string,
+      std::shared_ptr<transport::Connection>,
       TLock);
 
   void triggerConnectionRequestCallback_(


### PR DESCRIPTION
Basically, do to the listener what we did to the pipe in D20117741.

Since this was the last usage of the context's callback calling thread,
remove it.