### PR TITLE
Remove unused RingBuffer's ExtraData

### DIFF
--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TENSORPIPE_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/core/pipe.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/transport/connection.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/transport/error.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/util/ringbuffer/shm.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/util/shm/segment.cc
   )
 

--- a/tensorpipe/test/util/ringbuffer/ringbuffer_test.cc
+++ b/tensorpipe/test/util/ringbuffer/ringbuffer_test.cc
@@ -66,19 +66,19 @@ TEST(RingBuffer, WriteCopy) {
   TestData d2{.a = 0xFFFF, .b = 0x3333, .c = 0x1212};
 
   {
-    ssize_t ret = p.template write<TestData>(d0);
+    ssize_t ret = p.write(&d0, sizeof(d0));
     EXPECT_EQ(ret, sizeof(TestData));
   }
   EXPECT_EQ(rb->getHeader().usedSizeWeak(), 6);
 
   {
-    ssize_t ret = p.template write<TestData>(d1);
+    ssize_t ret = p.write(&d1, sizeof(d1));
     EXPECT_EQ(ret, sizeof(TestData));
   }
   EXPECT_EQ(rb->getHeader().usedSizeWeak(), 12);
 
   {
-    ssize_t ret = p.template write<TestData>(d2);
+    ssize_t ret = p.write(&d2, sizeof(d2));
     EXPECT_EQ(ret, -ENOSPC) << "Needs 2 more bytes to write the 6 required, "
                                "because 12 out of 16 are used.";
   }
@@ -86,13 +86,13 @@ TEST(RingBuffer, WriteCopy) {
   TestData r;
 
   {
-    ssize_t ret = c.copy(r);
+    ssize_t ret = c.copy(sizeof(r), &r);
     EXPECT_EQ(ret, sizeof(r));
     EXPECT_EQ(r, d0);
   }
 
   {
-    ssize_t ret = c.copy(r);
+    ssize_t ret = c.copy(sizeof(r), &r);
     EXPECT_EQ(ret, sizeof(r));
     EXPECT_EQ(r, d1);
   }
@@ -100,93 +100,14 @@ TEST(RingBuffer, WriteCopy) {
   EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
 
   {
-    ssize_t ret = p.template write<TestData>(d2);
+    ssize_t ret = p.write(&d2, sizeof(d2));
     EXPECT_EQ(ret, sizeof(TestData));
   }
   {
-    ssize_t ret = c.copy(r);
+    ssize_t ret = c.copy(sizeof(r), &r);
     EXPECT_EQ(ret, sizeof(r));
     EXPECT_EQ(r, d2);
   }
-  // It should be empty by now.
-  EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
-}
-
-TEST(RingBuffer, ReadWriteString) {
-  // 32 bytes.
-  size_t size = 1u << 5;
-  EXPECT_EQ(size, 32);
-
-  auto rb = makeRingBuffer(size);
-  // Make a producer.
-  TProducer p{rb};
-  // Make a consumer.
-  TConsumer c{rb};
-
-  EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
-
-  size_t exp_size = 4 + sizeof(uint32_t); // 8 bytes
-  {
-    ssize_t ret = p.writeSizedChunk<uint32_t>("hola");
-    EXPECT_EQ(ret, exp_size);
-  }
-  EXPECT_EQ(rb->getHeader().usedSizeWeak(), exp_size);
-
-  {
-    ssize_t ret = p.writeSizedChunk<uint32_t>("adios");
-    EXPECT_EQ(ret, 5 + sizeof(uint32_t));
-  }
-  exp_size += 5 + sizeof(uint32_t); // 17 bytes
-  EXPECT_EQ(rb->getHeader().usedSizeWeak(), exp_size);
-
-  {
-    ssize_t ret = p.template writeSizedChunk<uint32_t>("this will fail");
-    // 14 bytes in string. Needs 14 + sizeof(uint32_t) to write, but only 15
-    // left.
-    EXPECT_EQ(ret, -ENOSPC) << "Needs more bytes to write the full string";
-  }
-
-  {
-    // Read the first string out.
-    ssize_t ret;
-    optional<std::string> str;
-    std::tie(ret, str) = c.template readSizedChunk<uint32_t>();
-    EXPECT_EQ(ret, sizeof(uint32_t) + 4);
-    EXPECT_EQ(*str, "hola");
-  }
-  exp_size -= 4 + sizeof(uint32_t); // 9 bytes
-  EXPECT_EQ(exp_size, 9);
-  EXPECT_EQ(rb->getHeader().usedSizeWeak(), exp_size);
-
-  {
-    // Write one more, this one fits and will wrap around.
-    ssize_t ret =
-        p.writeSizedChunk<uint32_t>("  another very long"); // 19 bytes long.
-    EXPECT_EQ(ret, 19 + sizeof(uint32_t));
-  }
-  exp_size += 19 + sizeof(uint32_t); // 32 bytes
-  EXPECT_EQ(rb->getHeader().usedSizeWeak(), exp_size);
-
-  {
-    // Read second string.
-    ssize_t ret;
-    optional<std::string> str;
-    std::tie(ret, str) = c.template readSizedChunk<uint32_t>();
-    EXPECT_EQ(ret, sizeof(uint32_t) + 5);
-    EXPECT_EQ(*str, "adios");
-  }
-  exp_size -= 5 + sizeof(uint32_t); // 9 bytes less, 23.
-  EXPECT_EQ(rb->getHeader().usedSizeWeak(), exp_size);
-
-  {
-    // Read last string
-    ssize_t ret;
-    optional<std::string> str;
-    std::tie(ret, str) = c.template readSizedChunk<uint32_t>();
-    EXPECT_EQ(ret, sizeof(uint32_t) + 19);
-    EXPECT_EQ(*str, "  another very long");
-  }
-
   // It should be empty by now.
   EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
 }
@@ -228,11 +149,12 @@ TEST(RingBuffer, ReadMultipleElems) {
   {
     // read the three bytes at once.
     ssize_t ret;
-    const void* ptr;
-    std::tie(ret, ptr) = c.startReadTx(sizeof(uint8_t) * 3);
+    ret = c.startTx();
+    EXPECT_EQ(ret, 0);
+
+    std::array<uint8_t, 3> r;
+    ret = c.copyInTx(sizeof(r), r.data());
     EXPECT_EQ(ret, 3);
-    EXPECT_TRUE(ptr != nullptr);
-    auto r = static_cast<const uint8_t*>(ptr);
     EXPECT_EQ(r[0], 0xAC);
     EXPECT_EQ(r[1], 0xAC);
     EXPECT_EQ(r[2], 0xAC);
@@ -243,11 +165,12 @@ TEST(RingBuffer, ReadMultipleElems) {
   {
     // read 253 bytes at once.
     ssize_t ret;
-    const void* ptr;
-    std::tie(ret, ptr) = c.startReadTx(sizeof(uint8_t) * 253);
+    ret = c.startTx();
+    EXPECT_EQ(ret, 0);
+
+    std::array<uint8_t, 253> r;
+    ret = c.copyInTx(sizeof(r), r.data());
     EXPECT_EQ(ret, 253);
-    EXPECT_TRUE(ptr != nullptr);
-    auto r = static_cast<const uint8_t*>(ptr);
     for (int i = 0; i < 253; ++i) {
       EXPECT_EQ(r[i], 0xAC);
     }
@@ -258,11 +181,14 @@ TEST(RingBuffer, ReadMultipleElems) {
   {
     // No more elements
     ssize_t ret;
-    const void* ptr;
-    std::tie(ret, ptr) = c.startReadTx(sizeof(uint8_t));
+    ret = c.startTx();
+    EXPECT_EQ(ret, 0);
+    uint8_t ch;
+    ret = c.copyInTx(sizeof(ch), &ch);
     EXPECT_EQ(ret, -ENODATA);
-    EXPECT_TRUE(ptr == nullptr);
-    EXPECT_TRUE(!c.inTx()) << "Failed transaction should've be canceled";
+    ret = c.cancelTx();
+    EXPECT_EQ(ret, 0);
+    EXPECT_TRUE(!c.inTx()) << "Canceled transaction should've been canceled";
   }
 }
 
@@ -301,7 +227,7 @@ TEST(RingBuffer, CopyWrapping) {
   uint8_t cr;
   uint64_t nr;
 
-  ret = c.copy(cr);
+  ret = c.copy(sizeof(cr), &cr);
   EXPECT_EQ(ret, sizeof(cr));
   EXPECT_EQ(cr, ch);
   EXPECT_EQ(rb->getHeader().readHead(), 1);
@@ -313,7 +239,7 @@ TEST(RingBuffer, CopyWrapping) {
   EXPECT_EQ(rb->getHeader().readHead(), 9);
   EXPECT_EQ(rb->getHeader().readTail(), 1);
 
-  ret = c.copy(nr);
+  ret = c.copy(sizeof(nr), &nr);
   EXPECT_EQ(ret, sizeof(nr));
   EXPECT_EQ(nr, n);
   EXPECT_EQ(rb->getHeader().readHead(), 9);
@@ -361,11 +287,13 @@ TEST(RingBuffer, ReadTxWrappingOneCons) {
   {
     // Start c1 read Tx
     ssize_t ret;
-    const uint8_t* ptrch;
-    std::tie(ret, ptrch) = c1.template startReadTx<uint8_t>();
+    ret = c1.startTx();
+    EXPECT_EQ(ret, 0);
+
+    uint8_t rch;
+    ret = c1.copyInTx(sizeof(rch), &rch);
     EXPECT_EQ(ret, sizeof(uint8_t));
-    EXPECT_TRUE(ptrch != nullptr);
-    EXPECT_EQ(*ptrch, ch);
+    EXPECT_EQ(rch, ch);
     EXPECT_EQ(rb->getHeader().readHead(), 1);
     EXPECT_EQ(rb->getHeader().readTail(), 0);
     EXPECT_TRUE(c1.inTx());
@@ -395,11 +323,13 @@ TEST(RingBuffer, ReadTxWrappingOneCons) {
   {
     // Start c1 read Tx again.
     ssize_t ret;
-    const uint64_t* ptrn;
-    std::tie(ret, ptrn) = c1.template startReadTx<uint64_t>();
+    ret = c1.startTx();
+    EXPECT_EQ(ret, 0);
+
+    uint64_t rn;
+    ret = c1.copyInTx(sizeof(rn), &rn);
     EXPECT_EQ(ret, sizeof(uint64_t));
-    EXPECT_TRUE(ptrn != nullptr);
-    EXPECT_EQ((*ptrn), n);
+    EXPECT_EQ(rn, n);
     EXPECT_EQ(rb->getHeader().readHead(), 9);
     EXPECT_EQ(rb->getHeader().readTail(), 1);
     EXPECT_TRUE(c1.inTx());
@@ -422,11 +352,13 @@ TEST(RingBuffer, ReadTxWrappingOneCons) {
   }
   {
     ssize_t ret;
-    const uint64_t* ptrn;
-    std::tie(ret, ptrn) = c1.template startReadTx<uint64_t>();
+    ret = c1.startTx();
+    EXPECT_EQ(ret, 0);
+
+    uint64_t rn;
+    ret = c1.copyInTx(sizeof(rn), &rn);
     EXPECT_EQ(ret, sizeof(uint64_t));
-    EXPECT_TRUE(ptrn != nullptr);
-    EXPECT_EQ((*ptrn), n);
+    EXPECT_EQ(rn, n);
     EXPECT_EQ(rb->getHeader().readHead(), 17);
     EXPECT_EQ(rb->getHeader().readTail(), 9);
   }
@@ -440,11 +372,13 @@ TEST(RingBuffer, ReadTxWrappingOneCons) {
   {
     // Now c1 can read.
     ssize_t ret;
-    const uint64_t* ptrnr;
-    std::tie(ret, ptrnr) = c1.template startReadTx<uint64_t>();
+    ret = c1.startTx();
+    EXPECT_EQ(ret, 0);
+
+    uint64_t rn;
+    ret = c1.copyInTx(sizeof(rn), &rn);
     EXPECT_EQ(ret, sizeof(uint64_t));
-    EXPECT_TRUE(ptrnr != nullptr);
-    EXPECT_EQ((*ptrnr), n);
+    EXPECT_EQ(rn, n);
     EXPECT_EQ(rb->getHeader().readHead(), 17);
     EXPECT_EQ(rb->getHeader().readTail(), 9);
   }
@@ -500,11 +434,13 @@ TEST(RingBuffer, ReadTxWrapping) {
   {
     // Start c1 read Tx
     ssize_t ret;
-    const uint8_t* ptrch;
-    std::tie(ret, ptrch) = c1.template startReadTx<uint8_t>();
+    ret = c1.startTx();
+    EXPECT_EQ(ret, 0);
+
+    uint8_t rch;
+    ret = c1.copyInTx(sizeof(rch), &rch);
     EXPECT_EQ(ret, sizeof(uint8_t));
-    EXPECT_TRUE(ptrch != nullptr);
-    EXPECT_EQ(*ptrch, ch);
+    EXPECT_EQ(rch, ch);
     EXPECT_EQ(rb->getHeader().readHead(), 1);
     EXPECT_EQ(rb->getHeader().readTail(), 0);
     EXPECT_TRUE(c1.inTx());
@@ -534,23 +470,23 @@ TEST(RingBuffer, ReadTxWrapping) {
   {
     // Start c1 read Tx again.
     ssize_t ret;
-    const uint64_t* ptrn;
-    std::tie(ret, ptrn) = c1.template startReadTx<uint64_t>();
+    ret = c1.startTx();
+    EXPECT_EQ(ret, 0);
+
+    uint64_t rn;
+    ret = c1.copyInTx(sizeof(rn), &rn);
     EXPECT_EQ(ret, sizeof(uint64_t));
-    EXPECT_TRUE(ptrn != nullptr);
-    EXPECT_EQ((*ptrn), n);
+    EXPECT_EQ(rn, n);
     EXPECT_EQ(rb->getHeader().readHead(), 9);
     EXPECT_EQ(rb->getHeader().readTail(), 1);
     EXPECT_TRUE(c1.inTx());
   }
 
   {
-    // Try to read before c1 completing and get -EAGAIN because buffer is busy.
+    // Try to start read tx before c1 completing and get -EAGAIN.
     ssize_t ret;
-    const uint64_t* ptrn;
-    std::tie(ret, ptrn) = c2.template startReadTx<uint64_t>();
+    ret = c2.startTx();
     EXPECT_EQ(ret, -EAGAIN);
-    EXPECT_TRUE(ptrn == nullptr);
   }
 
   {
@@ -570,11 +506,13 @@ TEST(RingBuffer, ReadTxWrapping) {
   }
   {
     ssize_t ret;
-    const uint64_t* ptrn;
-    std::tie(ret, ptrn) = c2.template startReadTx<uint64_t>();
+    ret = c2.startTx();
+    EXPECT_EQ(ret, 0);
+
+    uint64_t rn;
+    ret = c2.copyInTx(sizeof(rn), &rn);
     EXPECT_EQ(ret, sizeof(uint64_t));
-    EXPECT_TRUE(ptrn != nullptr);
-    EXPECT_EQ((*ptrn), n);
+    EXPECT_EQ(rn, n);
     EXPECT_EQ(rb->getHeader().readHead(), 17);
     EXPECT_EQ(rb->getHeader().readTail(), 9);
   }
@@ -588,11 +526,13 @@ TEST(RingBuffer, ReadTxWrapping) {
   {
     // Now c1 can read.
     ssize_t ret;
-    const uint64_t* ptrnr;
-    std::tie(ret, ptrnr) = c1.template startReadTx<uint64_t>();
+    ret = c1.startTx();
+    EXPECT_EQ(ret, 0);
+
+    uint64_t rn;
+    ret = c1.copyInTx(sizeof(rn), &rn);
     EXPECT_EQ(ret, sizeof(uint64_t));
-    EXPECT_TRUE(ptrnr != nullptr);
-    EXPECT_EQ((*ptrnr), n);
+    EXPECT_EQ(rn, n);
     EXPECT_EQ(rb->getHeader().readHead(), 17);
     EXPECT_EQ(rb->getHeader().readTail(), 9);
   }
@@ -603,192 +543,5 @@ TEST(RingBuffer, ReadTxWrapping) {
     EXPECT_EQ(ret, 0);
     EXPECT_FALSE(c1.inTx());
     EXPECT_FALSE(c2.inTx());
-  }
-}
-
-TEST(RingBuffer, InTx) {
-  // Enough to fit the bytes required to fit all writes.
-  size_t size = (1 + 4) + 2 + 2 + (1 + 2) + (1 + 2);
-
-  auto rb = makeRingBuffer(size);
-  // Make a producer.
-  TProducer p{rb};
-
-  EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
-
-  {
-    ssize_t ret = p.startTx();
-    EXPECT_EQ(ret, 0);
-  }
-  {
-    // 1 + 4 bytes.
-    ssize_t ret = p.writeInTxWithSize<uint8_t>(4u, "hola");
-    EXPECT_EQ(ret, sizeof(uint8_t) + 4);
-  }
-  {
-    // 2 bytes.
-    ssize_t ret = p.writeInTx<uint16_t>(8u);
-    EXPECT_EQ(ret, sizeof(uint16_t));
-  }
-  {
-    // 2 bytes.
-    ssize_t ret = p.writeInTx<uint16_t>(9u);
-    EXPECT_EQ(ret, sizeof(uint16_t));
-  }
-  {
-    // 1 + 2 bytes.
-    uint16_t data = 10u;
-    ssize_t ret = p.writeInTxWithSize<uint8_t>(sizeof(data), &data);
-    EXPECT_EQ(ret, sizeof(uint8_t) + sizeof(uint16_t));
-  }
-  {
-    // 1 + 2 bytes.
-    uint16_t data = 11u;
-    ssize_t ret = p.writeInTxWithSize<uint8_t>(sizeof(data), &data);
-    EXPECT_EQ(ret, sizeof(uint8_t) + sizeof(uint16_t));
-  }
-  {
-    ssize_t ret = p.commitTx();
-    EXPECT_EQ(ret, 0);
-  }
-
-  EXPECT_EQ(rb->getHeader().usedSizeWeak(), size);
-
-  // Make a consumer.
-  TConsumer c{rb};
-  {
-    ssize_t ret = c.startTx();
-    EXPECT_EQ(ret, 0);
-  }
-
-  constexpr size_t kBytesInStrSize = sizeof(uint8_t);
-  {
-    ssize_t s0 = c.findInBufferInTx<false, 'h'>();
-    EXPECT_EQ(s0, kBytesInStrSize + 1);
-    // Read again to ensure that does not change.
-    ssize_t s1 = c.findInBufferInTx<false, 'h'>();
-    EXPECT_EQ(s1, kBytesInStrSize + 1);
-
-    // Read size of written data (no wrapping yet).
-    ssize_t s2 = c.findInBufferInTx<true>();
-    EXPECT_EQ(s2, c.getHeader().usedSizeWeak());
-  }
-  {
-    ssize_t s0 = c.findInBufferInTx<false, 'a'>();
-    EXPECT_EQ(s0, kBytesInStrSize + 4);
-    // Read again to ensure that does not change.
-    ssize_t s1 = c.findInBufferInTx<false, 'a'>();
-    EXPECT_EQ(s1, kBytesInStrSize + 4);
-  }
-  {
-    // Search for a character that does not exist.
-    ssize_t s = c.findInBufferInTx<false, 0x7>();
-    EXPECT_EQ(s, -ENODATA);
-    EXPECT_EQ(s, -ENODATA);
-  }
-
-  {
-    ssize_t size;
-    const void* d_ptr;
-    std::tie(size, d_ptr) = c.readInTxWithSize<uint8_t>();
-    EXPECT_EQ(size, 4u);
-    EXPECT_TRUE(memcmp(d_ptr, "hola", 4u) == 0);
-  }
-
-  {
-    // Verify has been consumed in transaction.
-    ssize_t s = c.findInBufferInTx<false, 'h'>();
-    EXPECT_EQ(s, -ENODATA);
-  }
-
-  // Cancel transaction and start over.
-  ssize_t ret = c.cancelTx();
-  EXPECT_EQ(ret, 0);
-  ret = c.startTx();
-  EXPECT_EQ(ret, 0);
-  {
-    ssize_t s0 = c.findInBufferInTx<false, 'h'>();
-    EXPECT_EQ(s0, kBytesInStrSize + 1);
-    // Read again to ensure that does not change.
-    ssize_t s1 = c.findInBufferInTx<false, 'h'>();
-    EXPECT_EQ(s1, kBytesInStrSize + 1);
-  }
-  {
-    ssize_t s0 = c.findInBufferInTx<false, 'a'>();
-    EXPECT_EQ(s0, kBytesInStrSize + 4);
-    // Read again to ensure that does not change.
-    ssize_t s1 = c.findInBufferInTx<false, 'a'>();
-    EXPECT_EQ(s1, kBytesInStrSize + 4);
-  }
-  {
-    // Search for a character that does not exist.
-    ssize_t s = c.findInBufferInTx<false, 0x7>();
-    EXPECT_EQ(s, -ENODATA);
-    EXPECT_EQ(s, -ENODATA);
-  }
-
-  {
-    ssize_t size;
-    const void* d_ptr;
-    std::tie(size, d_ptr) = c.readInTxWithSize<uint8_t>();
-    EXPECT_EQ(size, 4u);
-    EXPECT_TRUE(memcmp(d_ptr, "hola", 4u) == 0);
-  }
-
-  {
-    // Transaction has already read 'hola', so there should be no match.
-    ssize_t s = c.findInBufferInTx<false, 'h'>();
-    EXPECT_EQ(s, -ENODATA);
-  }
-
-  {
-    ssize_t size;
-    const uint16_t* d_ptr;
-    std::tie(ret, d_ptr) = c.readInTx<uint16_t>();
-    EXPECT_EQ(ret, 2);
-    EXPECT_EQ(*d_ptr, 8u);
-  }
-  {
-    ssize_t size;
-    uint16_t d = 0;
-    ret = c.copyInTx(sizeof(d), reinterpret_cast<uint8_t*>(&d));
-    EXPECT_EQ(ret, 2);
-    EXPECT_EQ(d, 9u);
-  }
-  {
-    ssize_t size;
-    const void* d_ptr;
-    std::tie(ret, d_ptr) = c.readInTxWithSize<uint8_t>();
-    EXPECT_EQ(ret, 2);
-    EXPECT_EQ(*reinterpret_cast<const uint16_t*>(d_ptr), 10u);
-  }
-  {
-    ssize_t size;
-    uint16_t d = 0;
-    ret =
-        c.copyInTxWithSize<uint8_t>(sizeof(d), reinterpret_cast<uint8_t*>(&d));
-    EXPECT_EQ(ret, 2);
-    EXPECT_EQ(d, 11u);
-  }
-  {
-    ssize_t size;
-    const void* d_ptr;
-    std::tie(ret, d_ptr) = c.readInTxWithSize<uint8_t>();
-    EXPECT_EQ(ret, -ENODATA);
-  }
-
-  ret = c.commitTx();
-  EXPECT_EQ(ret, 0);
-  EXPECT_EQ(c.getHeader().usedSizeWeak(), 0) << "There should be no data left";
-  {
-    // Verify has been consumed after committing transaction.
-    ret = c.startTx();
-    EXPECT_EQ(ret, 0);
-
-    ssize_t s = c.findInBufferInTx<false, 'h'>();
-    EXPECT_EQ(s, -ENODATA);
-
-    ret = c.dropInTx();
-    EXPECT_EQ(ret, 0);
   }
 }

--- a/tensorpipe/test/util/ringbuffer/ringbuffer_test.cc
+++ b/tensorpipe/test/util/ringbuffer/ringbuffer_test.cc
@@ -25,26 +25,12 @@ struct TestData {
   }
 };
 
-struct MockExtraData {
-  bool canRead() const {
-    return true;
-  }
-  bool canWrite() const {
-    return true;
-  }
-};
-
-using TRingBufferHeader = RingBufferHeader<MockExtraData>;
-using TRingBuffer = RingBuffer<MockExtraData>;
-using TProducer = Producer<MockExtraData>;
-using TConsumer = Consumer<MockExtraData>;
-
-std::shared_ptr<TRingBuffer> makeRingBuffer(size_t size) {
-  auto header = std::make_shared<TRingBufferHeader>(size);
+std::shared_ptr<RingBuffer> makeRingBuffer(size_t size) {
+  auto header = std::make_shared<RingBufferHeader>(size);
   // In C++20 use std::make_shared<uint8_t[]>(size)
   auto data = std::shared_ptr<uint8_t>(
       new uint8_t[header->kDataPoolByteSize], std::default_delete<uint8_t[]>());
-  return std::make_shared<TRingBuffer>(std::move(header), std::move(data));
+  return std::make_shared<RingBuffer>(std::move(header), std::move(data));
 }
 
 TEST(RingBuffer, WriteCopy) {
@@ -55,9 +41,9 @@ TEST(RingBuffer, WriteCopy) {
 
   auto rb = makeRingBuffer(size);
   // Make a producer.
-  TProducer p{rb};
+  Producer p{rb};
   // Make a consumer.
-  TConsumer c{rb};
+  Consumer c{rb};
 
   EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
 
@@ -118,9 +104,9 @@ TEST(RingBuffer, ReadMultipleElems) {
 
   auto rb = makeRingBuffer(size);
   // Make a producer.
-  TProducer p{rb};
+  Producer p{rb};
   // Make a consumer.
-  TConsumer c{rb};
+  Consumer c{rb};
 
   EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
 
@@ -198,9 +184,9 @@ TEST(RingBuffer, CopyWrapping) {
 
   auto rb = makeRingBuffer(size);
   // Make a producer.
-  TProducer p{rb};
+  Producer p{rb};
   // Make a consumer.
-  TConsumer c{rb};
+  Consumer c{rb};
 
   EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
 
@@ -252,9 +238,9 @@ TEST(RingBuffer, ReadTxWrappingOneCons) {
 
   auto rb = makeRingBuffer(size);
   // Make a producer.
-  TProducer p{rb};
+  Producer p{rb};
   // Make a consumer.
-  TConsumer c1{rb};
+  Consumer c1{rb};
 
   EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
 
@@ -397,10 +383,10 @@ TEST(RingBuffer, ReadTxWrapping) {
 
   auto rb = makeRingBuffer(size);
   // Make a producer.
-  TProducer p{rb};
+  Producer p{rb};
   // Make consumers.
-  TConsumer c1{rb};
-  TConsumer c2{rb};
+  Consumer c1{rb};
+  Consumer c2{rb};
 
   EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
 

--- a/tensorpipe/test/util/ringbuffer/shm_ringbuffer_test.cc
+++ b/tensorpipe/test/util/ringbuffer/shm_ringbuffer_test.cc
@@ -50,7 +50,7 @@ TEST(ShmRingBuffer, SameProducerConsumer) {
     // Producer loop. It all fits in buffer.
     int i = 0;
     while (i < 2000) {
-      ssize_t ret = prod.write(i);
+      ssize_t ret = prod.write(&i, sizeof(i));
       EXPECT_EQ(ret, sizeof(i));
       ++i;
     }
@@ -65,7 +65,7 @@ TEST(ShmRingBuffer, SameProducerConsumer) {
     int i = 0;
     while (i < 2000) {
       int value;
-      ssize_t ret = cons.copy(value);
+      ssize_t ret = cons.copy(sizeof(value), &value);
       EXPECT_EQ(ret, sizeof(value));
       EXPECT_EQ(value, i);
       ++i;
@@ -111,7 +111,7 @@ TEST(ShmRingBuffer, SingleProducer_SingleConsumer) {
 
       int i = 0;
       while (i < 2000) {
-        ssize_t ret = prod.write(i);
+        ssize_t ret = prod.write(&i, sizeof(i));
         if (ret == -ENOSPC) {
           std::this_thread::yield();
           continue;
@@ -150,7 +150,7 @@ TEST(ShmRingBuffer, SingleProducer_SingleConsumer) {
   int i = 0;
   while (i < 2000) {
     int value;
-    ssize_t ret = cons.copy(value);
+    ssize_t ret = cons.copy(sizeof(value), &value);
     if (ret == -ENODATA) {
       std::this_thread::yield();
       continue;

--- a/tensorpipe/transport/shm/connection.cc
+++ b/tensorpipe/transport/shm/connection.cc
@@ -391,9 +391,8 @@ bool Connection::ReadOperation::handleRead(TConsumer& inbox) {
 
   bool lengthRead = false;
   if (mode_ == READ_LENGTH) {
-    ssize_t ret;
-    const uint32_t* lengthPtr;
-    std::tie(ret, lengthPtr) = inbox.readInTx<uint32_t>();
+    uint32_t length;
+    ssize_t ret = inbox.copyInTx(sizeof(length), &length);
     if (ret == -ENODATA) {
       ret = inbox.cancelTx();
       TP_THROW_SYSTEM_IF(ret < 0, -ret);
@@ -402,9 +401,9 @@ bool Connection::ReadOperation::handleRead(TConsumer& inbox) {
     TP_THROW_SYSTEM_IF(ret < 0, -ret);
 
     if (ptr_ != nullptr) {
-      TP_DCHECK_EQ(*lengthPtr, len_);
+      TP_DCHECK_EQ(length, len_);
     } else {
-      len_ = *lengthPtr;
+      len_ = length;
       buf_ = std::make_unique<uint8_t[]>(len_);
       ptr_ = buf_.get();
     }

--- a/tensorpipe/transport/shm/reactor.cc
+++ b/tensorpipe/transport/shm/reactor.cc
@@ -18,7 +18,7 @@ namespace {
 
 void writeToken(TReactorProducer& producer, Reactor::TToken token) {
   for (;;) {
-    auto rv = producer.write(token);
+    auto rv = producer.write(&token, sizeof(token));
     if (rv == -EAGAIN) {
       std::this_thread::yield();
       continue;
@@ -90,7 +90,7 @@ std::tuple<int, int> Reactor::fds() const {
 void Reactor::run() {
   while (!done_.load()) {
     uint32_t token;
-    auto ret = consumer_->copy(token);
+    auto ret = consumer_->copy(sizeof(token), &token);
     if (ret == -ENODATA) {
       std::this_thread::yield();
       continue;

--- a/tensorpipe/transport/shm/reactor.cc
+++ b/tensorpipe/transport/shm/reactor.cc
@@ -16,7 +16,7 @@ namespace shm {
 
 namespace {
 
-void writeToken(TReactorProducer& producer, Reactor::TToken token) {
+void writeToken(util::ringbuffer::Producer& producer, Reactor::TToken token) {
   for (;;) {
     auto rv = producer.write(&token, sizeof(token));
     if (rv == -EAGAIN) {
@@ -33,9 +33,8 @@ void writeToken(TReactorProducer& producer, Reactor::TToken token) {
 Reactor::Reactor() {
   int headerFd;
   int dataFd;
-  std::shared_ptr<TReactorRingBuffer> rb;
-  std::tie(headerFd, dataFd, rb) =
-      util::ringbuffer::shm::create<TReactorRingBuffer>(kSize);
+  std::shared_ptr<util::ringbuffer::RingBuffer> rb;
+  std::tie(headerFd, dataFd, rb) = util::ringbuffer::shm::create(kSize);
   headerFd_ = Fd(headerFd);
   dataFd_ = Fd(dataFd);
   consumer_.emplace(rb);
@@ -113,7 +112,7 @@ void Reactor::run() {
 }
 
 Reactor::Trigger::Trigger(Fd&& headerFd, Fd&& dataFd)
-    : producer_(util::ringbuffer::shm::load<TReactorRingBuffer>(
+    : producer_(util::ringbuffer::shm::load(
           // The header and data segment objects take over ownership
           // of file descriptors. Release them to avoid double close.
           headerFd.release(),

--- a/tensorpipe/transport/shm/reactor.h
+++ b/tensorpipe/transport/shm/reactor.h
@@ -24,14 +24,6 @@ namespace tensorpipe {
 namespace transport {
 namespace shm {
 
-// Extra data stored in ring buffer header.
-struct ReactorRingBufferExtraData {};
-
-using TReactorRingBuffer =
-    util::ringbuffer::RingBuffer<ReactorRingBufferExtraData>;
-using TReactorProducer = util::ringbuffer::Producer<ReactorRingBufferExtraData>;
-using TReactorConsumer = util::ringbuffer::Consumer<ReactorRingBufferExtraData>;
-
 // Reactor loop.
 //
 // Companion class to the event loop in `loop.h` that executes
@@ -68,8 +60,8 @@ class Reactor final : public std::enable_shared_from_this<Reactor> {
  private:
   Fd headerFd_;
   Fd dataFd_;
-  optional<TReactorConsumer> consumer_;
-  optional<TReactorProducer> producer_;
+  optional<util::ringbuffer::Consumer> consumer_;
+  optional<util::ringbuffer::Producer> producer_;
 
   std::mutex mutex_;
   std::thread thread_;
@@ -96,7 +88,7 @@ class Reactor final : public std::enable_shared_from_this<Reactor> {
     void run(TToken token);
 
    private:
-    TReactorProducer producer_;
+    util::ringbuffer::Producer producer_;
   };
 };
 

--- a/tensorpipe/util/ringbuffer/consumer.h
+++ b/tensorpipe/util/ringbuffer/consumer.h
@@ -19,13 +19,10 @@ namespace ringbuffer {
 ///
 /// Provides method to read data ringbuffer.
 ///
-template <class THeaderExtraData>
-class Consumer : public RingBufferWrapper<THeaderExtraData> {
+class Consumer : public RingBufferWrapper {
  public:
-  using TExtraData = THeaderExtraData;
-
   // Use base class constructor.
-  using RingBufferWrapper<THeaderExtraData>::RingBufferWrapper;
+  using RingBufferWrapper::RingBufferWrapper;
 
   Consumer(const Consumer&) = delete;
   Consumer(Consumer&&) = delete;

--- a/tensorpipe/util/ringbuffer/consumer.h
+++ b/tensorpipe/util/ringbuffer/consumer.h
@@ -35,16 +35,6 @@ class Consumer : public RingBufferWrapper<THeaderExtraData> {
       auto r = this->cancelTx();
       TP_DCHECK_EQ(r, 0);
     }
-    releaseAuxBuffer();
-  }
-
-  void releaseAuxBuffer() {
-    if (aux_buffer_ == nullptr) {
-      return;
-    }
-    free(aux_buffer_);
-    aux_buffer_ = nullptr;
-    aux_buffer_size_ = 0;
   }
 
   //
@@ -68,69 +58,31 @@ class Consumer : public RingBufferWrapper<THeaderExtraData> {
     return 0;
   }
 
-  /// Returns {size, ptr) if succeded.
-  std::pair<ssize_t, const void*> readInTx(const size_t size) noexcept {
+  [[nodiscard]] ssize_t commitTx() noexcept {
     if (unlikely(!inTx())) {
-      return {-EINVAL, nullptr};
+      return -EINVAL;
     }
-    if (unlikely(size > this->header_.kDataPoolByteSize)) {
-      return {-EINVAL, nullptr};
-    }
-    auto ptr = this->read_(size);
-    if (ptr == nullptr) {
-      return {-ENODATA, nullptr};
-    }
-    return {size, ptr};
+    this->header_.incTail(this->tx_size_);
+    this->tx_size_ = 0;
+    this->inTx_ = false;
+    this->header_.in_read_tx.clear(std::memory_order_release);
+    return 0;
   }
 
-  // Pointer may become invalid in next read or when transaction completes.
-  template <class T>
-  std::pair<ssize_t, const T*> readInTx() noexcept {
-    static_assert(std::is_trivial<T>::value, "!");
-    static_assert(std::is_standard_layout<T>::value, "!");
-
-    ssize_t ret;
-    const void* ptr;
-    std::tie(ret, ptr) = readInTx(sizeof(T));
-    return {ret, static_cast<const T*>(ptr)};
-  }
-
-  // Reads the next sizeof(TSize) in ringbuffer and use it as the size for
-  // next chunk of data.
-  // On success, returns <size, ptr> where size is the number of bytes in
-  // next chunk and ptr is the pointer to it.
-  // On failure, returns <-ERROR CODE, nullptr>.
-  // Pointer may become invalid in next read or when transaction completes.
-  template <class TSize>
-  std::pair<ssize_t, const void*> readInTxWithSize() noexcept {
-    static_assert(std::is_integral<TSize>::value, "!");
+  [[nodiscard]] ssize_t cancelTx() noexcept {
     if (unlikely(!inTx())) {
-      return {-EINVAL, nullptr};
+      return -EINVAL;
     }
-
-    TSize length;
-
-    ssize_t ret_size;
-    const TSize* length_ptr;
-    std::tie(ret_size, length_ptr) = this->readInTx<TSize>();
-    if (0 > ret_size) {
-      return {ret_size, nullptr};
-    }
-    TP_DCHECK_EQ(ret_size, sizeof(TSize));
-    length = *length_ptr;
-
-    ssize_t ret;
-    const void* data_ptr;
-    std::tie(ret, data_ptr) = this->readInTx(length);
-    if (0 > ret) {
-      return {ret, nullptr};
-    }
-    TP_DCHECK_EQ(ret, length);
-    return {length, static_cast<const void*>(data_ptr)};
+    this->tx_size_ = 0;
+    // <in_read_tx> flags that we are in a transaction,
+    // so enforce no stores pass it.
+    this->inTx_ = false;
+    this->header_.in_read_tx.clear(std::memory_order_release);
+    return 0;
   }
 
   // Copy next <size> bytes to buffer.
-  [[nodiscard]] ssize_t copyInTx(const size_t size, uint8_t* buffer) noexcept {
+  [[nodiscard]] ssize_t copyInTx(const size_t size, void* buffer) noexcept {
     if (unlikely(!inTx())) {
       return -EINVAL;
     }
@@ -140,14 +92,8 @@ class Consumer : public RingBufferWrapper<THeaderExtraData> {
     if (unlikely(size > this->header_.kDataPoolByteSize)) {
       return -EINVAL;
     }
-    const uint8_t* ptr;
-    uint8_t* resized;
-    std::tie(ptr, resized) = readFromRingBuffer_<true, false>(
-        size, static_cast<uint8_t*>(buffer), size);
-    if (unlikely(resized)) {
-      TP_LOG_ERROR() << "Unexpected resizing of buffers";
-      return -EPERM;
-    }
+    const uint8_t* ptr =
+        readFromRingBuffer_(size, static_cast<uint8_t*>(buffer));
     if (ptr == nullptr) {
       return -ENODATA;
     }
@@ -166,171 +112,9 @@ class Consumer : public RingBufferWrapper<THeaderExtraData> {
     return this->copyInTx(std::min(size, avail), buffer);
   }
 
-  template <class T>
-  [[nodiscard]] ssize_t copyInTx(T* buffer) noexcept {
-    static_assert(std::is_trivially_copyable<T>::value, "!");
-    return copyInTx(sizeof(T), buffer);
-  }
-
-  template <class TSize>
-  [[nodiscard]] ssize_t copyInTxWithSize(
-      const size_t size,
-      uint8_t* buffer) noexcept {
-    static_assert(std::is_integral<TSize>::value, "!");
-    if (unlikely(!inTx())) {
-      return -EINVAL;
-    }
-
-    ssize_t ret_size;
-    const TSize* length_ptr;
-    std::tie(ret_size, length_ptr) = this->readInTx<TSize>();
-    if (0 > ret_size) {
-      return ret_size;
-    }
-    TP_DCHECK_EQ(ret_size, sizeof(TSize));
-    if (*length_ptr != size) {
-      return -EINVAL;
-    }
-
-    ssize_t ret = this->copyInTx(size, buffer);
-    if (0 > ret) {
-      return ret;
-    }
-    TP_DCHECK_EQ(ret, size);
-    return size;
-  }
-
-  [[nodiscard]] ssize_t commitTx() noexcept {
-    if (unlikely(!inTx())) {
-      return -EINVAL;
-    }
-    this->header_.incTail(this->tx_size_);
-    this->tx_size_ = 0;
-    this->inTx_ = false;
-    this->header_.in_read_tx.clear(std::memory_order_release);
-    return 0;
-  }
-
-  /// If kContiguous, look for end  of contiguous data and ignore kElem.
-  /// Else, search for first occurrence of kElem in buffer.
-  /// Both modes take into account bytes already read in transaction.
-  /// If found, returns size of read that ends at matched position (inclusive).
-  /// if not found, return -ENODATA.
-  /// It does not update <tx_size_>.
-  template <bool kContiguous, uint8_t kElem = 0x0>
-  ssize_t findInBufferInTx() const noexcept {
-    if (unlikely(!inTx())) {
-      return -EINVAL;
-    }
-    uint64_t head = this->header_.readHead();
-    // Single reader because we are in Tx, safe to read tail.
-    uint64_t tail = this->header_.readTail();
-
-    TP_DCHECK_LE(head - tail, this->header_.kDataPoolByteSize);
-    // This check was present in the original code but started failing as we
-    // modified a test. We believe the test is wrong: it would make sense in the
-    // producer (where it would check that adding the transaction to the current
-    // contents doesn't exceed the capacity), but not in the consumer (where we
-    // would have to subtract the transaction size, but then this becomes a
-    // looser version of the check just before it).
-    // TP_DCHECK_LE(
-    //     head + this->tx_size_ - tail, this->header_.kDataPoolByteSize);
-
-    TP_DCHECK_LE(tail + this->tx_size_, head);
-
-    if (tail + this->tx_size_ == head) {
-      return -ENODATA;
-    }
-
-    // start and end are head and tail in module arithmetic.
-    uint64_t start = (this->tx_size_ + tail) & this->header_.kDataModMask;
-    uint64_t end = head & this->header_.kDataModMask;
-
-    const bool wrap = start >= end;
-
-    if (kContiguous) {
-      // if no elem is provided, then find contiguous chunk.
-      if (wrap) {
-        return static_cast<ssize_t>(this->header_.kDataPoolByteSize - start);
-      } else {
-        return static_cast<ssize_t>(end - start);
-      }
-    }
-
-    const auto loop1_end = wrap ? this->header_.kDataPoolByteSize : end;
-    for (auto i = start; i < loop1_end; ++i) {
-      if (unlikely(this->data_[i] == kElem)) {
-        return static_cast<ssize_t>(i - start) + 1;
-      }
-    }
-    if (unlikely(wrap)) {
-      // Search in wrapped part of buffer.
-      for (decltype(end) i = 0; i < end; ++i) {
-        if (unlikely(this->data_[i] == kElem)) {
-          return static_cast<ssize_t>(
-              this->header_.kDataPoolByteSize - start + i + 1);
-        }
-      }
-    }
-    return -ENODATA;
-  }
-
-  /// If kContiguous, read chunk of data until wrapping or end of buffer.
-  /// Else, read next chunk of data until kStopByte (or -ENODATA).
-  /// Both modes takes into account bytes already read in transaction.
-  template <bool kContiguous, const uint8_t kStopByte>
-  [[nodiscard]] std::pair<ssize_t, const void*> readInTxChunk() {
-    if (unlikely(!inTx())) {
-      return {-EINVAL, nullptr};
-    }
-    auto ret = findInBufferInTx<kContiguous, kStopByte>();
-    if (0 > ret) {
-      return {ret, nullptr};
-    }
-    // Single reader because we are in Tx, safe to read tail.
-    uint64_t tail = this->header_.readTail();
-    uint64_t start = (this->tx_size_ + tail) & this->header_.kDataModMask;
-    this->tx_size_ += ret;
-    // Now ret is the size of first contiguous chunk.
-    return {ret, &this->data_[start]};
-  }
-
-  [[nodiscard]] ssize_t cancelTx() noexcept {
-    if (unlikely(!inTx())) {
-      return -EINVAL;
-    }
-    this->tx_size_ = 0;
-    // <in_read_tx> flags that we are in a transaction,
-    // so enforce no stores pass it.
-    this->inTx_ = false;
-    this->header_.in_read_tx.clear(std::memory_order_release);
-    return 0;
-  }
-
-  /// Drop the contents of buffer and commits transaction.
-  [[nodiscard]] ssize_t dropInTx() noexcept {
-    if (unlikely(!inTx())) {
-      return -EINVAL;
-    }
-    this->tx_size_ = 0;
-    this->header_.drop();
-    this->inTx_ = false;
-    this->header_.in_read_tx.clear(std::memory_order_release);
-    return 0;
-  }
-
   //
   // High-level atomic operations.
   //
-
-  /// Drop all content of the buffer.
-  [[nodiscard]] ssize_t drop() noexcept {
-    auto ret = startTx();
-    if (0 > ret) {
-      return ret;
-    }
-    return dropInTx();
-  }
 
   /// Makes a copy to <buffer>, buffer must be of size <size> or larger.
   [[nodiscard]] ssize_t copy(const size_t size, void* buffer) noexcept {
@@ -352,245 +136,55 @@ class Consumer : public RingBufferWrapper<THeaderExtraData> {
     return static_cast<ssize_t>(size);
   }
 
-  /// Makes a copy to <t>.
-  template <class T>
-  [[nodiscard]] ssize_t copy(T& t) noexcept {
-    static_assert(std::is_trivially_copyable<T>::value, "!");
-    return copy(sizeof(T), &t);
-  }
-
-  /// Start transaction and get ptr to first element.
-  std::pair<ssize_t, const void*> startReadTx(size_t size) noexcept {
-    if (unlikely(size > this->header_.kDataPoolByteSize)) {
-      return {-EINVAL, nullptr};
-    }
-
-    {
-      auto ret = startTx();
-      if (0 > ret) {
-        return {ret, nullptr};
-      }
-    }
-
-    {
-      ssize_t ret;
-      const void* ptr;
-      std::tie(ret, ptr) = this->readInTx(size);
-      if (0 > ret) {
-        ssize_t r = cancelTx();
-        TP_DCHECK_EQ(r, 0);
-        TP_DCHECK(ptr == nullptr);
-      }
-      return {ret, ptr};
-    }
-  }
-
-  template <class T>
-  std::pair<ssize_t, const T*> startReadTx() noexcept {
-    static_assert(std::is_trivially_copyable<T>::value, "!");
-    ssize_t ret;
-    const void* ptr;
-    std::tie(ret, ptr) = this->startReadTx(sizeof(T));
-    return {ret, reinterpret_cast<const T*>(ptr)};
-  }
-
-  /// Read next size bytes.
-  /// Return nummber of bytes read and, if successfull an object
-  /// of type TRet with read data.
-  template <class TRet = std::string>
-  std::pair<ssize_t, optional<TRet>> read(size_t size) {
-    ssize_t ret;
-    const void* ptr;
-    std::tie(ret, ptr) = startReadTx(size);
-    if (0 > ret) {
-      return {ret, {}};
-    }
-    TP_DCHECK_GE(ret, 0);
-    auto length = static_cast<size_t>(ret);
-    TP_DCHECK(ptr != nullptr);
-    TRet obj_ret{reinterpret_cast<const char*>(ptr), length};
-    ret = this->commitTx();
-    TP_DCHECK_EQ(ret, 0);
-    return {length, obj_ret};
-  }
-
-  /// Read next chunk that has a size prefix of type TSize.
-  /// TRet must have a constructor that takes a pointer and a length.
-  /// Return nummber of bytes read and, if successfull an object
-  /// of type TRet with read data.
-  template <class TSize, class TRet = std::string>
-  std::pair<ssize_t, optional<TRet>> readSizedChunk() {
-    static_assert(std::is_integral<TSize>::value, "!");
-
-    {
-      auto ret = startTx();
-      if (0 > ret) {
-        return {ret, nullopt};
-      }
-    }
-
-    ssize_t ret;
-    const void* ptr;
-    std::tie(ret, ptr) = this->template readInTxWithSize<TSize>();
-    if (0 > ret) {
-      auto r = cancelTx();
-      TP_DCHECK_EQ(r, 0);
-      return {ret, nullopt};
-    }
-    TP_DCHECK(ptr != nullptr);
-    static_assert(
-        std::numeric_limits<TSize>::max() <=
-            std::numeric_limits<decltype(ret)>::max(),
-        "Selected TSize can encode larger than sizes than function return. "
-        "This may cause silent overflow");
-    TSize length = static_cast<TSize>(ret);
-
-    // Buuild string and complete transaction.
-    TRet obj_ret{reinterpret_cast<const char*>(ptr), length};
-    ret = this->commitTx();
-    TP_DCHECK_EQ(ret, 0);
-    return {sizeof(TSize) + length, obj_ret};
-  }
-
-  /// If kContiguous, read chunk of data until wrapping or end of buffer.
-  /// Both modes takes into account bytes already read in transaction.
-  template <bool kContiguous, const uint8_t kStopByte, class TRet = std::string>
-  std::pair<ssize_t, optional<TRet>> readChunk() {
-    {
-      auto ret = startTx();
-      if (0 > ret) {
-        return {ret, nullopt};
-      }
-    }
-
-    ssize_t ssize_ret;
-    const void* ptr;
-    std::tie(ssize_ret, ptr) =
-        this->template readInTxChunk<kContiguous, kStopByte>();
-    if (0 > ssize_ret) {
-      auto r = cancelTx();
-      TP_DCHECK_EQ(r, 0);
-      return {ssize_ret, nullopt};
-    }
-    auto length = static_cast<size_t>(ssize_ret);
-    TP_DCHECK(ptr != nullptr);
-    TRet obj_ret{reinterpret_cast<const char*>(ptr), length};
-    auto ret = this->commitTx();
-    TP_DCHECK_EQ(ret, 0);
-    return {ssize_ret, obj_ret};
-  }
-
  protected:
-  uint8_t* aux_buffer_ = nullptr;
-  size_t aux_buffer_size_ = 0;
   bool inTx_{false};
 
-  // Get a pointer to next contiguous <size> bytes in ringbuffer's data.
-  // May copy to auxiliar buffer if no contiguous.
-  const uint8_t* read_(const size_t size) noexcept {
-    if (size == 0) {
-      return nullptr;
-    }
-
-    const uint8_t* ptr;
-    uint8_t* resized;
-    std::tie(ptr, resized) =
-        readFromRingBuffer_<false, true>(size, aux_buffer_, aux_buffer_size_);
-    if (ptr == nullptr) {
-      return nullptr;
-    }
-    if (resized != nullptr) {
-      aux_buffer_ = resized;
-      aux_buffer_size_ = size;
-    }
-    return ptr;
-  }
-
-  /// If <kCanResizeCopyBuffer> is true, then <copy_buffer> will be resized
-  /// as needed.
-  ///
-  /// Returns a pair with ptr to data (or null if no data available), and ptr to
-  /// resized buffer iff resized (nullptr otherwise).
+  /// Returns a ptr to data (or null if no data available).
   /// If succeeds, increases <tx_size_> by size.
-  template <bool kAlwaysCopy, bool kCanResizeCopyBuffer>
-  std::pair<const uint8_t*, uint8_t*> readFromRingBuffer_(
+  const uint8_t* readFromRingBuffer_(
       const size_t size,
-      uint8_t* copy_buffer,
-      size_t buffer_size) noexcept {
+      uint8_t* copy_buffer) noexcept {
     // Caller must have taken care of this.
     TP_DCHECK_LE(size, this->header_.kDataPoolByteSize);
 
-    if (kAlwaysCopy) {
-      if (unlikely(copy_buffer == nullptr)) {
-        TP_LOG_ERROR() << "kAlwaysCopy requires non-null copy_buffer";
-        return {nullptr, nullptr};
-      }
-    }
-
-    if (!kCanResizeCopyBuffer) {
-      if (unlikely(buffer_size < size)) {
-        TP_LOG_ERROR() << "Copy buffer is too small and "
-                       << "kCanResizeCopyBuffer is set to false";
-        return {nullptr, nullptr};
-      }
-    }
-
     if (unlikely(0 >= size)) {
       TP_LOG_ERROR() << "Cannot copy value of zero size";
-      return {nullptr, nullptr};
+      return nullptr;
     }
 
     if (unlikely(size > this->header_.kDataPoolByteSize)) {
       TP_LOG_ERROR() << "reads larger than buffer are not supported";
-      return {nullptr, nullptr};
+      return nullptr;
     }
 
-    uint64_t head = this->header_.readHead();
+    const uint64_t head = this->header_.readHead();
     // Single reader because we are in Tx, safe to read tail.
-    uint64_t tail = this->header_.readTail();
+    const uint64_t tail = this->header_.readTail();
 
     TP_DCHECK_LE(head - tail, this->header_.kDataPoolByteSize);
 
     // Check if there is enough data.
     if (this->tx_size_ + size > head - tail) {
-      return {nullptr, nullptr};
+      return nullptr;
     }
 
     // start and end are head and tail in module arithmetic.
-    uint64_t start = (this->tx_size_ + tail) & this->header_.kDataModMask;
-    uint64_t end = (start + size) & this->header_.kDataModMask;
+    const uint64_t start = (this->tx_size_ + tail) & this->header_.kDataModMask;
+    const uint64_t end = (start + size) & this->header_.kDataModMask;
 
-    bool wrap = start >= end;
-    const bool needs_copy = kAlwaysCopy || wrap;
-    if (!needs_copy) {
-      this->tx_size_ += size;
-      // if no copy required, return pointer to data.
-      return {&this->data_[start], nullptr};
-    }
+    const bool wrap = start >= end;
 
-    bool needs_resize = buffer_size < size;
-    if (unlikely(needs_resize)) {
-      if (!kCanResizeCopyBuffer) {
-        TP_LOG_ERROR() << "resizing is needed but kCanResizeCopyBuffer"
-                       << " is set to false. Make buffer larger?";
-        return {nullptr, nullptr};
-      }
-      copy_buffer = static_cast<uint8_t*>(realloc(copy_buffer, size));
-      if (unlikely(copy_buffer == nullptr)) {
-        TP_LOG_ERROR() << "Bad alloc";
-        return {nullptr, nullptr};
-      }
-    }
+    this->tx_size_ += size;
 
     if (likely(!wrap)) {
       std::memcpy(copy_buffer, &this->data_[start], size);
     } else {
-      size_t size0 = this->header_.kDataPoolByteSize - start;
+      const size_t size0 = this->header_.kDataPoolByteSize - start;
       std::memcpy(copy_buffer, &this->data_[start], size0);
       std::memcpy(copy_buffer + size0, &this->data_[0], end);
     }
-    this->tx_size_ += size;
-    return {copy_buffer, needs_resize ? copy_buffer : nullptr};
+
+    return copy_buffer;
   }
 };
 

--- a/tensorpipe/util/ringbuffer/producer.h
+++ b/tensorpipe/util/ringbuffer/producer.h
@@ -53,58 +53,6 @@ class Producer : public RingBufferWrapper<THeaderExtraData> {
     return 0;
   }
 
-  [[nodiscard]] ssize_t writeInTx(size_t size, const void* data) noexcept {
-    if (unlikely(!inTx())) {
-      return -EINVAL;
-    }
-    return this->copyToRingBuffer_(static_cast<const uint8_t*>(data), size);
-  }
-
-  [[nodiscard]] ssize_t writeAtMostInTx(
-      size_t size,
-      const void* data) noexcept {
-    if (unlikely(!inTx())) {
-      return -EINVAL;
-    }
-
-    const auto space = this->header_.freeSizeWeak() - this->tx_size_;
-    if (space == 0) {
-      return -ENOSPC;
-    }
-    return this->writeInTx(std::min(size, space), data);
-  }
-
-  template <class T>
-  [[nodiscard]] ssize_t writeInTx(const T& d) noexcept {
-    return writeInTx(sizeof(T), &d);
-  }
-
-  template <class TSize>
-  [[nodiscard]] ssize_t writeInTxWithSize(
-      TSize length,
-      const void* data) noexcept {
-    static_assert(std::is_integral<TSize>::value, "!");
-
-    if (unlikely(!inTx())) {
-      return -EINVAL;
-    }
-
-    // Copy length.
-    auto plen = reinterpret_cast<const uint8_t*>(&length);
-    auto s = this->copyToRingBuffer_(plen, sizeof(TSize));
-    if (0 > s) {
-      return s;
-    }
-
-    // Copy data.
-    auto ptr = static_cast<const uint8_t*>(data);
-    auto sdata = this->copyToRingBuffer_(ptr, length);
-    if (0 > sdata) {
-      return sdata;
-    }
-    return s + sdata;
-  }
-
   [[nodiscard]] ssize_t commitTx() noexcept {
     if (unlikely(!inTx())) {
       return -EINVAL;
@@ -130,30 +78,7 @@ class Producer : public RingBufferWrapper<THeaderExtraData> {
     return 0;
   }
 
-  // Write a chunk with a size prefix of type TSize.
-  template <class TSize>
-  [[nodiscard]] ssize_t writeInTxSizedChunk(const std::string& str) noexcept {
-    static_assert(std::is_integral<TSize>::value, "!");
-    if (unlikely(!inTx())) {
-      return -EINVAL;
-    }
-    if (unlikely(str.size() > std::numeric_limits<TSize>::max())) {
-      return -EINVAL;
-    }
-    auto byte_size = static_cast<TSize>(str.size());
-    return this->writeInTxWithSize(byte_size, str.data());
-  }
-
-  //
-  // High-level atomic operations.
-  //
-  template <class T>
-  [[nodiscard]] ssize_t write(const T& t) noexcept {
-    static_assert(std::is_trivial<T>::value, "!");
-    static_assert(std::is_standard_layout<T>::value, "!");
-    return write(&t, sizeof(T));
-  }
-
+  // TODO: Pass size first.
   [[nodiscard]] ssize_t write(const void* d, size_t size) noexcept {
     {
       auto ret = startTx();
@@ -172,26 +97,30 @@ class Producer : public RingBufferWrapper<THeaderExtraData> {
     return static_cast<ssize_t>(size);
   }
 
-  // Write a chunk with a size prefix of type TSize.
-  template <class TSize>
-  [[nodiscard]] ssize_t writeSizedChunk(const std::string& str) noexcept {
-    {
-      auto ret = startTx();
-      if (0 > ret) {
-        return ret;
-      }
+  [[nodiscard]] ssize_t writeInTx(size_t size, const void* data) noexcept {
+    if (unlikely(!inTx())) {
+      return -EINVAL;
     }
-    auto s = this->writeInTxSizedChunk<TSize>(str);
-    if (0 > s) {
-      auto r = cancelTx();
-      TP_DCHECK_EQ(r, 0);
-      return s;
+    return this->copyToRingBuffer_(static_cast<const uint8_t*>(data), size);
+  }
+
+  [[nodiscard]] ssize_t writeAtMostInTx(
+      size_t size,
+      const void* data) noexcept {
+    if (unlikely(!inTx())) {
+      return -EINVAL;
     }
-    {
-      auto ret = commitTx();
-      TP_DCHECK_EQ(ret, 0);
+
+    const auto space = this->header_.freeSizeWeak() - this->tx_size_;
+    if (space == 0) {
+      return -ENOSPC;
     }
-    return s;
+    return this->writeInTx(std::min(size, space), data);
+  }
+
+  template <class T>
+  [[nodiscard]] ssize_t writeInTx(const T& d) noexcept {
+    return writeInTx(sizeof(T), &d);
   }
 
   [[nodiscard]] std::pair<ssize_t, void*> reserveContiguousInTx(

--- a/tensorpipe/util/ringbuffer/producer.h
+++ b/tensorpipe/util/ringbuffer/producer.h
@@ -19,14 +19,10 @@ namespace ringbuffer {
 ///
 /// Provides method to write into ringbuffer.
 ///
-template <class THeaderExtraData>
-class Producer : public RingBufferWrapper<THeaderExtraData> {
+class Producer : public RingBufferWrapper {
  public:
-  // Declare TExtraData in class namespace.
-  using TExtraData = THeaderExtraData;
-
   // Use base class constructor.
-  using RingBufferWrapper<THeaderExtraData>::RingBufferWrapper;
+  using RingBufferWrapper::RingBufferWrapper;
 
   Producer(const Producer&) = delete;
   Producer(Producer&&) = delete;

--- a/tensorpipe/util/ringbuffer/shm.cc
+++ b/tensorpipe/util/ringbuffer/shm.cc
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/util/ringbuffer/shm.h>
+
+namespace tensorpipe {
+namespace util {
+namespace ringbuffer {
+namespace shm {
+
+std::tuple<int, int, std::shared_ptr<RingBuffer>> create(
+    size_t min_rb_byte_size,
+    optional<tensorpipe::util::shm::PageType> data_page_type,
+    bool perm_write) {
+  std::shared_ptr<RingBufferHeader> header;
+  std::shared_ptr<tensorpipe::util::shm::Segment> header_segment;
+  std::tie(header, header_segment) =
+      tensorpipe::util::shm::Segment::create<RingBufferHeader>(
+          perm_write,
+          tensorpipe::util::shm::PageType::Default,
+          min_rb_byte_size);
+
+  std::shared_ptr<uint8_t> data;
+  std::shared_ptr<tensorpipe::util::shm::Segment> data_segment;
+  std::tie(data, data_segment) =
+      tensorpipe::util::shm::Segment::create<uint8_t[]>(
+          header->kDataPoolByteSize, perm_write, data_page_type);
+
+  // Note: cannot use implicit construction from initializer list on GCC 5.5:
+  // "converting to XYZ from initializer list would use explicit constructor".
+  return std::make_tuple(
+      header_segment->getFd(),
+      data_segment->getFd(),
+      std::make_shared<RingBuffer>(std::move(header), std::move(data)));
+}
+
+std::shared_ptr<RingBuffer> load(
+    int header_fd,
+    int data_fd,
+    optional<tensorpipe::util::shm::PageType> data_page_type,
+    bool perm_write) {
+  std::shared_ptr<RingBufferHeader> header;
+  std::shared_ptr<tensorpipe::util::shm::Segment> header_segment;
+  std::tie(header, header_segment) =
+      tensorpipe::util::shm::Segment::load<RingBufferHeader>(
+          header_fd, perm_write, tensorpipe::util::shm::PageType::Default);
+  constexpr auto kHeaderSize = sizeof(RingBufferHeader);
+  if (unlikely(kHeaderSize != header_segment->getSize())) {
+    TP_THROW_SYSTEM(EPERM) << "Header segment of unexpected size";
+  }
+
+  std::shared_ptr<uint8_t> data;
+  std::shared_ptr<tensorpipe::util::shm::Segment> data_segment;
+  std::tie(data, data_segment) =
+      tensorpipe::util::shm::Segment::load<uint8_t[]>(
+          data_fd, perm_write, data_page_type);
+  if (unlikely(header->kDataPoolByteSize != data_segment->getSize())) {
+    TP_THROW_SYSTEM(EPERM) << "Data segment of unexpected size";
+  }
+
+  return std::make_shared<RingBuffer>(std::move(header), std::move(data));
+}
+
+} // namespace shm
+} // namespace ringbuffer
+} // namespace util
+} // namespace tensorpipe


### PR DESCRIPTION
Summary: This also removes the need for template arguments and type aliases in a few places.

Reviewed By: lerks

Differential Revision: D20249335

