### PR TITLE
Have the SHM reactor perform a clean shutdown

### DIFF
--- a/tensorpipe/common/callback.h
+++ b/tensorpipe/common/callback.h
@@ -13,6 +13,7 @@
 #include <memory>
 #include <mutex>
 #include <tuple>
+#include <unordered_map>
 
 #include <tensorpipe/common/defs.h>
 #include <tensorpipe/common/error.h>

--- a/tensorpipe/test/transport/shm/reactor_test.cc
+++ b/tensorpipe/test/transport/shm/reactor_test.cc
@@ -69,6 +69,9 @@ TEST(Reactor, Basic) {
         // Wait for other process to run trigger.
         ASSERT_EQ(queue.pop(), 1);
         ASSERT_EQ(queue.pop(), 2);
+
+        reactor->remove(token1);
+        reactor->remove(token2);
       },
       [](int fd) {
         Reactor::TToken token1;
@@ -114,4 +117,8 @@ TEST(Reactor, TokenReuse) {
   auto t6 = reactor->add([&] { queue.push(6); });
   ASSERT_EQ(t5, t2);
   ASSERT_EQ(t6, t3);
+
+  reactor->remove(t4);
+  reactor->remove(t5);
+  reactor->remove(t6);
 }

--- a/tensorpipe/transport/error.cc
+++ b/tensorpipe/transport/error.cc
@@ -38,5 +38,9 @@ std::string EOFError::what() const {
   return "eof";
 }
 
+std::string ConnectionClosedError::what() const {
+  return "connection closed";
+}
+
 } // namespace transport
 } // namespace tensorpipe

--- a/tensorpipe/transport/error.h
+++ b/tensorpipe/transport/error.h
@@ -58,5 +58,12 @@ class EOFError final : public BaseError {
   std::string what() const override;
 };
 
+class ConnectionClosedError final : public BaseError {
+ public:
+  ConnectionClosedError() {}
+
+  std::string what() const override;
+};
+
 } // namespace transport
 } // namespace tensorpipe

--- a/tensorpipe/transport/shm/connection.cc
+++ b/tensorpipe/transport/shm/connection.cc
@@ -824,6 +824,7 @@ void Connection::Impl::failFromLoop(Error&& error) {
 void Connection::Impl::closeFromLoop() {
   TP_DCHECK(loop_->inLoopThread());
 
+  failFromLoop(TP_CREATE_ERROR(ConnectionClosedError));
   if (inboxReactorToken_.has_value()) {
     reactor_->remove(inboxReactorToken_.value());
     inboxReactorToken_.reset();

--- a/tensorpipe/transport/shm/loop.h
+++ b/tensorpipe/transport/shm/loop.h
@@ -213,20 +213,6 @@ class Loop final : public std::enable_shared_from_this<Loop> {
   std::condition_variable epollCond_;
   std::vector<struct epoll_event> epollEvents_;
 
-  // Deferred functions.
-  //
-  // None of the callbacks are triggered inline. Doing so usually
-  // comes with the risk of trying to acquire the same lock twice, or
-  // some form of inversion. Instead, we run all callbacks from the
-  // reactor thread, either in response to some I/O event, or because
-  // we were asked to do so. The latter we call "deferred functions"
-  // because execution is deferred to a later point in time (and more
-  // importantly, with a clean stack).
-  //
-  Reactor::TToken deferredFunctionReactorToken_;
-  std::mutex deferredFunctionMutex_;
-  std::list<TDeferredFunction> deferredFunctionList_;
-
   // Wake up the event loop.
   void wakeup();
 
@@ -249,9 +235,6 @@ class Loop final : public std::enable_shared_from_this<Loop> {
   // Called by the reactor in response to epoll_wait(2) producing a
   // vector with epoll_event structs in `epollEvents_`.
   void handleEpollEventsFromLoop();
-
-  // Called by the reactor in response to a deferred function.
-  void handleDeferredFunctionFromLoop();
 
   friend class Connection;
   friend class Listener;


### PR DESCRIPTION
Summary:
Several things were amiss:
- The reactor could only be stopped by destructing it: there was no graceful close->join->destruct sequence.
- The SHM loop was the "owner" of the reactor but it wasn't forwarding the close and join calls appropriately. Combined with the previous point, it meant that if the last reference to the reactor was being held by a connection, it was the connection's destructor that joined the reactor, which lead to a self-join that crashed the program.
- The reactor thread would immediately exit as soon as the closed flag got set, even if some "users" still needed to run stuff on it. This left those users hanging: they deferred something but it never ran. Instead, we need to wait until all users deregistered (which is what we do in other loops). The token to defer functions to the reactor is special, because it is used to "wake up" the reactor. Therefore it won't be counted against the active users and for that to work it must be managed by the reactor itself (until now it was managed by the loop).

Differential Revision: D20815215

