### PR TITLE
Disable CMA channel on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ jobs:
               -DCMAKE_CXX_FLAGS="-Werror -Wno-deprecated-declarations" \
               -DCMAKE_C_COMPILER=<< parameters.c_compiler >> \
               -DCMAKE_CXX_COMPILER=<< parameters.cxx_compiler >> \
+              -DTP_ENABLE_CMA=OFF \
               << parameters.cmake_args >>
             make -j
       - run:


### PR DESCRIPTION
Summary: It appears the process_vm_readv syscall fails with EPERM. I'll investigate why that happens (maybe because the tests are run as root?), but for now let's just make the CI green again.

Differential Revision: D20599792

