### PR TITLE
Introduce config.h.

### DIFF
--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+configure_file(config.h.in config.h)
+
 set(TENSORPIPE_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/channel/channel.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/channel/error.cc

--- a/tensorpipe/channel/cma/CMakeLists.txt
+++ b/tensorpipe/channel/cma/CMakeLists.txt
@@ -6,4 +6,3 @@
 
 add_library(tensorpipe_cma cma.cc)
 target_link_libraries(tensorpipe_cma tensorpipe)
-target_compile_definitions(tensorpipe_cma INTERFACE TP_ENABLE_CMA)

--- a/tensorpipe/config.h.in
+++ b/tensorpipe/config.h.in
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// Transports
+#cmakedefine TP_ENABLE_SHM
+
+// Channels
+#cmakedefine TP_ENABLE_CMA

--- a/tensorpipe/tensorpipe.h
+++ b/tensorpipe/tensorpipe.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <tensorpipe/config.h>
+
 #include <tensorpipe/channel/basic/basic.h>
 #include <tensorpipe/channel/channel.h>
 #include <tensorpipe/channel/helpers.h>

--- a/tensorpipe/transport/shm/CMakeLists.txt
+++ b/tensorpipe/transport/shm/CMakeLists.txt
@@ -6,4 +6,3 @@
 
 add_library(tensorpipe_shm context.cc connection.cc fd.cc listener.cc loop.cc reactor.cc socket.cc)
 target_link_libraries(tensorpipe_shm tensorpipe)
-target_compile_definitions(tensorpipe_shm INTERFACE TP_ENABLE_SHM)


### PR DESCRIPTION
Introducing a header that centralizes the `#define`s for various optional parts (transports/channels), mapping directly from CMake options. 