### PR TITLE
Bundle the Python bindings in a single shared library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,10 +35,10 @@ class CMakeBuild(build_ext):
             f"-DCMAKE_BUILD_TYPE={build_type}",
             "-DCMAKE_C_COMPILER=clang-6.0",
             "-DCMAKE_CXX_COMPILER=clang++-6.0",
-            "-DBUILD_SHARED_LIBS=true",
+            "-DCMAKE_POSITION_INDEPENDENT_CODE=true",
             "-DBUILD_PYTHON_MODULE=true",
         ]
-        make_cmd = ["make"]
+        make_cmd = ["make", "-j", "pytensorpipe"]
 
         subprocess.check_call(cmake_cmd, cwd=self.build_temp)
         subprocess.check_call(make_cmd, cwd=self.build_temp)

--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -52,8 +52,6 @@ add_library(tensorpipe ${TENSORPIPE_SOURCES})
 target_include_directories(tensorpipe PUBLIC ${CMAKE_SOURCE_DIR})
 target_link_libraries(tensorpipe PUBLIC tensorpipe_proto)
 
-target_link_libraries(tensorpipe PUBLIC uv)
-
 add_subdirectory(channel/basic)
 add_subdirectory(transport/shm)
 add_subdirectory(transport/uv)

--- a/tensorpipe/python/CMakeLists.txt
+++ b/tensorpipe/python/CMakeLists.txt
@@ -8,7 +8,7 @@ set(PYBIND11_CPP_STANDARD -std=c++14)
 pybind11_add_module(pytensorpipe tensorpipe.cc)
 target_link_libraries(
   pytensorpipe
-  PUBLIC
+  PRIVATE
   tensorpipe
   tensorpipe_basic
   tensorpipe_uv

--- a/tensorpipe/test/channel/CMakeLists.txt
+++ b/tensorpipe/test/channel/CMakeLists.txt
@@ -9,6 +9,7 @@ target_include_directories(
   tensorpipe_channel_test
   PUBLIC
   $<TARGET_PROPERTY:tensorpipe,INCLUDE_DIRECTORIES>
+  $<TARGET_PROPERTY:uv_a,INCLUDE_DIRECTORIES>
   $<TARGET_PROPERTY:gtest_main,INCLUDE_DIRECTORIES>
   )
 

--- a/tensorpipe/transport/uv/CMakeLists.txt
+++ b/tensorpipe/transport/uv/CMakeLists.txt
@@ -5,4 +5,4 @@
 # LICENSE file in the root directory of this source tree.
 
 add_library(tensorpipe_uv connection.cc context.cc error.cc listener.cc loop.cc sockaddr.cc uv.cc)
-target_link_libraries(tensorpipe_uv tensorpipe uv)
+target_link_libraries(tensorpipe_uv tensorpipe uv_a)


### PR DESCRIPTION
Except libuv, as their CMakeLists.txt file enforces building it as a shared library.

Fixes #110.