### PR TITLE
Using Transport Registry for Pipe Benchmark

### DIFF
--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(tensorpipe PRIVATE
   core/pipe.cc
   transport/connection.cc
   transport/error.cc
+  transport/registry.cc
   )
 
 

--- a/tensorpipe/benchmark/benchmark_pipe.cc
+++ b/tensorpipe/benchmark/benchmark_pipe.cc
@@ -18,10 +18,7 @@
 #include <tensorpipe/core/context.h>
 #include <tensorpipe/core/listener.h>
 #include <tensorpipe/core/pipe.h>
-#ifdef TP_ENABLE_SHM
-#include <tensorpipe/transport/shm/context.h>
-#endif // TP_ENABLE_SHM
-#include <tensorpipe/transport/uv/context.h>
+#include <tensorpipe/transport/registry.h>
 
 using namespace tensorpipe;
 using namespace tensorpipe::benchmark;
@@ -143,19 +140,11 @@ static void runServer(const Options& options) {
   measurements.reserve(options.numRoundTrips);
 
   std::shared_ptr<Context> context = std::make_shared<Context>();
-#ifdef TP_ENABLE_SHM
-  if (options.transport == "shm") {
-    context->registerTransport(
-        0, "shm", std::make_shared<transport::shm::Context>());
-  } else
-#endif // TP_ENABLE_SHM
-      if (options.transport == "uv") {
-    context->registerTransport(
-        0, "uv", std::make_shared<transport::uv::Context>());
-  } else {
-    // Should never be here
-    TP_THROW_ASSERT() << "unknown transport: " << options.transport;
-  }
+  auto transportContext =
+      TensorpipeTransportRegistry().create(options.transport);
+  validateContext(transportContext);
+  context->registerTransport(0, options.transport, transportContext);
+
   if (options.channel == "basic") {
     context->registerChannel(
         0, "basic", std::make_shared<channel::basic::Context>());
@@ -274,19 +263,11 @@ static void runClient(const Options& options) {
   measurements.reserve(options.numRoundTrips);
 
   std::shared_ptr<Context> context = std::make_shared<Context>();
-#ifdef TP_ENABLE_SHM
-  if (options.transport == "shm") {
-    context->registerTransport(
-        0, "shm", std::make_shared<transport::shm::Context>());
-  } else
-#endif // TP_ENABLE_SHM
-      if (options.transport == "uv") {
-    context->registerTransport(
-        0, "uv", std::make_shared<transport::uv::Context>());
-  } else {
-    // Should never be here
-    TP_THROW_ASSERT() << "unknown transport: " << options.transport;
-  }
+  auto transportContext =
+      TensorpipeTransportRegistry().create(options.transport);
+  validateContext(transportContext);
+  context->registerTransport(0, options.transport, transportContext);
+
   if (options.channel == "basic") {
     context->registerChannel(
         0, "basic", std::make_shared<channel::basic::Context>());

--- a/tensorpipe/benchmark/benchmark_transport.cc
+++ b/tensorpipe/benchmark/benchmark_transport.cc
@@ -11,10 +11,7 @@
 #include <tensorpipe/benchmark/measurements.h>
 #include <tensorpipe/benchmark/options.h>
 #include <tensorpipe/common/defs.h>
-#ifdef TP_ENABLE_SHM
-#include <tensorpipe/transport/shm/context.h>
-#endif // TP_ENABLE_SHM
-#include <tensorpipe/transport/uv/context.h>
+#include <tensorpipe/transport/registry.h>
 
 using namespace tensorpipe;
 using namespace tensorpipe::benchmark;
@@ -100,17 +97,8 @@ static void runServer(const Options& options) {
   measurements.reserve(options.numRoundTrips);
 
   std::shared_ptr<Context> context;
-#ifdef TP_ENABLE_SHM
-  if (options.transport == "shm") {
-    context = std::make_shared<shm::Context>();
-  } else
-#endif // TP_ENABLE_SHM
-      if (options.transport == "uv") {
-    context = std::make_shared<uv::Context>();
-  } else {
-    // Should never be here
-    TP_THROW_ASSERT() << "unknown transport: " << options.transport;
-  }
+  context = TensorpipeTransportRegistry().create(options.transport);
+  validateContext(context);
 
   std::promise<std::shared_ptr<Connection>> connProm;
   std::shared_ptr<Listener> listener = context->listen(addr);
@@ -172,17 +160,8 @@ static void runClient(const Options& options) {
   measurements.reserve(options.numRoundTrips);
 
   std::shared_ptr<Context> context;
-#ifdef TP_ENABLE_SHM
-  if (options.transport == "shm") {
-    context = std::make_shared<shm::Context>();
-  } else
-#endif // TP_ENABLE_SHM
-      if (options.transport == "uv") {
-    context = std::make_shared<uv::Context>();
-  } else {
-    // Should never be here
-    TP_THROW_ASSERT() << "unknown transport: " << options.transport;
-  }
+  context = TensorpipeTransportRegistry().create(options.transport);
+  validateContext(context);
   std::shared_ptr<Connection> conn = context->connect(addr);
 
   std::promise<void> doneProm;

--- a/tensorpipe/benchmark/options.cc
+++ b/tensorpipe/benchmark/options.cc
@@ -13,8 +13,23 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <tensorpipe/transport/registry.h>
+
 namespace tensorpipe {
 namespace benchmark {
+
+void validateContext(std::shared_ptr<transport::Context> context) {
+  if (!context) {
+    auto keys = TensorpipeTransportRegistry().keys();
+    std::cout
+        << "The transport you passed in is not supported. The following transports are valid: ";
+    for (const auto& key : keys) {
+      std::cout << key << ", ";
+    }
+    std::cout << "\n";
+    exit(EXIT_FAILURE);
+  }
+}
 
 static void usage(int status, const char* argv0) {
   if (status != EXIT_SUCCESS) {

--- a/tensorpipe/benchmark/options.h
+++ b/tensorpipe/benchmark/options.h
@@ -10,6 +10,8 @@
 
 #include <string>
 
+#include <tensorpipe/transport/context.h>
+
 namespace tensorpipe {
 namespace benchmark {
 
@@ -25,6 +27,8 @@ struct Options {
 };
 
 struct Options parseOptions(int argc, char** argv);
+
+void validateContext(std::shared_ptr<transport::Context> context);
 
 } // namespace benchmark
 } // namespace tensorpipe

--- a/tensorpipe/transport/registry.cc
+++ b/tensorpipe/transport/registry.cc
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/transport/registry.h>
+
+TP_DEFINE_SHARED_REGISTRY(
+    TensorpipeTransportRegistry,
+    tensorpipe::transport::Context);

--- a/tensorpipe/transport/registry.h
+++ b/tensorpipe/transport/registry.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <tensorpipe/transport/context.h>
+#include <tensorpipe/util/registry/registry.h>
+
+TP_DECLARE_SHARED_REGISTRY(
+    TensorpipeTransportRegistry,
+    tensorpipe::transport::Context);

--- a/tensorpipe/transport/shm/context.cc
+++ b/tensorpipe/transport/shm/context.cc
@@ -9,6 +9,7 @@
 #include <tensorpipe/transport/shm/context.h>
 
 #include <tensorpipe/common/system.h>
+#include <tensorpipe/transport/registry.h>
 #include <tensorpipe/transport/shm/connection.h>
 #include <tensorpipe/transport/shm/listener.h>
 #include <tensorpipe/transport/shm/loop.h>
@@ -17,6 +18,16 @@
 namespace tensorpipe {
 namespace transport {
 namespace shm {
+
+namespace {
+
+std::shared_ptr<Context> makeShmContext() {
+  return std::make_shared<Context>();
+}
+
+TP_REGISTER_CREATOR(TensorpipeTransportRegistry, shm, makeShmContext);
+
+} // namespace
 
 namespace {
 

--- a/tensorpipe/transport/uv/context.cc
+++ b/tensorpipe/transport/uv/context.cc
@@ -8,6 +8,7 @@
 
 #include <tensorpipe/transport/uv/context.h>
 
+#include <tensorpipe/transport/registry.h>
 #include <tensorpipe/transport/uv/connection.h>
 #include <tensorpipe/transport/uv/listener.h>
 #include <tensorpipe/transport/uv/loop.h>
@@ -17,6 +18,16 @@
 namespace tensorpipe {
 namespace transport {
 namespace uv {
+
+namespace {
+
+std::shared_ptr<Context> makeUvContext() {
+  return std::make_shared<Context>();
+}
+
+TP_REGISTER_CREATOR(TensorpipeTransportRegistry, uv, makeUvContext);
+
+} // namespace
 
 namespace {
 

--- a/tensorpipe/util/registry/registry.h
+++ b/tensorpipe/util/registry/registry.h
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// NB: This Registry works poorly when you have other namespaces.
+
+/**
+ * Simple registry implementation that uses static variables to
+ * register object creators during program initialization time. This registry
+ * implementation is largely borrowed from the PyTorch registry utility in file
+ * pytorch/c10/util/Registry.h.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace tensorpipe {
+namespace util {
+namespace registry {
+
+/**
+ * @brief A template class that allows one to register classes by keys.
+ *
+ * The keys are usually a std::string specifying the name, but can be anything
+ * that can be used in a std::map.
+ *
+ * You should most likely not use the Registry class explicitly, but use the
+ * helper macros below to declare specific registries as well as registering
+ * objects.
+ */
+template <class ObjectPtrType, class... Args>
+class Registry {
+ public:
+  typedef std::function<ObjectPtrType(Args...)> Creator;
+
+  Registry() : registry_() {}
+
+  // Adds a key and its associated creator to the desired registry. If the key
+  // already exists in the registry, we simply replace the old creator
+  // with the new args for the key.
+  void registerCreator(std::string key, Creator creator) {
+    registry_[key] = creator;
+  }
+
+  // Allows you to register and key/Creator pair and provide a help_messge for
+  // the key as well.
+  void registerCreator(
+      std::string key,
+      Creator creator,
+      const std::string& help_msg) {
+    registerCreator(key, creator);
+    help_message_[key] = help_msg;
+  }
+
+  // Returns whether a particular key exists in the given registry.
+  inline bool has(std::string key) {
+    return (registry_.count(key) != 0);
+  }
+
+  // Given the key, create() invokes the creator with the provided args and
+  // returns the object that the creator function constructs.
+  ObjectPtrType create(std::string key, Args... args) {
+    if (registry_.count(key) == 0) {
+      // Returns nullptr if the key is not registered.
+      return nullptr;
+    }
+    return registry_[key](args...);
+  }
+
+  // Returns the registered keys as a std::vector.
+  std::vector<std::string> keys() const {
+    std::vector<std::string> keys;
+    for (const auto& it : registry_) {
+      keys.push_back(it.first);
+    }
+    return keys;
+  }
+
+  // Returns the help_message for the key if one is provided.
+  inline const std::unordered_map<std::string, std::string>& helpMessage()
+      const {
+    return help_message_;
+  }
+
+  const char* helpMessage(std::string key) const {
+    auto it = help_message_.find(key);
+    if (it == help_message_.end()) {
+      return nullptr;
+    }
+    return it->second.c_str();
+  }
+
+ private:
+  std::unordered_map<std::string, Creator> registry_;
+  std::unordered_map<std::string, std::string> help_message_;
+};
+
+// Registerer is a class template that simplifies Register-ing keys for a given
+// registry.
+template <class ObjectPtrType, class... Args>
+class Registerer {
+ public:
+  explicit Registerer(
+      std::string key,
+      Registry<ObjectPtrType, Args...>& registry,
+      typename Registry<ObjectPtrType, Args...>::Creator creator,
+      const std::string& help_msg = "") {
+    registry.registerCreator(key, creator, help_msg);
+  }
+};
+
+// The following macros should be used to create/add to registries. Avoid
+// invoking the Registry class template functions directly.
+
+#define TP_CONCATENATE_IMPL(s1, s2) s1##s2
+#define TP_CONCATENATE(s1, s2) TP_CONCATENATE_IMPL(s1, s2)
+#define TP_ANONYMOUS_VARIABLE(str) TP_CONCATENATE(str, __LINE__)
+
+// Using the construct on first use idiom to avoid static order initialization
+// issue. Refer to this link for reference:
+// https://isocpp.org/wiki/faq/ctors#static-init-order-on-first-use
+#define TP_DEFINE_TYPED_REGISTRY(RegistryName, ObjectType, PtrType, ...)    \
+  tensorpipe::util::registry::Registry<PtrType<ObjectType>, ##__VA_ARGS__>& \
+  RegistryName() {                                                          \
+    static tensorpipe::util::registry::                                     \
+        Registry<PtrType<ObjectType>, ##__VA_ARGS__>* registry =            \
+            new tensorpipe::util::registry::                                \
+                Registry<PtrType<ObjectType>, ##__VA_ARGS__>();             \
+    return *registry;                                                       \
+  }
+
+#define TP_DECLARE_TYPED_REGISTRY(RegistryName, ObjectType, PtrType, ...)   \
+  tensorpipe::util::registry::Registry<PtrType<ObjectType>, ##__VA_ARGS__>& \
+  RegistryName();                                                           \
+  typedef tensorpipe::util::registry::                                      \
+      Registerer<PtrType<ObjectType>, ##__VA_ARGS__>                        \
+          Registerer##RegistryName
+
+#define TP_DEFINE_SHARED_REGISTRY(RegistryName, ObjectType, ...) \
+  TP_DEFINE_TYPED_REGISTRY(                                      \
+      RegistryName, ObjectType, std::shared_ptr, ##__VA_ARGS__)
+
+#define TP_DECLARE_SHARED_REGISTRY(RegistryName, ObjectType, ...) \
+  TP_DECLARE_TYPED_REGISTRY(                                      \
+      RegistryName, ObjectType, std::shared_ptr, ##__VA_ARGS__)
+
+#define TP_REGISTER_TYPED_CREATOR(RegistryName, key, ...)                  \
+  static Registerer##RegistryName TP_ANONYMOUS_VARIABLE(g_##RegistryName)( \
+      key, RegistryName(), ##__VA_ARGS__);
+
+#define TP_REGISTER_CREATOR(RegistryName, key, ...) \
+  TP_REGISTER_TYPED_CREATOR(RegistryName, #key, __VA_ARGS__)
+
+} // namespace registry
+} // namespace util
+} // namespace tensorpipe


### PR DESCRIPTION
Summary:
This diff uses the transport registry in benchmark_pipe, which allows
us to support TLS transport there.

Reviewed By: lw

Differential Revision: D21147708

