### PR TITLE
Handle empty buffer for transport

### DIFF
--- a/tensorpipe/transport/shm/connection.h
+++ b/tensorpipe/transport/shm/connection.h
@@ -166,6 +166,7 @@ class Connection final : public transport::Connection,
     size_t len_{0};
     size_t bytesRead_{0};
     read_callback_fn fn_;
+    const bool ptrProvided_;
   };
 
   // Writes happen only if the user supplied a memory pointer, the


### PR DESCRIPTION
Summary:
In RPC agent integration test, there are cases of one node sends empty payload, which mirrors to tensorpipe::message::data. We need to allow transports to handle empty buffers whose ptr is nullptr and len is 0.

uv is not updated to accommodate

Differential Revision: D20531580

