### PR TITLE
Fix shm read() race condition

### DIFF
--- a/tensorpipe/transport/shm/connection.h
+++ b/tensorpipe/transport/shm/connection.h
@@ -212,14 +212,14 @@ class Connection final : public transport::Connection,
   // Defer execution of processReadOperations to loop thread.
   void triggerProcessReadOperations();
 
-  // Process pending read operations if in an operational state.
-  void processReadOperationsFromReactor(std::unique_lock<std::mutex> lock);
+  // Process pending read operations if in an operational or error state.
+  void processReadOperationsFromReactor(std::unique_lock<std::mutex>& lock);
 
   // Defer execution of processWriteOperations to loop thread.
   void triggerProcessWriteOperations();
 
   // Process pending write operations if in an operational state.
-  void processWriteOperationsFromReactor(std::unique_lock<std::mutex> lock);
+  void processWriteOperationsFromReactor(std::unique_lock<std::mutex>& lock);
 
   // Set error object while holding mutex.
   void setErrorHoldingMutexFromReactor(Error&&);


### PR DESCRIPTION
Summary:
From first RPC integration run D20088366, tensorpipe throws assert error - P126775856. It's caused by SHM race condition on connection state_.

`read()` path could race when state_ is not ESTABLISHED yet. Could be triggered by
* peer's write()
* user's read()
* error_

Reviewed By: lw

Differential Revision: D20178466

