### PR TITLE
Remove sccache configuration in CMakeLists.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,18 +19,6 @@ endif()
 option(TP_ENABLE_SHM "Enable shm transport" ${LINUX})
 option(TP_ENABLE_CMA "Enable cma channel" ${LINUX})
 
-# Use CMAKE_<LANG>_COMPILER_LAUNCHER if available.
-find_program(SCCACHE_EXECUTABLE sccache)
-mark_as_advanced(SCCACHE_EXECUTABLE)
-if(SCCACHE_EXECUTABLE)
-  foreach(LANG CXX C)
-    if(NOT DEFINED CMAKE_${LANG}_COMPILER_LAUNCHER AND NOT CMAKE_${LANG}_COMPILER MATCHES ".*/s?ccache$")
-      message(STATUS "Enabling sccache for ${LANG}")
-      set(CMAKE_${LANG}_COMPILER_LAUNCHER ${SCCACHE_EXECUTABLE} CACHE STRING "")
-    endif()
-  endforeach()
-endif()
-
 # Define sanitizer option, if specified.
 if(SANITIZE)
   add_definitions("-fsanitize=${SANITIZE}")

--- a/docs/development.md
+++ b/docs/development.md
@@ -64,34 +64,6 @@ Useful TensorPipe specific variables:
   example: `address` or `thread`, to run with `asan` or `tsan`,
   respectively.
 
-### sccache
-
-If you have [`sccache`][sccache] installed and available in your
-`PATH`, the build system will automatically find and use it.
-
-If you're not sure if `sscache` is being used for your build, check
-out its cache statistics before and after a build by running:
-
-``` shell
-$ sccache -s
-```
-
-[sccache]: https://github.com/mozilla/sccache
-
-### Colorized output with sccache
-
-By default, `sccache` will strip color information from the compiler
-output. To make it pass through the compilers colorized output, you
-have to install `sccache` version 0.2.13 or higher (as of 2020-01-21
-this version is not yet available and you have to build `sscache` from
-source -- this features was added in [mozilla/sccache#589][pr-589]).
-
-[pr-589]: https://github.com/mozilla/sccache/pull/589
-
-After getting the right version, configure the compiler to always
-produce colorized output by passing the CMake variable
-`-DCMAKE_CXX_FLAGS=-fdiagnostics-color`
-
 ## Ninja
 
 To make CMake output something other than the default `Makefile`, see


### PR DESCRIPTION
This is not really needed at the moment as compile time is a few seconds.