### PR TITLE
Enable `make test` target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,9 @@ jobs:
             make
       - run:
           name: Test
-          command: make test
+          command: |
+            cd build
+            make test
   python:
     parameters:
       docker_image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,17 +46,7 @@ jobs:
             make
       - run:
           name: Test
-          command: |
-            build/tensorpipe/test/common/defs_test
-            build/tensorpipe/test/common/system_test
-            build/tensorpipe/test/util/shm/segment_test
-            build/tensorpipe/test/util/ringbuffer/ringbuffer_test
-            build/tensorpipe/test/util/ringbuffer/shm_ringbuffer_test
-            build/tensorpipe/test/proto/core_test
-            build/tensorpipe/test/transport/shm/transport_shm_test
-            build/tensorpipe/test/transport/uv/transport_uv_test
-            build/tensorpipe/test/channel/basic/channel_basic_test
-            build/tensorpipe/test/core/core_context_test
+          command: make test
   python:
     parameters:
       docker_image:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,14 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   endif()
 endif()
 
+# CTest must be included in the top level to enable `make test` target.
+include(CTest)
+
 # Make dependencies available (but don't build by default)
 add_subdirectory(third_party/backward-cpp EXCLUDE_FROM_ALL)
-add_subdirectory(third_party/googletest EXCLUDE_FROM_ALL)
+if(BUILD_TESTING)
+  add_subdirectory(third_party/googletest EXCLUDE_FROM_ALL)
+endif()
 add_subdirectory(third_party/libuv EXCLUDE_FROM_ALL)
 if(BUILD_PYTHON_MODULE)
   add_subdirectory(third_party/pybind11 EXCLUDE_FROM_ALL)

--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -62,6 +62,8 @@ if(BUILD_PYTHON_MODULE)
   add_subdirectory(python)
 endif()
 
-add_subdirectory(test)
-
 add_subdirectory(benchmark)
+
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()

--- a/tensorpipe/test/CMakeLists.txt
+++ b/tensorpipe/test/CMakeLists.txt
@@ -4,6 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Defines `gtest_discover_tests()`.
+include(GoogleTest)
+
 add_library(tensorpipe_test OBJECT test.cc)
 
 function(add_tensorpipe_test)
@@ -14,6 +17,7 @@ function(add_tensorpipe_test)
     tensorpipe
     gtest_main
     )
+  gtest_discover_tests(${ARGV0})
 endfunction()
 
 add_subdirectory(channel)


### PR DESCRIPTION
This PR enables the `make test` target through CTest, and introduces a `BUILD_TESTING` option that when set to `OFF` disables everything testing related.