### PR TITLE
Make transport tests wait for protobuf generation before building

### DIFF
--- a/tensorpipe/test/channel/CMakeLists.txt
+++ b/tensorpipe/test/channel/CMakeLists.txt
@@ -12,6 +12,8 @@ target_include_directories(
   $<TARGET_PROPERTY:uv_a,INCLUDE_DIRECTORIES>
   $<TARGET_PROPERTY:gtest_main,INCLUDE_DIRECTORIES>
   )
+# Build this after having generated the .pb.h files needed by some tests.
+add_dependencies(tensorpipe_channel_test tensorpipe_proto)
 
 function(add_tensorpipe_channel_test)
   add_tensorpipe_test(${ARGV})

--- a/tensorpipe/test/transport/CMakeLists.txt
+++ b/tensorpipe/test/transport/CMakeLists.txt
@@ -17,6 +17,8 @@ target_include_directories(
   $<TARGET_PROPERTY:tensorpipe,INCLUDE_DIRECTORIES>
   $<TARGET_PROPERTY:gtest_main,INCLUDE_DIRECTORIES>
   )
+# Build this after having generated the .pb.h files needed by some tests.
+add_dependencies(tensorpipe_transport_test tensorpipe_proto)
 
 function(add_tensorpipe_transport_test)
   add_tensorpipe_test(${ARGV})


### PR DESCRIPTION
Tested by running make with a very high parallelism factor: before these changes it always gave the error, after them it worked.

Fixes #101.