### PR TITLE
Fix cma queue capacity

### DIFF
--- a/tensorpipe/channel/cma/cma.cc
+++ b/tensorpipe/channel/cma/cma.cc
@@ -62,9 +62,12 @@ std::shared_ptr<CmaChannelFactory> CmaChannelFactory::create() {
   return factory;
 }
 
-CmaChannelFactory::CmaChannelFactory(ConstructorToken /* unused */)
+CmaChannelFactory::CmaChannelFactory(
+    ConstructorToken /* unused */,
+    int queueCapacity)
     : ChannelFactory(kChannelName),
-      domainDescriptor_(generateDomainDescriptor()) {}
+      domainDescriptor_(generateDomainDescriptor()),
+      requests_(queueCapacity) {}
 
 void CmaChannelFactory::init_() {
   std::unique_lock<std::mutex> lock(mutex_);

--- a/tensorpipe/channel/cma/cma.h
+++ b/tensorpipe/channel/cma/cma.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <limits>
 #include <list>
 #include <mutex>
 
@@ -32,7 +33,7 @@ class CmaChannelFactory
  public:
   static std::shared_ptr<CmaChannelFactory> create();
 
-  explicit CmaChannelFactory(ConstructorToken);
+  explicit CmaChannelFactory(ConstructorToken, int queueCapacity = INT_MAX);
 
   ~CmaChannelFactory() override;
 

--- a/tensorpipe/test/transport/connection_test.cc
+++ b/tensorpipe/test/transport/connection_test.cc
@@ -182,3 +182,78 @@ TEST_P(TransportTest, Connection_QueueWritesBeforeReads) {
         readCompletedFuture.wait();
       });
 }
+
+// TODO: Enable this test when uv transport could handle
+TEST_P(TransportTest, DISABLED_Connection_EmptyBuffer) {
+  constexpr size_t numBytes = 13;
+  std::array<char, numBytes> garbage;
+  std::promise<void> writeCompletedProm;
+  std::promise<void> readCompletedProm;
+  std::future<void> writeCompletedFuture = writeCompletedProm.get_future();
+  std::future<void> readCompletedFuture = readCompletedProm.get_future();
+  int ioNum = 100;
+
+  this->testConnection(
+      [&](std::shared_ptr<Connection> conn) {
+        std::atomic<int> n = ioNum;
+        for (int i = 0; i < ioNum; i++) {
+          if ((i & 1) == 0) {
+            // Empty buffer
+            this->doRead(
+                conn,
+                nullptr,
+                0,
+                [&, conn](const Error& error, const void* ptr, size_t len) {
+                  ASSERT_FALSE(error) << error.what();
+                  ASSERT_EQ(len, 0);
+                  ASSERT_EQ(ptr, nullptr);
+                  if (--n == 0) {
+                    readCompletedProm.set_value();
+                  }
+                });
+          } else {
+            // Garbage buffer
+            this->doRead(
+                conn,
+                [&, conn](
+                    const Error& error, const void* /* unused */, size_t len) {
+                  ASSERT_FALSE(error) << error.what();
+                  ASSERT_EQ(len, garbage.size());
+                  if (--n == 0) {
+                    readCompletedProm.set_value();
+                  }
+                });
+          }
+        }
+        writeCompletedFuture.wait();
+        readCompletedFuture.wait();
+      },
+      [&](std::shared_ptr<Connection> conn) {
+        std::atomic<int> n = ioNum;
+        for (int i = 0; i < ioNum; i++) {
+          if ((i & 1) == 0) {
+            // Empty buffer
+            this->doWrite(conn, nullptr, 0, [&, conn](const Error& error) {
+              ASSERT_FALSE(error) << error.what();
+              if (--n == 0) {
+                writeCompletedProm.set_value();
+              }
+            });
+          } else {
+            // Garbage buffer
+            this->doWrite(
+                conn,
+                garbage.data(),
+                garbage.size(),
+                [&, conn](const Error& error) {
+                  ASSERT_FALSE(error) << error.what();
+                  if (--n == 0) {
+                    writeCompletedProm.set_value();
+                  }
+                });
+          }
+        }
+        writeCompletedFuture.wait();
+        readCompletedFuture.wait();
+      });
+}

--- a/tensorpipe/transport/shm/connection.h
+++ b/tensorpipe/transport/shm/connection.h
@@ -166,6 +166,7 @@ class Connection final : public transport::Connection,
     size_t len_{0};
     size_t bytesRead_{0};
     read_callback_fn fn_;
+    const bool ptrProvided_;
   };
 
   // Writes happen only if the user supplied a memory pointer, the


### PR DESCRIPTION
Summary:
common/queue.h by default sets capacity to 1. In cma channel case, when we send more than 2 tensors, the 3rd `requestCopy_()::requests_.push()` blocks on queue capacity (1st got pop(), 2nd in queue) - in fact it blocks pipe thread calling channel::recv() with holding pipe lock. This could dead lock with below 1st `callback(Error::kSuccess);` who holds queue size to 1 and tries to acquire pipe lock.

https://our.intern.facebook.com/intern/diffusion/FBS/browse/master/fbcode/tensorpipe/channel/cma/cma.cc?commit=eb34653ec4ad923cc913802647c4f06d4f759a31&lines=200-220

https://our.intern.facebook.com/intern/diffusion/FBS/browse/master/fbcode/tensorpipe/common/queue.h?commit=84c07bf644aa5becf01a3da7714830e5aa18e8e2&lines=20-24

Reviewed By: lw

Differential Revision: D20554941

