### PR TITLE
Catch exception from shm connection start()

### DIFF
--- a/tensorpipe/transport/shm/connection.h
+++ b/tensorpipe/transport/shm/connection.h
@@ -36,6 +36,7 @@ class Connection final : public transport::Connection,
 
   enum State {
     INITIALIZING = 1,
+    INITIALIZING_ERROR,
     SEND_FDS,
     RECV_FDS,
     ESTABLISHED,


### PR DESCRIPTION
Summary:
util::ringbuffer::shm::create(kDefaultSize) could throw system exception and
cause connection destruction before initilization completes. If not catch the
exception on connection level, destruction will clean up unregistered
resources to cause unrelated errors.

Differential Revision: D20616906

