### PR TITLE
Release lock before calling callbacks with error in SHM

### DIFF
--- a/tensorpipe/transport/shm/connection.h
+++ b/tensorpipe/transport/shm/connection.h
@@ -225,7 +225,7 @@ class Connection final : public transport::Connection,
   void setErrorHoldingMutexFromReactor(Error&&);
 
   // Fail with error while holding mutex.
-  void failHoldingMutexFromReactor(Error&&);
+  void failHoldingMutexFromReactor(Error&&, std::unique_lock<std::mutex>& lock);
 
   // Close connection.
   void close();


### PR DESCRIPTION
Summary: This fixes the lock inversion we were seeing in the TSAN tests.

Differential Revision: D20385329

