### PR TITLE
Support building using pre-installed libuv.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 
 option(TP_ENABLE_SHM "Enable shm transport" ${LINUX})
 option(TP_ENABLE_CMA "Enable cma channel" ${LINUX})
+option(TP_BUILD_LIBUV "Build libuv from source" OFF)
 
 # Define sanitizer option, if specified.
 include(Sanitize)
@@ -38,19 +39,9 @@ include(CTest)
 if(BUILD_TESTING)
   add_subdirectory(third_party/googletest EXCLUDE_FROM_ALL)
 endif()
-add_subdirectory(third_party/libuv EXCLUDE_FROM_ALL)
+
 if(BUILD_PYTHON_MODULE)
   add_subdirectory(third_party/pybind11 EXCLUDE_FROM_ALL)
 endif()
-
-# Add include paths for libuv targets.
-# These are defined as relative paths in third_party/libuv/CMakeLists.txt,
-# but they don't propagate to downstream targets that depend on libuv.
-set_target_properties(uv PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES "${libuv_SOURCE_DIR}/include"
-  )
-set_target_properties(uv_a PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES "${libuv_SOURCE_DIR}/include"
-  )
 
 add_subdirectory(tensorpipe)

--- a/cmake/Finduv.cmake
+++ b/cmake/Finduv.cmake
@@ -1,0 +1,75 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#
+# Finduv
+# ------
+#
+# Imported Targets
+# ^^^^^^^^^^^^^^^^
+#
+# An imported target named ``uv::uv`` is provided if libuv has been found.
+#
+# Result Variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module defines the following variables:
+#
+# ``uv_FOUND``
+#   True if libuv was found, false otherwise.
+# ``uv_LIBRARY_DIRS``
+#   The path(s) to uv libraries.
+# ``uv_VERSION``
+#   The version of libuv found.
+#
+
+find_package(PkgConfig QUIET)
+
+if((NOT TP_BUILD_LIBUV) AND PkgConfig_FOUND)
+  pkg_check_modules(uv QUIET libuv)
+  if (uv_FOUND)
+    add_library(uv::uv_a INTERFACE IMPORTED)
+
+    if(uv_STATIC_INCLUDE_DIRS)
+      set_property(TARGET uv::uv_a PROPERTY
+                   INTERFACE_INCLUDE_DIRECTORIES "${uv_STATIC_INCLUDE_DIRS}")
+    endif()
+    if(uv_STATIC_LIBRARIES)
+      list(REMOVE_ITEM uv_STATIC_LIBRARIES uv)
+      find_library(uv_LIBRARY_ARCHIVE
+                   NAMES libuv.a libuv_a.a
+                   PATHS "${uv_STATIC_LIBRARY_DIRS}"
+                   NO_DEFAULT_PATH)
+      list(INSERT uv_STATIC_LIBRARIES 0 "${uv_LIBRARY_ARCHIVE}")
+      set_property(TARGET uv::uv_a PROPERTY
+                   INTERFACE_LINK_LIBRARIES "${uv_STATIC_LIBRARIES}")
+    endif()
+    if(uv_STATIC_LDFLAGS_OTHER)
+      set_property(TARGET uv::uv_a PROPERTY
+                   INTERFACE_LINK_OPTIONS "${uv_STATIC_LDFLAGS_OTHER}")
+    endif()
+    if(uv_STATIC_CFLAGS_OTHER)
+      set_property(TARGET uv::uv_a PROPERTY
+                   INTERFACE_COMPILE_OPTIONS "${uv_STATIC_CFLAGS_OTHER}")
+    endif()
+  endif()
+endif()
+
+if(NOT uv_FOUND)
+  set(uv_VERSION "1.33.1")
+  set(uv_LIBRARY_DIRS "${CMAKE_BINARY_DIR}/third_party/libuv")
+
+  add_subdirectory(${CMAKE_SOURCE_DIR}/third_party/libuv
+                   ${CMAKE_BINARY_DIR}/third_party/libuv
+                   EXCLUDE_FROM_ALL)
+
+  add_library(uv::uv_a ALIAS uv_a)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(uv
+  REQUIRED_VARS uv_LIBRARY_DIRS
+  VERSION_VAR uv_VERSION)

--- a/tensorpipe/test/channel/CMakeLists.txt
+++ b/tensorpipe/test/channel/CMakeLists.txt
@@ -9,7 +9,7 @@ target_include_directories(
   tensorpipe_channel_test
   PUBLIC
   $<TARGET_PROPERTY:tensorpipe,INCLUDE_DIRECTORIES>
-  $<TARGET_PROPERTY:uv_a,INCLUDE_DIRECTORIES>
+  $<TARGET_PROPERTY:tensorpipe_uv,INCLUDE_DIRECTORIES>
   $<TARGET_PROPERTY:gtest_main,INCLUDE_DIRECTORIES>
   )
 # Build this after having generated the .pb.h files needed by some tests.

--- a/tensorpipe/transport/uv/CMakeLists.txt
+++ b/tensorpipe/transport/uv/CMakeLists.txt
@@ -4,5 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+find_package(uv REQUIRED)
+
 add_library(tensorpipe_uv connection.cc context.cc error.cc listener.cc loop.cc sockaddr.cc uv.cc)
-target_link_libraries(tensorpipe_uv tensorpipe uv_a)
+target_link_libraries(tensorpipe_uv PUBLIC tensorpipe uv::uv_a)


### PR DESCRIPTION
Default behavior is: build using system libuv if available, otherwise fallback on the submodule one. The CMake option `TP_BUILD_LIBUV` allows the user to force using the submodule one.

Based on #144.