### PR TITLE
Move some channel code around

### DIFF
--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 set(TENSORPIPE_SOURCES
-  ${CMAKE_CURRENT_SOURCE_DIR}/channel/channel.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/channel/context.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/channel/error.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/common/address.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/common/error.cc

--- a/tensorpipe/benchmark/benchmark_pipe.cc
+++ b/tensorpipe/benchmark/benchmark_pipe.cc
@@ -10,9 +10,9 @@
 
 #include <tensorpipe/benchmark/measurements.h>
 #include <tensorpipe/benchmark/options.h>
-#include <tensorpipe/channel/basic/basic.h>
+#include <tensorpipe/channel/basic/context.h>
 #ifdef TP_ENABLE_CMA
-#include <tensorpipe/channel/cma/cma.h>
+#include <tensorpipe/channel/cma/context.h>
 #endif // TP_ENABLE_CMA
 #include <tensorpipe/common/defs.h>
 #include <tensorpipe/core/context.h>
@@ -157,13 +157,13 @@ static void runServer(const Options& options) {
     TP_THROW_ASSERT() << "unknown transport: " << options.transport;
   }
   if (options.channel == "basic") {
-    context->registerChannelFactory(
-        0, "basic", std::make_shared<channel::basic::BasicChannelFactory>());
+    context->registerChannel(
+        0, "basic", std::make_shared<channel::basic::Context>());
   } else
 #ifdef TP_ENABLE_CMA
       if (options.channel == "cma") {
-    context->registerChannelFactory(
-        0, "cma", channel::cma::CmaChannelFactory::create());
+    context->registerChannel(
+        0, "cma", std::make_shared<channel::cma::Context>());
   } else
 #endif // TP_ENABLE_CMA
   {
@@ -288,13 +288,13 @@ static void runClient(const Options& options) {
     TP_THROW_ASSERT() << "unknown transport: " << options.transport;
   }
   if (options.channel == "basic") {
-    context->registerChannelFactory(
-        0, "basic", std::make_shared<channel::basic::BasicChannelFactory>());
+    context->registerChannel(
+        0, "basic", std::make_shared<channel::basic::Context>());
   } else
 #ifdef TP_ENABLE_CMA
       if (options.channel == "cma") {
-    context->registerChannelFactory(
-        0, "cma", channel::cma::CmaChannelFactory::create());
+    context->registerChannel(
+        0, "cma", std::make_shared<channel::cma::Context>());
   } else
 #endif // TP_ENABLE_CMA
   {

--- a/tensorpipe/channel/basic/CMakeLists.txt
+++ b/tensorpipe/channel/basic/CMakeLists.txt
@@ -4,5 +4,5 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-add_library(tensorpipe_basic basic.cc)
+add_library(tensorpipe_basic channel.cc context.cc)
 target_link_libraries(tensorpipe_basic tensorpipe)

--- a/tensorpipe/channel/basic/channel.cc
+++ b/tensorpipe/channel/basic/channel.cc
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <tensorpipe/channel/basic/basic.h>
+#include <tensorpipe/channel/basic/channel.h>
 
 #include <algorithm>
 
@@ -20,100 +20,38 @@ namespace tensorpipe {
 namespace channel {
 namespace basic {
 
-BasicChannelFactory::BasicChannelFactory()
-    : ChannelFactory("basic"), impl_(std::make_shared<Impl>()) {}
-
-BasicChannelFactory::Impl::Impl() : domainDescriptor_("any") {}
-
-ClosingEmitter& BasicChannelFactory::Impl::getClosingEmitter() {
-  return closingEmitter_;
-}
-
-const std::string& BasicChannelFactory::domainDescriptor() const {
-  return impl_->domainDescriptor();
-}
-
-const std::string& BasicChannelFactory::Impl::domainDescriptor() const {
-  return domainDescriptor_;
-}
-
-std::shared_ptr<Channel> BasicChannelFactory::createChannel(
-    std::shared_ptr<transport::Connection> connection,
-    Channel::Endpoint endpoint) {
-  return impl_->createChannel(std::move(connection), endpoint);
-}
-
-std::shared_ptr<Channel> BasicChannelFactory::Impl::createChannel(
-    std::shared_ptr<transport::Connection> connection,
-    Channel::Endpoint /* unused */) {
-  return std::make_shared<BasicChannel>(
-      BasicChannel::ConstructorToken(),
-      std::static_pointer_cast<PrivateIface>(shared_from_this()),
-      std::move(connection));
-}
-
-void BasicChannelFactory::close() {
-  impl_->close();
-}
-
-void BasicChannelFactory::Impl::close() {
-  bool wasClosed = false;
-  closed_.compare_exchange_strong(wasClosed, true);
-  if (!wasClosed) {
-    closingEmitter_.close();
-  }
-}
-
-void BasicChannelFactory::join() {
-  impl_->join();
-}
-
-void BasicChannelFactory::Impl::join() {
-  close();
-
-  bool wasJoined = false;
-  joined_.compare_exchange_strong(wasJoined, true);
-  if (!wasJoined) {
-    // Nothing to do?
-  }
-}
-
-BasicChannelFactory::~BasicChannelFactory() {
-  join();
-}
-
-BasicChannel::BasicChannel(
+Channel::Channel(
     ConstructorToken /* unused */,
-    std::shared_ptr<BasicChannelFactory::PrivateIface> factory,
+    std::shared_ptr<Context::PrivateIface> context,
     std::shared_ptr<transport::Connection> connection)
-    : impl_(Impl::create(std::move(factory), std::move(connection))) {}
+    : impl_(Impl::create(std::move(context), std::move(connection))) {}
 
-std::shared_ptr<BasicChannel::Impl> BasicChannel::Impl::create(
-    std::shared_ptr<BasicChannelFactory::PrivateIface> factory,
+std::shared_ptr<Channel::Impl> Channel::Impl::create(
+    std::shared_ptr<Context::PrivateIface> context,
     std::shared_ptr<transport::Connection> connection) {
   auto impl = std::make_shared<Impl>(
-      ConstructorToken(), std::move(factory), std::move(connection));
+      ConstructorToken(), std::move(context), std::move(connection));
   impl->init_();
   return impl;
 }
 
-BasicChannel::Impl::Impl(
+Channel::Impl::Impl(
     ConstructorToken /* unused */,
-    std::shared_ptr<BasicChannelFactory::PrivateIface> factory,
+    std::shared_ptr<Context::PrivateIface> context,
     std::shared_ptr<transport::Connection> connection)
-    : factory_(std::move(factory)),
+    : context_(std::move(context)),
       connection_(std::move(connection)),
-      closingReceiver_(factory_, factory_->getClosingEmitter()),
+      closingReceiver_(context_, context_->getClosingEmitter()),
       readCallbackWrapper_(*this),
       readProtoCallbackWrapper_(*this),
       writeCallbackWrapper_(*this),
       writeProtoCallbackWrapper_(*this) {}
 
-bool BasicChannel::Impl::inLoop_() {
+bool Channel::Impl::inLoop_() {
   return currentLoop_ == std::this_thread::get_id();
 }
 
-void BasicChannel::Impl::deferToLoop_(std::function<void()> fn) {
+void Channel::Impl::deferToLoop_(std::function<void()> fn) {
   {
     std::unique_lock<std::mutex> lock(mutex_);
     pendingTasks_.push_back(std::move(fn));
@@ -138,7 +76,7 @@ void BasicChannel::Impl::deferToLoop_(std::function<void()> fn) {
   }
 }
 
-void BasicChannel::send(
+void Channel::send(
     const void* ptr,
     size_t length,
     TDescriptorCallback descriptorCallback,
@@ -146,7 +84,7 @@ void BasicChannel::send(
   impl_->send(ptr, length, std::move(descriptorCallback), std::move(callback));
 }
 
-void BasicChannel::Impl::send(
+void Channel::Impl::send(
     const void* ptr,
     size_t length,
     TDescriptorCallback descriptorCallback,
@@ -162,7 +100,7 @@ void BasicChannel::Impl::send(
 }
 
 // Send memory region to peer.
-void BasicChannel::Impl::sendFromLoop_(
+void Channel::Impl::sendFromLoop_(
     const void* ptr,
     size_t length,
     TDescriptorCallback descriptorCallback,
@@ -179,7 +117,7 @@ void BasicChannel::Impl::sendFromLoop_(
 }
 
 // Receive memory region from peer.
-void BasicChannel::recv(
+void Channel::recv(
     TDescriptor descriptor,
     void* ptr,
     size_t length,
@@ -187,7 +125,7 @@ void BasicChannel::recv(
   impl_->recv(std::move(descriptor), ptr, length, std::move(callback));
 }
 
-void BasicChannel::Impl::recv(
+void Channel::Impl::recv(
     TDescriptor descriptor,
     void* ptr,
     size_t length,
@@ -201,7 +139,7 @@ void BasicChannel::Impl::recv(
   });
 }
 
-void BasicChannel::Impl::recvFromLoop_(
+void Channel::Impl::recvFromLoop_(
     TDescriptor descriptor,
     void* ptr,
     size_t length,
@@ -222,29 +160,29 @@ void BasicChannel::Impl::recvFromLoop_(
   return;
 }
 
-void BasicChannel::Impl::init_() {
+void Channel::Impl::init_() {
   deferToLoop_([this]() { initFromLoop_(); });
 }
 
-void BasicChannel::Impl::initFromLoop_() {
+void Channel::Impl::initFromLoop_() {
   TP_DCHECK(inLoop_());
   closingReceiver_.activate(*this);
   readPacket_();
 }
 
-void BasicChannel::close() {
+void Channel::close() {
   impl_->close();
 }
 
-BasicChannel::~BasicChannel() {
+Channel::~Channel() {
   close();
 }
 
-void BasicChannel::Impl::close() {
+void Channel::Impl::close() {
   deferToLoop_([this]() { closeFromLoop_(); });
 }
 
-void BasicChannel::Impl::closeFromLoop_() {
+void Channel::Impl::closeFromLoop_() {
   TP_DCHECK(inLoop_());
   if (!error_) {
     error_ = TP_CREATE_ERROR(ChannelClosedError);
@@ -252,7 +190,7 @@ void BasicChannel::Impl::closeFromLoop_() {
   }
 }
 
-void BasicChannel::Impl::readPacket_() {
+void Channel::Impl::readPacket_() {
   TP_DCHECK(inLoop_());
   auto packet = std::make_shared<proto::Packet>();
   connection_->read(*packet, readProtoCallbackWrapper_([packet](Impl& impl) {
@@ -260,7 +198,7 @@ void BasicChannel::Impl::readPacket_() {
   }));
 }
 
-void BasicChannel::Impl::onPacket_(const proto::Packet& packet) {
+void Channel::Impl::onPacket_(const proto::Packet& packet) {
   TP_DCHECK(inLoop_());
   if (packet.has_request()) {
     onRequest_(packet.request());
@@ -274,7 +212,7 @@ void BasicChannel::Impl::onPacket_(const proto::Packet& packet) {
   readPacket_();
 }
 
-void BasicChannel::Impl::onRequest_(const proto::Request& request) {
+void Channel::Impl::onRequest_(const proto::Request& request) {
   TP_DCHECK(inLoop_());
   // Find the send operation matching the request's operation ID.
   const auto id = request.operation_id();
@@ -302,7 +240,7 @@ void BasicChannel::Impl::onRequest_(const proto::Request& request) {
                      }));
 }
 
-void BasicChannel::Impl::onReply_(const proto::Reply& reply) {
+void Channel::Impl::onReply_(const proto::Reply& reply) {
   TP_DCHECK(inLoop_());
   // Find the recv operation matching the reply's operation ID.
   const auto id = reply.operation_id();
@@ -326,7 +264,7 @@ void BasicChannel::Impl::onReply_(const proto::Reply& reply) {
           }));
 }
 
-void BasicChannel::Impl::sendCompleted(const uint64_t id) {
+void Channel::Impl::sendCompleted(const uint64_t id) {
   TP_DCHECK(inLoop_());
   auto it = std::find_if(
       sendOperations_.begin(), sendOperations_.end(), [id](const auto& op) {
@@ -342,7 +280,7 @@ void BasicChannel::Impl::sendCompleted(const uint64_t id) {
   op.callback(error_);
 }
 
-void BasicChannel::Impl::recvCompleted(const uint64_t id) {
+void Channel::Impl::recvCompleted(const uint64_t id) {
   TP_DCHECK(inLoop_());
   auto it = std::find_if(
       recvOperations_.begin(), recvOperations_.end(), [id](const auto& op) {
@@ -358,7 +296,7 @@ void BasicChannel::Impl::recvCompleted(const uint64_t id) {
   op.callback(error_);
 }
 
-void BasicChannel::Impl::handleError_() {
+void Channel::Impl::handleError_() {
   TP_DCHECK(inLoop_());
   // Close the connection so that all current operations will be aborted. This
   // will cause their callbacks to be invoked, and only then we'll invoke ours.

--- a/tensorpipe/channel/basic/channel.h
+++ b/tensorpipe/channel/basic/channel.h
@@ -10,6 +10,7 @@
 
 #include <list>
 
+#include <tensorpipe/channel/basic/context.h>
 #include <tensorpipe/channel/channel.h>
 #include <tensorpipe/common/callback.h>
 #include <tensorpipe/common/error.h>
@@ -19,73 +20,15 @@ namespace tensorpipe {
 namespace channel {
 namespace basic {
 
-class BasicChannelFactory : public ChannelFactory {
- public:
-  explicit BasicChannelFactory();
-
-  const std::string& domainDescriptor() const override;
-
-  std::shared_ptr<Channel> createChannel(
-      std::shared_ptr<transport::Connection>,
-      Channel::Endpoint) override;
-
-  void close() override;
-
-  void join() override;
-
-  ~BasicChannelFactory() override;
-
- private:
-  class PrivateIface {
-   public:
-    virtual ClosingEmitter& getClosingEmitter() = 0;
-
-    virtual ~PrivateIface() = default;
-  };
-
-  class Impl : public PrivateIface, public std::enable_shared_from_this<Impl> {
-   public:
-    Impl();
-
-    const std::string& domainDescriptor() const;
-
-    std::shared_ptr<Channel> createChannel(
-        std::shared_ptr<transport::Connection>,
-        Channel::Endpoint);
-
-    ClosingEmitter& getClosingEmitter() override;
-
-    void close();
-
-    void join();
-
-    ~Impl() override = default;
-
-   private:
-    std::string domainDescriptor_;
-    std::atomic<bool> closed_{false};
-    std::atomic<bool> joined_{false};
-    ClosingEmitter closingEmitter_;
-  };
-
-  // The implementation is managed by a shared_ptr because each child object
-  // will also hold a shared_ptr to it (downcast as a shared_ptr to the private
-  // interface). However, its lifetime is tied to the one of this public object,
-  // since when the latter is destroyed the implementation is closed and joined.
-  std::shared_ptr<Impl> impl_;
-
-  friend class BasicChannel;
-};
-
-class BasicChannel : public Channel {
+class Channel : public channel::Channel {
   // Use the passkey idiom to allow make_shared to call what should be a private
   // constructor. See https://abseil.io/tips/134 for more information.
   struct ConstructorToken {};
 
  public:
-  BasicChannel(
+  Channel(
       ConstructorToken,
-      std::shared_ptr<BasicChannelFactory::PrivateIface> factory,
+      std::shared_ptr<Context::PrivateIface> context,
       std::shared_ptr<transport::Connection> connection);
 
   // Send memory region to peer.
@@ -104,7 +47,7 @@ class BasicChannel : public Channel {
 
   void close() override;
 
-  ~BasicChannel() override;
+  ~Channel() override;
 
  private:
   class Impl : public std::enable_shared_from_this<Impl> {
@@ -114,12 +57,12 @@ class BasicChannel : public Channel {
 
    public:
     static std::shared_ptr<Impl> create(
-        std::shared_ptr<BasicChannelFactory::PrivateIface>,
+        std::shared_ptr<Context::PrivateIface>,
         std::shared_ptr<transport::Connection>);
 
     Impl(
         ConstructorToken,
-        std::shared_ptr<BasicChannelFactory::PrivateIface>,
+        std::shared_ptr<Context::PrivateIface>,
         std::shared_ptr<transport::Connection>);
 
     void send(
@@ -161,7 +104,7 @@ class BasicChannel : public Channel {
 
     void closeFromLoop_();
 
-    // Called by factory class after construction.
+    // Called by context class after construction.
     void init_();
 
     // Arm connection to read next protobuf packet.
@@ -176,7 +119,7 @@ class BasicChannel : public Channel {
     // Called when protobuf packet is a reply.
     void onReply_(const proto::Reply& reply);
 
-    std::shared_ptr<BasicChannelFactory::PrivateIface> factory_;
+    std::shared_ptr<Context::PrivateIface> context_;
     std::shared_ptr<transport::Connection> connection_;
     Error error_{Error::kSuccess};
     ClosingReceiver closingReceiver_;
@@ -231,8 +174,8 @@ class BasicChannel : public Channel {
   // from the public object's one and perform the destruction asynchronously.
   std::shared_ptr<Impl> impl_;
 
-  // Allow factory class to call constructor.
-  friend class BasicChannelFactory;
+  // Allow context class to call constructor.
+  friend class Context;
 };
 
 } // namespace basic

--- a/tensorpipe/channel/basic/context.cc
+++ b/tensorpipe/channel/basic/context.cc
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/channel/basic/context.h>
+
+#include <algorithm>
+
+#include <tensorpipe/channel/basic/channel.h>
+#include <tensorpipe/channel/error.h>
+#include <tensorpipe/channel/helpers.h>
+#include <tensorpipe/common/callback.h>
+#include <tensorpipe/common/defs.h>
+#include <tensorpipe/common/error_macros.h>
+
+namespace tensorpipe {
+namespace channel {
+namespace basic {
+
+Context::Context()
+    : channel::Context("basic"), impl_(std::make_shared<Impl>()) {}
+
+Context::Impl::Impl() : domainDescriptor_("any") {}
+
+ClosingEmitter& Context::Impl::getClosingEmitter() {
+  return closingEmitter_;
+}
+
+const std::string& Context::domainDescriptor() const {
+  return impl_->domainDescriptor();
+}
+
+const std::string& Context::Impl::domainDescriptor() const {
+  return domainDescriptor_;
+}
+
+std::shared_ptr<channel::Channel> Context::createChannel(
+    std::shared_ptr<transport::Connection> connection,
+    Channel::Endpoint endpoint) {
+  return impl_->createChannel(std::move(connection), endpoint);
+}
+
+std::shared_ptr<channel::Channel> Context::Impl::createChannel(
+    std::shared_ptr<transport::Connection> connection,
+    Channel::Endpoint /* unused */) {
+  return std::make_shared<Channel>(
+      Channel::ConstructorToken(),
+      std::static_pointer_cast<PrivateIface>(shared_from_this()),
+      std::move(connection));
+}
+
+void Context::close() {
+  impl_->close();
+}
+
+void Context::Impl::close() {
+  bool wasClosed = false;
+  closed_.compare_exchange_strong(wasClosed, true);
+  if (!wasClosed) {
+    closingEmitter_.close();
+  }
+}
+
+void Context::join() {
+  impl_->join();
+}
+
+void Context::Impl::join() {
+  close();
+
+  bool wasJoined = false;
+  joined_.compare_exchange_strong(wasJoined, true);
+  if (!wasJoined) {
+    // Nothing to do?
+  }
+}
+
+Context::~Context() {
+  join();
+}
+
+} // namespace basic
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/basic/context.h
+++ b/tensorpipe/channel/basic/context.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <list>
+
+#include <tensorpipe/channel/context.h>
+#include <tensorpipe/common/callback.h>
+#include <tensorpipe/common/error.h>
+#include <tensorpipe/proto/channel/basic.pb.h>
+
+namespace tensorpipe {
+namespace channel {
+namespace basic {
+
+class Context : public channel::Context {
+ public:
+  explicit Context();
+
+  const std::string& domainDescriptor() const override;
+
+  std::shared_ptr<Channel> createChannel(
+      std::shared_ptr<transport::Connection>,
+      Channel::Endpoint) override;
+
+  void close() override;
+
+  void join() override;
+
+  ~Context() override;
+
+ private:
+  class PrivateIface {
+   public:
+    virtual ClosingEmitter& getClosingEmitter() = 0;
+
+    virtual ~PrivateIface() = default;
+  };
+
+  class Impl : public PrivateIface, public std::enable_shared_from_this<Impl> {
+   public:
+    Impl();
+
+    const std::string& domainDescriptor() const;
+
+    std::shared_ptr<Channel> createChannel(
+        std::shared_ptr<transport::Connection>,
+        Channel::Endpoint);
+
+    ClosingEmitter& getClosingEmitter() override;
+
+    void close();
+
+    void join();
+
+    ~Impl() override = default;
+
+   private:
+    std::string domainDescriptor_;
+    std::atomic<bool> closed_{false};
+    std::atomic<bool> joined_{false};
+    ClosingEmitter closingEmitter_;
+  };
+
+  // The implementation is managed by a shared_ptr because each child object
+  // will also hold a shared_ptr to it (downcast as a shared_ptr to the private
+  // interface). However, its lifetime is tied to the one of this public object,
+  // since when the latter is destroyed the implementation is closed and joined.
+  std::shared_ptr<Impl> impl_;
+
+  friend class Channel;
+};
+
+} // namespace basic
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/channel.h
+++ b/tensorpipe/channel/channel.h
@@ -22,7 +22,7 @@
 // Construction of a channel happens as follows.
 //
 //   1) During initialization of a pipe, the connecting peer sends its
-//      list of channel factories and their domain descriptors. The
+//      list of channel contexts and their domain descriptors. The
 //      domain descriptor is used to determine whether or not a
 //      channel can be used by a pair of peers.
 //   2) The listening side of the pipe compares the list it received
@@ -75,52 +75,6 @@ class Channel {
   virtual void close() = 0;
 
   virtual ~Channel() = default;
-};
-
-// Abstract base class for channel factory classes.
-//
-// Instances of these classes are expected to be registered with a
-// context. All registered instances are assumed to be eligible
-// channels for all pairs.
-//
-class ChannelFactory {
- public:
-  explicit ChannelFactory(std::string name);
-
-  // Return the factory's name.
-  const std::string& name() const;
-
-  // Return string to describe the domain for this channel.
-  //
-  // Two processes with a channel factory of the same type whose
-  // domain descriptors are identical can connect to each other.
-  //
-  virtual const std::string& domainDescriptor() const = 0;
-
-  // Return newly created channel using the specified connection.
-  //
-  // It is up to the channel to either use this connection for further
-  // initialization, or use it directly. Either way, the returned
-  // channel should be immediately usable. If the channel isn't fully
-  // initialized yet, take care to queue these operations to execute
-  // as soon as initialization has completed.
-  //
-  virtual std::shared_ptr<Channel> createChannel(
-      std::shared_ptr<transport::Connection>,
-      Channel::Endpoint) = 0;
-
-  // Put the channel factory in a terminal state, in turn closing all of its
-  // channels, and release its resources. This may be done asynchronously, in
-  // background.
-  virtual void close() = 0;
-
-  // Wait for all resources to be released and all background activity to stop.
-  virtual void join() = 0;
-
-  virtual ~ChannelFactory() = default;
-
- private:
-  std::string name_;
 };
 
 } // namespace channel

--- a/tensorpipe/channel/cma/CMakeLists.txt
+++ b/tensorpipe/channel/cma/CMakeLists.txt
@@ -4,6 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-add_library(tensorpipe_cma cma.cc)
+add_library(tensorpipe_cma channel.cc context.cc)
 target_link_libraries(tensorpipe_cma tensorpipe)
 target_compile_definitions(tensorpipe_cma INTERFACE TP_ENABLE_CMA)

--- a/tensorpipe/channel/cma/channel.cc
+++ b/tensorpipe/channel/cma/channel.cc
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <tensorpipe/channel/cma/cma.h>
+#include <tensorpipe/channel/cma/channel.h>
 
 #include <sys/types.h>
 #include <sys/uio.h>
@@ -26,195 +26,44 @@ namespace tensorpipe {
 namespace channel {
 namespace cma {
 
-namespace {
-
-const std::string kChannelName{"cma"};
-
-std::string generateDomainDescriptor() {
-  std::ostringstream oss;
-  auto bootID = getBootID();
-  TP_THROW_ASSERT_IF(!bootID) << "Unable to read boot_id";
-
-  // According to the man page of process_vm_readv and process_vm_writev,
-  // permission to read from or write to another process is governed by a ptrace
-  // access mode PTRACE_MODE_ATTACH_REALCREDS check. This consists in a series
-  // of checks, some governed by the CAP_SYS_PTRACE capability, others by the
-  // Linux Security Modules (LSMs), but the primary constraint is that the real,
-  // effective, and saved-set user IDs of the target match the caller's real
-  // user ID, and the same for group IDs. Since channels are bidirectional, we
-  // end up needing these IDs to all be the same on both processes.
-
-  // Combine boot ID, effective UID, and effective GID.
-  oss << kChannelName;
-  oss << ":" << bootID.value();
-  // FIXME As domain descriptors are just compared for equality, we only include
-  // the effective IDs, but we should abide by the rules above and make sure
-  // that they match the real and saved-set ones too.
-  oss << "/" << geteuid();
-  oss << "/" << getegid();
-  return oss.str();
-}
-
-} // namespace
-
-std::shared_ptr<CmaChannelFactory> CmaChannelFactory::create() {
-  return std::make_shared<CmaChannelFactory>(ConstructorToken());
-}
-
-std::shared_ptr<CmaChannelFactory::Impl> CmaChannelFactory::Impl::create() {
-  return std::make_shared<CmaChannelFactory::Impl>(ConstructorToken());
-}
-
-CmaChannelFactory::CmaChannelFactory(ConstructorToken /* unused */)
-    : ChannelFactory(kChannelName), impl_(Impl::create()) {}
-
-CmaChannelFactory::Impl::Impl(ConstructorToken /* unused */)
-    : domainDescriptor_(generateDomainDescriptor()), requests_(INT_MAX) {
-  thread_ = std::thread(&Impl::handleCopyRequests_, this);
-}
-
-void CmaChannelFactory::close() {
-  impl_->close();
-}
-
-void CmaChannelFactory::Impl::close() {
-  // FIXME Acquiring this lock causes a deadlock when calling join. The solution
-  // is avoiding locks by using the event loop approach just like in transports.
-  // std::unique_lock<std::mutex> lock(mutex_);
-
-  bool wasClosed = false;
-  closed_.compare_exchange_strong(wasClosed, true);
-  if (!wasClosed) {
-    closingEmitter_.close();
-    requests_.push(nullopt);
-  }
-}
-
-void CmaChannelFactory::join() {
-  impl_->join();
-}
-
-void CmaChannelFactory::Impl::join() {
-  std::unique_lock<std::mutex> lock(mutex_);
-
-  close();
-
-  bool wasJoined = false;
-  joined_.compare_exchange_strong(wasJoined, true);
-  if (!wasJoined) {
-    thread_.join();
-    // TP_DCHECK(requests_.empty());
-  }
-}
-
-CmaChannelFactory::~CmaChannelFactory() {
-  join();
-}
-
-ClosingEmitter& CmaChannelFactory::Impl::getClosingEmitter() {
-  return closingEmitter_;
-}
-
-const std::string& CmaChannelFactory::domainDescriptor() const {
-  return impl_->domainDescriptor();
-}
-
-const std::string& CmaChannelFactory::Impl::domainDescriptor() const {
-  std::unique_lock<std::mutex> lock(mutex_);
-  return domainDescriptor_;
-}
-
-std::shared_ptr<Channel> CmaChannelFactory::createChannel(
-    std::shared_ptr<transport::Connection> connection,
-    Channel::Endpoint endpoint) {
-  return impl_->createChannel(std::move(connection), endpoint);
-}
-
-std::shared_ptr<Channel> CmaChannelFactory::Impl::createChannel(
-    std::shared_ptr<transport::Connection> connection,
-    Channel::Endpoint /* unused */) {
-  TP_THROW_ASSERT_IF(joined_);
-  return std::make_shared<CmaChannel>(
-      CmaChannel::ConstructorToken(),
-      std::static_pointer_cast<PrivateIface>(shared_from_this()),
-      std::move(connection));
-}
-
-void CmaChannelFactory::Impl::requestCopy(
-    pid_t remotePid,
-    void* remotePtr,
-    void* localPtr,
-    size_t length,
-    std::function<void(const Error&)> fn) {
-  requests_.push(
-      CopyRequest{remotePid, remotePtr, localPtr, length, std::move(fn)});
-}
-
-void CmaChannelFactory::Impl::handleCopyRequests_() {
-  while (true) {
-    auto maybeRequest = requests_.pop();
-    if (!maybeRequest.has_value()) {
-      break;
-    }
-    CopyRequest request = std::move(maybeRequest).value();
-
-    // Perform copy.
-    struct iovec local {
-      .iov_base = request.localPtr, .iov_len = request.length
-    };
-    struct iovec remote {
-      .iov_base = request.remotePtr, .iov_len = request.length
-    };
-    auto nread =
-        ::process_vm_readv(request.remotePid, &local, 1, &remote, 1, 0);
-    if (nread == -1) {
-      request.callback(TP_CREATE_ERROR(SystemError, "cma", errno));
-    } else if (nread != request.length) {
-      request.callback(TP_CREATE_ERROR(ShortReadError, request.length, nread));
-    } else {
-      request.callback(Error::kSuccess);
-    }
-  }
-}
-
-CmaChannel::CmaChannel(
+Channel::Channel(
     ConstructorToken /* unused */,
-    std::shared_ptr<CmaChannelFactory::PrivateIface> factory,
+    std::shared_ptr<Context::PrivateIface> context,
     std::shared_ptr<transport::Connection> connection)
-    : impl_(Impl::create(std::move(factory), std::move(connection))) {}
+    : impl_(Impl::create(std::move(context), std::move(connection))) {}
 
-std::shared_ptr<CmaChannel::Impl> CmaChannel::Impl::create(
-    std::shared_ptr<CmaChannelFactory::PrivateIface> factory,
+std::shared_ptr<Channel::Impl> Channel::Impl::create(
+    std::shared_ptr<Context::PrivateIface> context,
     std::shared_ptr<transport::Connection> connection) {
   auto impl = std::make_shared<Impl>(
-      ConstructorToken(), std::move(factory), std::move(connection));
+      ConstructorToken(), std::move(context), std::move(connection));
   impl->init_();
   return impl;
 }
 
-CmaChannel::Impl::Impl(
+Channel::Impl::Impl(
     ConstructorToken /* unused */,
-    std::shared_ptr<CmaChannelFactory::PrivateIface> factory,
+    std::shared_ptr<Context::PrivateIface> context,
     std::shared_ptr<transport::Connection> connection)
-    : factory_(std::move(factory)),
+    : context_(std::move(context)),
       connection_(std::move(connection)),
-      closingReceiver_(factory_, factory_->getClosingEmitter()) {}
+      closingReceiver_(context_, context_->getClosingEmitter()) {}
 
-void CmaChannel::Impl::init_() {
+void Channel::Impl::init_() {
   deferToLoop_([this]() { initFromLoop_(); });
 }
 
-void CmaChannel::Impl::initFromLoop_() {
+void Channel::Impl::initFromLoop_() {
   TP_DCHECK(inLoop_());
   closingReceiver_.activate(*this);
   readPacket_();
 }
 
-bool CmaChannel::Impl::inLoop_() {
+bool Channel::Impl::inLoop_() {
   return currentLoop_ == std::this_thread::get_id();
 }
 
-void CmaChannel::Impl::deferToLoop_(std::function<void()> fn) {
+void Channel::Impl::deferToLoop_(std::function<void()> fn) {
   {
     std::unique_lock<std::mutex> lock(mutex_);
     pendingTasks_.push_back(std::move(fn));
@@ -239,7 +88,7 @@ void CmaChannel::Impl::deferToLoop_(std::function<void()> fn) {
   }
 }
 
-void CmaChannel::send(
+void Channel::send(
     const void* ptr,
     size_t length,
     TDescriptorCallback descriptorCallback,
@@ -247,7 +96,7 @@ void CmaChannel::send(
   impl_->send(ptr, length, std::move(descriptorCallback), std::move(callback));
 }
 
-void CmaChannel::Impl::send(
+void Channel::Impl::send(
     const void* ptr,
     size_t length,
     TDescriptorCallback descriptorCallback,
@@ -262,13 +111,13 @@ void CmaChannel::Impl::send(
   });
 }
 
-void CmaChannel::Impl::sendFromLoop_(
+void Channel::Impl::sendFromLoop_(
     const void* ptr,
     size_t length,
     TDescriptorCallback descriptorCallback,
     TSendCallback callback) {
   TP_DCHECK(inLoop_());
-  // TP_THROW_ASSERT_IF(factory_->joined_);
+  // TP_THROW_ASSERT_IF(context_->joined_);
   if (error_) {
     // FIXME Ideally here we should either call the callback with an error (but
     // this may deadlock if we do it inline) or return an error as an additional
@@ -287,7 +136,7 @@ void CmaChannel::Impl::sendFromLoop_(
 }
 
 // Receive memory region from peer.
-void CmaChannel::recv(
+void Channel::recv(
     TDescriptor descriptor,
     void* ptr,
     size_t length,
@@ -295,7 +144,7 @@ void CmaChannel::recv(
   impl_->recv(std::move(descriptor), ptr, length, std::move(callback));
 }
 
-void CmaChannel::Impl::recv(
+void Channel::Impl::recv(
     TDescriptor descriptor,
     void* ptr,
     size_t length,
@@ -309,7 +158,7 @@ void CmaChannel::Impl::recv(
   });
 }
 
-void CmaChannel::Impl::recvFromLoop_(
+void Channel::Impl::recvFromLoop_(
     TDescriptor descriptor,
     void* ptr,
     size_t length,
@@ -321,7 +170,7 @@ void CmaChannel::Impl::recvFromLoop_(
   pid_t remotePid = pbDescriptor.pid();
   void* remotePtr = reinterpret_cast<void*>(pbDescriptor.ptr());
 
-  factory_->requestCopy(
+  context_->requestCopy(
       remotePid,
       remotePtr,
       ptr,
@@ -340,19 +189,19 @@ void CmaChannel::Impl::recvFromLoop_(
       }));
 }
 
-void CmaChannel::close() {
+void Channel::close() {
   impl_->close();
 }
 
-CmaChannel::~CmaChannel() {
+Channel::~Channel() {
   close();
 }
 
-void CmaChannel::Impl::close() {
+void Channel::Impl::close() {
   deferToLoop_([this]() { closeFromLoop_(); });
 }
 
-void CmaChannel::Impl::closeFromLoop_() {
+void Channel::Impl::closeFromLoop_() {
   TP_DCHECK(inLoop_());
   if (!error_) {
     error_ = TP_CREATE_ERROR(ChannelClosedError);
@@ -360,7 +209,7 @@ void CmaChannel::Impl::closeFromLoop_() {
   }
 }
 
-void CmaChannel::Impl::readPacket_() {
+void Channel::Impl::readPacket_() {
   TP_DCHECK(inLoop_());
   auto pbPacketIn = std::make_shared<proto::Packet>();
   connection_->read(
@@ -369,7 +218,7 @@ void CmaChannel::Impl::readPacket_() {
       }));
 }
 
-void CmaChannel::Impl::onPacket_(const proto::Packet& pbPacketIn) {
+void Channel::Impl::onPacket_(const proto::Packet& pbPacketIn) {
   TP_DCHECK(inLoop_());
 
   TP_DCHECK_EQ(pbPacketIn.type_case(), proto::Packet::kNotification);
@@ -379,8 +228,7 @@ void CmaChannel::Impl::onPacket_(const proto::Packet& pbPacketIn) {
   readPacket_();
 }
 
-void CmaChannel::Impl::onNotification_(
-    const proto::Notification& pbNotification) {
+void Channel::Impl::onNotification_(const proto::Notification& pbNotification) {
   TP_DCHECK(inLoop_());
 
   // Find the send operation matching the notification's operation ID.
@@ -400,7 +248,7 @@ void CmaChannel::Impl::onNotification_(
   op.callback(Error::kSuccess);
 }
 
-void CmaChannel::Impl::handleError_() {
+void Channel::Impl::handleError_() {
   TP_DCHECK(inLoop_());
 
   // Move pending operations to stack.

--- a/tensorpipe/channel/cma/context.cc
+++ b/tensorpipe/channel/cma/context.cc
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/channel/cma/context.h>
+
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <limits>
+
+#include <tensorpipe/channel/cma/channel.h>
+#include <tensorpipe/channel/error.h>
+#include <tensorpipe/channel/helpers.h>
+#include <tensorpipe/common/callback.h>
+#include <tensorpipe/common/defs.h>
+#include <tensorpipe/common/error_macros.h>
+#include <tensorpipe/common/system.h>
+
+namespace tensorpipe {
+namespace channel {
+namespace cma {
+
+namespace {
+
+const std::string kChannelName{"cma"};
+
+std::string generateDomainDescriptor() {
+  std::ostringstream oss;
+  auto bootID = getBootID();
+  TP_THROW_ASSERT_IF(!bootID) << "Unable to read boot_id";
+
+  // According to the man page of process_vm_readv and process_vm_writev,
+  // permission to read from or write to another process is governed by a ptrace
+  // access mode PTRACE_MODE_ATTACH_REALCREDS check. This consists in a series
+  // of checks, some governed by the CAP_SYS_PTRACE capability, others by the
+  // Linux Security Modules (LSMs), but the primary constraint is that the real,
+  // effective, and saved-set user IDs of the target match the caller's real
+  // user ID, and the same for group IDs. Since channels are bidirectional, we
+  // end up needing these IDs to all be the same on both processes.
+
+  // Combine boot ID, effective UID, and effective GID.
+  oss << kChannelName;
+  oss << ":" << bootID.value();
+  // FIXME As domain descriptors are just compared for equality, we only include
+  // the effective IDs, but we should abide by the rules above and make sure
+  // that they match the real and saved-set ones too.
+  oss << "/" << geteuid();
+  oss << "/" << getegid();
+  return oss.str();
+}
+
+} // namespace
+
+Context::Context()
+    : channel::Context(kChannelName),
+      impl_(std::make_shared<Context::Impl>()) {}
+
+Context::Impl::Impl()
+    : domainDescriptor_(generateDomainDescriptor()), requests_(INT_MAX) {
+  thread_ = std::thread(&Impl::handleCopyRequests_, this);
+}
+
+void Context::close() {
+  impl_->close();
+}
+
+void Context::Impl::close() {
+  // FIXME Acquiring this lock causes a deadlock when calling join. The solution
+  // is avoiding locks by using the event loop approach just like in transports.
+  // std::unique_lock<std::mutex> lock(mutex_);
+
+  bool wasClosed = false;
+  closed_.compare_exchange_strong(wasClosed, true);
+  if (!wasClosed) {
+    closingEmitter_.close();
+    requests_.push(nullopt);
+  }
+}
+
+void Context::join() {
+  impl_->join();
+}
+
+void Context::Impl::join() {
+  std::unique_lock<std::mutex> lock(mutex_);
+
+  close();
+
+  bool wasJoined = false;
+  joined_.compare_exchange_strong(wasJoined, true);
+  if (!wasJoined) {
+    thread_.join();
+    // TP_DCHECK(requests_.empty());
+  }
+}
+
+Context::~Context() {
+  join();
+}
+
+ClosingEmitter& Context::Impl::getClosingEmitter() {
+  return closingEmitter_;
+}
+
+const std::string& Context::domainDescriptor() const {
+  return impl_->domainDescriptor();
+}
+
+const std::string& Context::Impl::domainDescriptor() const {
+  std::unique_lock<std::mutex> lock(mutex_);
+  return domainDescriptor_;
+}
+
+std::shared_ptr<channel::Channel> Context::createChannel(
+    std::shared_ptr<transport::Connection> connection,
+    Channel::Endpoint endpoint) {
+  return impl_->createChannel(std::move(connection), endpoint);
+}
+
+std::shared_ptr<channel::Channel> Context::Impl::createChannel(
+    std::shared_ptr<transport::Connection> connection,
+    Channel::Endpoint /* unused */) {
+  TP_THROW_ASSERT_IF(joined_);
+  return std::make_shared<Channel>(
+      Channel::ConstructorToken(),
+      std::static_pointer_cast<PrivateIface>(shared_from_this()),
+      std::move(connection));
+}
+
+void Context::Impl::requestCopy(
+    pid_t remotePid,
+    void* remotePtr,
+    void* localPtr,
+    size_t length,
+    std::function<void(const Error&)> fn) {
+  requests_.push(
+      CopyRequest{remotePid, remotePtr, localPtr, length, std::move(fn)});
+}
+
+void Context::Impl::handleCopyRequests_() {
+  while (true) {
+    auto maybeRequest = requests_.pop();
+    if (!maybeRequest.has_value()) {
+      break;
+    }
+    CopyRequest request = std::move(maybeRequest).value();
+
+    // Perform copy.
+    struct iovec local {
+      .iov_base = request.localPtr, .iov_len = request.length
+    };
+    struct iovec remote {
+      .iov_base = request.remotePtr, .iov_len = request.length
+    };
+    auto nread =
+        ::process_vm_readv(request.remotePid, &local, 1, &remote, 1, 0);
+    if (nread == -1) {
+      request.callback(TP_CREATE_ERROR(SystemError, "cma", errno));
+    } else if (nread != request.length) {
+      request.callback(TP_CREATE_ERROR(ShortReadError, request.length, nread));
+    } else {
+      request.callback(Error::kSuccess);
+    }
+  }
+}
+
+} // namespace cma
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/cma/context.h
+++ b/tensorpipe/channel/cma/context.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <limits>
+#include <list>
+#include <mutex>
+
+#include <tensorpipe/channel/context.h>
+#include <tensorpipe/common/callback.h>
+#include <tensorpipe/common/error.h>
+#include <tensorpipe/common/optional.h>
+#include <tensorpipe/common/queue.h>
+#include <tensorpipe/proto/channel/cma.pb.h>
+
+namespace tensorpipe {
+namespace channel {
+namespace cma {
+
+class Context : public channel::Context {
+ public:
+  Context();
+
+  const std::string& domainDescriptor() const override;
+
+  std::shared_ptr<Channel> createChannel(
+      std::shared_ptr<transport::Connection>,
+      Channel::Endpoint) override;
+
+  void close() override;
+
+  void join() override;
+
+  ~Context() override;
+
+ private:
+  class PrivateIface {
+   public:
+    virtual ClosingEmitter& getClosingEmitter() = 0;
+
+    using copy_request_callback_fn = std::function<void(const Error&)>;
+
+    virtual void requestCopy(
+        pid_t remotePid,
+        void* remotePtr,
+        void* localPtr,
+        size_t length,
+        copy_request_callback_fn fn) = 0;
+
+    virtual ~PrivateIface() = default;
+  };
+
+  class Impl : public PrivateIface, public std::enable_shared_from_this<Impl> {
+   public:
+    Impl();
+
+    const std::string& domainDescriptor() const;
+
+    std::shared_ptr<Channel> createChannel(
+        std::shared_ptr<transport::Connection>,
+        Channel::Endpoint);
+
+    ClosingEmitter& getClosingEmitter() override;
+
+    using copy_request_callback_fn = std::function<void(const Error&)>;
+
+    void requestCopy(
+        pid_t remotePid,
+        void* remotePtr,
+        void* localPtr,
+        size_t length,
+        copy_request_callback_fn fn) override;
+
+    void close();
+
+    void join();
+
+    ~Impl() override = default;
+
+   private:
+    struct CopyRequest {
+      pid_t remotePid;
+      void* remotePtr;
+      void* localPtr;
+      size_t length;
+      copy_request_callback_fn callback;
+    };
+
+    mutable std::mutex mutex_;
+    std::string domainDescriptor_;
+    std::thread thread_;
+    Queue<optional<CopyRequest>> requests_;
+    std::atomic<bool> closed_{false};
+    std::atomic<bool> joined_{false};
+    ClosingEmitter closingEmitter_;
+
+    void handleCopyRequests_();
+  };
+
+  // The implementation is managed by a shared_ptr because each child object
+  // will also hold a shared_ptr to it (downcast as a shared_ptr to the private
+  // interface). However, its lifetime is tied to the one of this public object,
+  // since when the latter is destroyed the implementation is closed and joined.
+  std::shared_ptr<Impl> impl_;
+
+  friend class Channel;
+};
+
+} // namespace cma
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/context.cc
+++ b/tensorpipe/channel/context.cc
@@ -6,14 +6,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <tensorpipe/channel/channel.h>
+#include <tensorpipe/channel/context.h>
 
 namespace tensorpipe {
 namespace channel {
 
-ChannelFactory::ChannelFactory(std::string name) : name_(std::move(name)) {}
+Context::Context(std::string name) : name_(std::move(name)) {}
 
-const std::string& ChannelFactory::name() const {
+const std::string& Context::name() const {
   return name_;
 }
 

--- a/tensorpipe/channel/context.h
+++ b/tensorpipe/channel/context.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <future>
+#include <memory>
+#include <vector>
+
+#include <tensorpipe/channel/channel.h>
+#include <tensorpipe/common/optional.h>
+#include <tensorpipe/transport/connection.h>
+
+namespace tensorpipe {
+namespace channel {
+
+// Abstract base class for channel context classes.
+//
+// Instances of these classes are expected to be registered with a
+// context. All registered instances are assumed to be eligible
+// channels for all pairs.
+//
+class Context {
+ public:
+  explicit Context(std::string name);
+
+  // Return the context's name.
+  const std::string& name() const;
+
+  // Return string to describe the domain for this channel.
+  //
+  // Two processes with a channel context of the same type whose
+  // domain descriptors are identical can connect to each other.
+  //
+  virtual const std::string& domainDescriptor() const = 0;
+
+  // Return newly created channel using the specified connection.
+  //
+  // It is up to the channel to either use this connection for further
+  // initialization, or use it directly. Either way, the returned
+  // channel should be immediately usable. If the channel isn't fully
+  // initialized yet, take care to queue these operations to execute
+  // as soon as initialization has completed.
+  //
+  virtual std::shared_ptr<Channel> createChannel(
+      std::shared_ptr<transport::Connection>,
+      Channel::Endpoint) = 0;
+
+  // Put the channel context in a terminal state, in turn closing all of its
+  // channels, and release its resources. This may be done asynchronously, in
+  // background.
+  virtual void close() = 0;
+
+  // Wait for all resources to be released and all background activity to stop.
+  virtual void join() = 0;
+
+  virtual ~Context() = default;
+
+ private:
+  std::string name_;
+};
+
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/common/callback.h
+++ b/tensorpipe/common/callback.h
@@ -358,8 +358,8 @@ class DeferringTolerantCallbackWrapper {
 };
 
 // This class is designed to be installed on objects that, when closed, should
-// in turn cause other objects to be closed too. This is the case for contexts
-// and factories, which close pipes, connections, listeners and channels.
+// in turn cause other objects to be closed too. This is the case for contexts,
+// which close pipes, connections, listeners and channels.
 // This class goes hand in hand with the one following it.
 class ClosingEmitter {
  public:
@@ -390,11 +390,11 @@ class ClosingEmitter {
 
 // This class is designed to be installed on objects that need to become closed
 // when another object is closed. This is the case for pipes, connections,
-// listeners and channels when contexts and factories get closed.
+// listeners and channels when contexts get closed.
 // This class goes hand in hand with the previous one.
 class ClosingReceiver {
  public:
-  // T will be the context or the channel factory.
+  // T will be the context.
   template <typename T>
   ClosingReceiver(const std::shared_ptr<T>& object, ClosingEmitter& emitter)
       : emitter_(std::shared_ptr<ClosingEmitter>(object, &emitter)) {}

--- a/tensorpipe/core/context.h
+++ b/tensorpipe/core/context.h
@@ -14,7 +14,7 @@
 #include <tuple>
 #include <vector>
 
-#include <tensorpipe/channel/channel.h>
+#include <tensorpipe/channel/context.h>
 #include <tensorpipe/common/callback.h>
 #include <tensorpipe/transport/context.h>
 
@@ -38,10 +38,7 @@ class Context final : public std::enable_shared_from_this<Context> {
       std::string,
       std::shared_ptr<transport::Context>);
 
-  void registerChannelFactory(
-      int64_t,
-      std::string,
-      std::shared_ptr<channel::ChannelFactory>);
+  void registerChannel(int64_t, std::string, std::shared_ptr<channel::Context>);
 
   std::shared_ptr<Listener> listen(const std::vector<std::string>&);
 
@@ -62,23 +59,23 @@ class Context final : public std::enable_shared_from_this<Context> {
    public:
     virtual ClosingEmitter& getClosingEmitter() = 0;
 
-    virtual std::shared_ptr<transport::Context> getContextForTransport(
+    virtual std::shared_ptr<transport::Context> getTransport(
         const std::string&) = 0;
 
-    virtual std::shared_ptr<channel::ChannelFactory> getChannelFactory(
+    virtual std::shared_ptr<channel::Context> getChannel(
         const std::string&) = 0;
 
-    using TOrderedContexts = std::map<
+    using TOrderedTransports = std::map<
         int64_t,
         std::tuple<std::string, std::shared_ptr<transport::Context>>>;
 
-    virtual const TOrderedContexts& getOrderedContexts() = 0;
+    virtual const TOrderedTransports& getOrderedTransports() = 0;
 
-    using TOrderedChannelFactories = std::map<
+    using TOrderedChannels = std::map<
         int64_t,
-        std::tuple<std::string, std::shared_ptr<channel::ChannelFactory>>>;
+        std::tuple<std::string, std::shared_ptr<channel::Context>>>;
 
-    virtual const TOrderedChannelFactories& getOrderedChannelFactories() = 0;
+    virtual const TOrderedChannels& getOrderedChannels() = 0;
 
     virtual ~PrivateIface() = default;
   };

--- a/tensorpipe/core/listener.cc
+++ b/tensorpipe/core/listener.cc
@@ -193,7 +193,7 @@ Listener::Impl::Impl(
     std::string address;
     std::tie(transport, address) = splitSchemeOfURL(url);
     std::shared_ptr<transport::Context> context =
-        context_->getContextForTransport(transport);
+        context_->getTransport(transport);
     std::shared_ptr<transport::Listener> listener = context->listen(address);
     addresses_.emplace(transport, listener->addr());
     listeners_.emplace(transport, std::move(listener));

--- a/tensorpipe/python/tensorpipe.cc
+++ b/tensorpipe/python/tensorpipe.cc
@@ -14,9 +14,9 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#include <tensorpipe/channel/basic/basic.h>
+#include <tensorpipe/channel/basic/context.h>
 #ifdef TP_ENABLE_CMA
-#include <tensorpipe/channel/cma/cma.h>
+#include <tensorpipe/channel/cma/context.h>
 #endif // TP_ENABLE_CMA
 #include <tensorpipe/common/defs.h>
 #include <tensorpipe/common/optional.h>
@@ -200,8 +200,8 @@ using transport_class_ =
     py::class_<T, tensorpipe::transport::Context, std::shared_ptr<T>>;
 
 template <typename T>
-using channel_factory_class_ =
-    py::class_<T, tensorpipe::channel::ChannelFactory, std::shared_ptr<T>>;
+using channel_class_ =
+    py::class_<T, tensorpipe::channel::Context, std::shared_ptr<T>>;
 
 } // namespace
 
@@ -386,7 +386,7 @@ PYBIND11_MODULE(pytensorpipe, module) {
 
   // Transports and channels
 
-  shared_ptr_class_<tensorpipe::transport::Context> AbstractTransport(
+  shared_ptr_class_<tensorpipe::transport::Context> abstractTransport(
       module, "AbstractTransport");
 
   transport_class_<tensorpipe::transport::uv::Context> uvTransport(
@@ -406,23 +406,22 @@ PYBIND11_MODULE(pytensorpipe, module) {
       py::arg("name"),
       py::arg("transport"));
 
-  shared_ptr_class_<tensorpipe::channel::ChannelFactory> AbstractChannel(
+  shared_ptr_class_<tensorpipe::channel::Context> abstractChannel(
       module, "AbstractChannel");
 
-  channel_factory_class_<tensorpipe::channel::basic::BasicChannelFactory>
-      basicChannel(module, "BasicChannel");
+  channel_class_<tensorpipe::channel::basic::Context> basicChannel(
+      module, "BasicChannel");
   basicChannel.def(py::init<>());
 
 #ifdef TP_ENABLE_CMA
-  channel_factory_class_<tensorpipe::channel::cma::CmaChannelFactory>
-      processVmReadvChannel(module, "CmaChannel");
-  processVmReadvChannel.def(
-      py::init(&tensorpipe::channel::cma::CmaChannelFactory::create));
+  channel_class_<tensorpipe::channel::cma::Context> cmaChannel(
+      module, "CmaChannel");
+  cmaChannel.def(py::init<>());
 #endif // TP_ENABLE_CMA
 
   context.def(
       "register_channel",
-      &tensorpipe::Context::registerChannelFactory,
+      &tensorpipe::Context::registerChannel,
       py::arg("priority"),
       py::arg("name"),
       py::arg("channel"));

--- a/tensorpipe/tensorpipe.h
+++ b/tensorpipe/tensorpipe.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <tensorpipe/channel/basic/basic.h>
+#include <tensorpipe/channel/basic/context.h>
 #include <tensorpipe/channel/channel.h>
 #include <tensorpipe/channel/helpers.h>
 #include <tensorpipe/common/address.h>
@@ -36,5 +36,5 @@
 #endif // TP_ENABLE_SHM
 
 #ifdef TP_ENABLE_CMA
-#include <tensorpipe/channel/cma/cma.h>
+#include <tensorpipe/channel/cma/context.h>
 #endif // TP_ENABLE_CMA

--- a/tensorpipe/test/channel/basic/basic_test.h
+++ b/tensorpipe/test/channel/basic/basic_test.h
@@ -8,13 +8,13 @@
 
 #pragma once
 
-#include <tensorpipe/channel/basic/basic.h>
+#include <tensorpipe/channel/basic/context.h>
 #include <tensorpipe/test/channel/channel_test.h>
 
 class BasicChannelTestHelper : public ChannelTestHelper {
  public:
-  std::shared_ptr<tensorpipe::channel::ChannelFactory> makeFactory() override {
-    return std::make_shared<tensorpipe::channel::basic::BasicChannelFactory>();
+  std::shared_ptr<tensorpipe::channel::Context> makeContext() override {
+    return std::make_shared<tensorpipe::channel::basic::Context>();
   }
 
   std::string getName() override {

--- a/tensorpipe/test/channel/channel_test.h
+++ b/tensorpipe/test/channel/channel_test.h
@@ -12,7 +12,7 @@
 #include <memory>
 #include <thread>
 
-#include <tensorpipe/channel/channel.h>
+#include <tensorpipe/channel/context.h>
 #include <tensorpipe/common/queue.h>
 #include <tensorpipe/transport/uv/context.h>
 
@@ -20,7 +20,7 @@
 
 class ChannelTestHelper {
  public:
-  virtual std::shared_ptr<tensorpipe::channel::ChannelFactory> makeFactory() = 0;
+  virtual std::shared_ptr<tensorpipe::channel::Context> makeContext() = 0;
   virtual std::string getName() = 0;
   virtual ~ChannelTestHelper() = default;
 };

--- a/tensorpipe/test/channel/cma/cma_test.h
+++ b/tensorpipe/test/channel/cma/cma_test.h
@@ -8,13 +8,13 @@
 
 #pragma once
 
-#include <tensorpipe/channel/cma/cma.h>
+#include <tensorpipe/channel/cma/context.h>
 #include <tensorpipe/test/channel/channel_test.h>
 
 class CmaChannelTestHelper : public ChannelTestHelper {
  public:
-  std::shared_ptr<tensorpipe::channel::ChannelFactory> makeFactory() override {
-    return tensorpipe::channel::cma::CmaChannelFactory::create();
+  std::shared_ptr<tensorpipe::channel::Context> makeContext() override {
+    return std::make_shared<tensorpipe::channel::cma::Context>();
   }
 
   std::string getName() override {

--- a/tensorpipe/test/core/context_test.cc
+++ b/tensorpipe/test/core/context_test.cc
@@ -130,11 +130,11 @@ TEST(Context, ClientPingSerial) {
   context->registerTransport(
       -1, "shm", std::make_shared<transport::shm::Context>());
 #endif // TP_ENABLE_SHM
-  context->registerChannelFactory(
-      0, "basic", std::make_shared<channel::basic::BasicChannelFactory>());
+  context->registerChannel(
+      0, "basic", std::make_shared<channel::basic::Context>());
 #ifdef TP_ENABLE_CMA
-  context->registerChannelFactory(
-      -1, "cma", channel::cma::CmaChannelFactory::create());
+  context->registerChannel(
+      -1, "cma", std::make_shared<channel::cma::Context>());
 #endif // TP_ENABLE_CMA
 
   auto listener = context->listen(genUrls());
@@ -213,11 +213,11 @@ TEST(Context, ClientPingInline) {
   context->registerTransport(
       -1, "shm", std::make_shared<transport::shm::Context>());
 #endif // TP_ENABLE_SHM
-  context->registerChannelFactory(
-      0, "basic", std::make_shared<channel::basic::BasicChannelFactory>());
+  context->registerChannel(
+      0, "basic", std::make_shared<channel::basic::Context>());
 #ifdef TP_ENABLE_CMA
-  context->registerChannelFactory(
-      -1, "cma", channel::cma::CmaChannelFactory::create());
+  context->registerChannel(
+      -1, "cma", std::make_shared<channel::cma::Context>());
 #endif // TP_ENABLE_CMA
 
   auto listener = context->listen(genUrls());
@@ -293,11 +293,11 @@ TEST(Context, ServerPingPongTwice) {
   context->registerTransport(
       -1, "shm", std::make_shared<transport::shm::Context>());
 #endif // TP_ENABLE_SHM
-  context->registerChannelFactory(
-      0, "basic", std::make_shared<channel::basic::BasicChannelFactory>());
+  context->registerChannel(
+      0, "basic", std::make_shared<channel::basic::Context>());
 #ifdef TP_ENABLE_CMA
-  context->registerChannelFactory(
-      -1, "cma", channel::cma::CmaChannelFactory::create());
+  context->registerChannel(
+      -1, "cma", std::make_shared<channel::cma::Context>());
 #endif // TP_ENABLE_CMA
 
   auto listener = context->listen(genUrls());
@@ -460,11 +460,11 @@ TEST(Context, MixedTensorMessage) {
   context->registerTransport(
       -1, "shm", std::make_shared<transport::shm::Context>());
 #endif // TP_ENABLE_SHM
-  context->registerChannelFactory(
-      0, "basic", std::make_shared<channel::basic::BasicChannelFactory>());
+  context->registerChannel(
+      0, "basic", std::make_shared<channel::basic::Context>());
 #ifdef TP_ENABLE_CMA
-  context->registerChannelFactory(
-      -1, "cma", channel::cma::CmaChannelFactory::create());
+  context->registerChannel(
+      -1, "cma", std::make_shared<channel::cma::Context>());
 #endif // TP_ENABLE_CMA
 
   auto listener = context->listen(genUrls());


### PR DESCRIPTION
Summary:
This is a big diff, but it *has no functional changes*!

What it does is:
- Rename channel factories to contexts, because we've realized that they will not just create channels, they will also manage threads and own resources. We've been using context to denote this type of objects.
- Put channels and contexts in separate files, like we do everywhere else.
- Rename channel::cma::CmaChannel to just channel::cma::Channel. There's no need to use both namespaces and prefixes to avoid conflicts, and elsewhere we've used namespace, so let's do the same here.
- Avoid using a factory method for the Cma context, as it's equivalent to a plain make_shared.
- Because of the above, rename a bunch of members and variables in the core context and pipe. Namely, channelFactory -> channel and context -> transport (because now context can refer to both transports and channels).

Differential Revision: D20891181

