### PR TITLE
Avoid temp buffer on protobuf read

### DIFF
--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -41,6 +41,7 @@ set(TENSORPIPE_HEADERS
   ${CMAKE_CURRENT_SOURCE_DIR}/transport/listener.h
   ${CMAKE_CURRENT_SOURCE_DIR}/util/ringbuffer/consumer.h
   ${CMAKE_CURRENT_SOURCE_DIR}/util/ringbuffer/producer.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/util/ringbuffer/protobuf_streams.h
   ${CMAKE_CURRENT_SOURCE_DIR}/util/ringbuffer/ringbuffer.h
   ${CMAKE_CURRENT_SOURCE_DIR}/util/ringbuffer/shm.h
   ${CMAKE_CURRENT_SOURCE_DIR}/util/shm/segment.h

--- a/tensorpipe/test/util/ringbuffer/CMakeLists.txt
+++ b/tensorpipe/test/util/ringbuffer/CMakeLists.txt
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 add_tensorpipe_test(ringbuffer_test ringbuffer_test.cc)
+add_tensorpipe_test(protobuf_streams_test protobuf_streams_test.cc)
+target_link_libraries(protobuf_streams_test tensorpipe_proto)
 add_tensorpipe_test(shm_ringbuffer_test shm_ringbuffer_test.cc)
 # Needed to use socket.h to send fds across a UNIX domain socket.
 target_link_libraries(shm_ringbuffer_test tensorpipe_shm)

--- a/tensorpipe/test/util/ringbuffer/protobuf_streams_test.cc
+++ b/tensorpipe/test/util/ringbuffer/protobuf_streams_test.cc
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/proto/core.pb.h>
+#include <tensorpipe/util/ringbuffer/consumer.h>
+#include <tensorpipe/util/ringbuffer/producer.h>
+#include <tensorpipe/util/ringbuffer/protobuf_streams.h>
+#include <tensorpipe/util/ringbuffer/ringbuffer.h>
+
+#include <google/protobuf/util/message_differencer.h>
+#include <gtest/gtest.h>
+
+using namespace tensorpipe;
+using namespace tensorpipe::util::ringbuffer;
+
+namespace {
+
+std::shared_ptr<RingBuffer> makeRingBuffer(size_t size) {
+  auto header = std::make_shared<RingBufferHeader>(size);
+  // In C++20 use std::make_shared<uint8_t[]>(size)
+  auto data = std::shared_ptr<uint8_t>(
+      new uint8_t[header->kDataPoolByteSize], std::default_delete<uint8_t[]>());
+  return std::make_shared<RingBuffer>(std::move(header), std::move(data));
+}
+
+proto::Brochure getMessage() {
+  proto::Brochure message;
+  const std::map<std::string, std::string> ta_map = {{"foo", "bar"},
+                                                     {"foobar", "baz"}};
+
+  for (const auto& [k, v] : ta_map) {
+    proto::TransportAdvertisement ta;
+    ta.set_domain_descriptor(v);
+    (*message.mutable_transport_advertisement())[k] = ta;
+  }
+
+  const std::map<std::string, std::string> ca_map = {{"foo2", "bar2"},
+                                                     {"foobar2", "baz2"}};
+  for (const auto& [k, v] : ca_map) {
+    proto::ChannelAdvertisement ca;
+    ca.set_domain_descriptor(v);
+    (*message.mutable_channel_advertisement())[k] = ca;
+  }
+
+  return message;
+}
+
+void test_serialize_parse(
+    std::shared_ptr<RingBuffer> rb,
+    const proto::Brochure message) {
+  uint32_t len = message.ByteSize();
+  EXPECT_LE(len, rb->getHeader().kDataPoolByteSize)
+      << "Message larger than ring buffer.";
+  {
+    Producer p{rb};
+
+    ssize_t ret = p.startTx();
+    EXPECT_EQ(ret, 0);
+
+    ZeroCopyOutputStream os(&p, len);
+    ASSERT_TRUE(message.SerializeToZeroCopyStream(&os));
+
+    ret = p.commitTx();
+    EXPECT_EQ(ret, 0);
+
+    EXPECT_EQ(rb->getHeader().usedSizeWeak(), len);
+  }
+
+  proto::Brochure parsed_message;
+  {
+    Consumer c{rb};
+
+    ssize_t ret = c.startTx();
+    EXPECT_EQ(ret, 0);
+
+    ZeroCopyInputStream is(&c, len);
+    ASSERT_TRUE(parsed_message.ParseFromZeroCopyStream(&is));
+
+    ret = c.commitTx();
+    EXPECT_EQ(ret, 0);
+
+    EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
+  }
+
+  ASSERT_TRUE(google::protobuf::util::MessageDifferencer::Equals(
+      message, parsed_message));
+}
+
+} // namespace
+
+TEST(RingBuffer, NonWrappingZeroCopyStream) {
+  constexpr size_t kBufferSize = 2 * 1024 * 1024;
+  auto rb = makeRingBuffer(kBufferSize);
+
+  proto::Brochure message = getMessage();
+
+  test_serialize_parse(rb, message);
+}
+
+TEST(RingBuffer, WrappingZeroCopyStream) {
+  constexpr size_t kBufferSize = 2 * 1024 * 1024;
+  auto rb = makeRingBuffer(kBufferSize);
+
+  // Write and consume enough bytes to force the next write to wrap around.
+  {
+    Producer p{rb};
+    std::array<char, kBufferSize - 1> garbage;
+    EXPECT_EQ(p.write(garbage.data(), sizeof(garbage)), sizeof(garbage));
+  }
+  {
+    Consumer c{rb};
+    std::array<char, kBufferSize - 1> buf;
+    EXPECT_EQ(c.copy(sizeof(buf), buf.data()), sizeof(buf));
+  }
+
+  proto::Brochure message = getMessage();
+  test_serialize_parse(rb, message);
+}

--- a/tensorpipe/transport/connection.h
+++ b/tensorpipe/transport/connection.h
@@ -38,11 +38,17 @@ class Connection {
 
   // Read and parse protobuf message.
   //
-  // This function may not be overridden by a subclass.
+  // This function may be overridden by a subclass.
+  //
+  // For example, the shm transport may be able to bypass reading into a
+  // temporary buffer and instead instead read directly from its peer's
+  // ring buffer. This saves an allocation and a memory copy.
   //
   using read_proto_callback_fn = std::function<void(const Error& error)>;
 
-  void read(google::protobuf::MessageLite& message, read_proto_callback_fn fn);
+  virtual void read(
+      google::protobuf::MessageLite& message,
+      read_proto_callback_fn fn);
 
   // Serialize and write protobuf message.
   //

--- a/tensorpipe/util/ringbuffer/protobuf_streams.h
+++ b/tensorpipe/util/ringbuffer/protobuf_streams.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <tensorpipe/util/ringbuffer/consumer.h>
+#include <tensorpipe/util/ringbuffer/producer.h>
+
+#include <google/protobuf/io/zero_copy_stream.h>
+
+namespace tensorpipe {
+namespace util {
+namespace ringbuffer {
+
+class ZeroCopyInputStream : public google::protobuf::io::ZeroCopyInputStream {
+ public:
+  ZeroCopyInputStream(Consumer* buffer, size_t payloadSize)
+      : buffer_(buffer), payloadSize_(payloadSize) {}
+
+  bool Next(const void** data, int* size) override {
+    if (bytesCount_ == payloadSize_) {
+      return false;
+    }
+
+    std::tie(*size, *data) =
+        buffer_->readContiguousAtMostInTx(payloadSize_ - bytesCount_);
+    TP_THROW_SYSTEM_IF(*size < 0, -*size);
+
+    bytesCount_ += *size;
+
+    return true;
+  }
+
+  void BackUp(int /* unused */) override {
+    // This should never be called as we know the size upfront.
+    TP_THROW_ASSERT() << "BackUp() called from ZeroCopyInputStream";
+  }
+
+  bool Skip(int /* unused */) override {
+    // This should never be called as we know the size upfront.
+    TP_THROW_ASSERT() << "Skip() called from ZeroCopyInputStream";
+    return false;
+  }
+
+  int64_t ByteCount() const override {
+    return bytesCount_;
+  }
+
+ private:
+  Consumer* buffer_{nullptr};
+  const size_t payloadSize_{0};
+  int64_t bytesCount_{0};
+};
+
+class ZeroCopyOutputStream : public google::protobuf::io::ZeroCopyOutputStream {
+ public:
+  ZeroCopyOutputStream(Producer* buffer, size_t payloadSize)
+      : buffer_(buffer), payloadSize_(payloadSize) {}
+
+  bool Next(void** data, int* size) override {
+    std::tie(*size, *data) =
+        buffer_->reserveContiguousInTx(payloadSize_ - bytesCount_);
+    if (*size == -ENOSPC) {
+      return false;
+    }
+    TP_THROW_SYSTEM_IF(*size < 0, -*size);
+
+    bytesCount_ += *size;
+
+    return true;
+  }
+
+  void BackUp(int /* unused */) override {
+    // This should never be called as we know the size upfront.
+    TP_THROW_ASSERT() << "BackUp() called from ZeroCopyOutputStream";
+  }
+
+  int64_t ByteCount() const override {
+    return bytesCount_;
+  }
+
+ private:
+  Producer* buffer_{nullptr};
+  const size_t payloadSize_{0};
+  int64_t bytesCount_{0};
+};
+
+} // namespace ringbuffer
+} // namespace util
+} // namespace tensorpipe


### PR DESCRIPTION
Summary: Implement a fast path for reading protobufs from shm leveraging `ZeroCopyInputStream`.

Reviewed By: lw

Differential Revision: D20225074

