### PR TITLE
[TensorPipe] fix CI failure of assigning to std::atomic

### DIFF
--- a/tensorpipe/test/transport/connection_test.cc
+++ b/tensorpipe/test/transport/connection_test.cc
@@ -229,7 +229,7 @@ TEST_P(TransportTest, DISABLED_Connection_EmptyBuffer) {
         readCompletedFuture.wait();
       },
       [&](std::shared_ptr<Connection> conn) {
-        std::atomic<int> n = ioNum;
+        std::atomic<int> n(ioNum);
         for (int i = 0; i < ioNum; i++) {
           if ((i & 1) == 0) {
             // Empty buffer


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#137 [TensorPipe] fix CI failure of assigning to std::atomic**

Summary:
CI failed on std::atomic assigning. Changing to construction

Test Plan:
unit test

Reviewers:

Subscribers:

Tasks:

Tags: