### PR TITLE
Enable Channel Registry in Benchmark Pipe

### DIFF
--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -42,6 +42,7 @@ target_sources(tensorpipe PRIVATE
   channel/context.cc
   channel/error.cc
   channel/helpers.cc
+  channel/registry.cc
   common/address.cc
   common/error.cc
   common/system.cc

--- a/tensorpipe/benchmark/benchmark_pipe.cc
+++ b/tensorpipe/benchmark/benchmark_pipe.cc
@@ -12,10 +12,7 @@
 
 #include <tensorpipe/benchmark/measurements.h>
 #include <tensorpipe/benchmark/options.h>
-#include <tensorpipe/channel/basic/context.h>
-#ifdef TP_ENABLE_CMA
-#include <tensorpipe/channel/cma/context.h>
-#endif // TP_ENABLE_CMA
+#include <tensorpipe/channel/registry.h>
 #include <tensorpipe/common/defs.h>
 #include <tensorpipe/core/context.h>
 #include <tensorpipe/core/listener.h>
@@ -144,23 +141,12 @@ static void runServer(const Options& options) {
   std::shared_ptr<Context> context = std::make_shared<Context>();
   auto transportContext =
       TensorpipeTransportRegistry().create(options.transport);
-  validateContext(transportContext);
+  validateTransportContext(transportContext);
   context->registerTransport(0, options.transport, transportContext);
 
-  if (options.channel == "basic") {
-    context->registerChannel(
-        0, "basic", std::make_shared<channel::basic::Context>());
-  } else
-#ifdef TP_ENABLE_CMA
-      if (options.channel == "cma") {
-    context->registerChannel(
-        0, "cma", std::make_shared<channel::cma::Context>());
-  } else
-#endif // TP_ENABLE_CMA
-  {
-    // Should never be here
-    TP_THROW_ASSERT() << "unknown channel: " << options.channel;
-  }
+  auto channelContext = TensorpipeChannelRegistry().create(options.channel);
+  validateChannelContext(channelContext);
+  context->registerChannel(0, options.channel, channelContext);
 
   std::promise<std::shared_ptr<Pipe>> pipeProm;
   std::shared_ptr<Listener> listener = context->listen({addr});
@@ -267,23 +253,12 @@ static void runClient(const Options& options) {
   std::shared_ptr<Context> context = std::make_shared<Context>();
   auto transportContext =
       TensorpipeTransportRegistry().create(options.transport);
-  validateContext(transportContext);
+  validateTransportContext(transportContext);
   context->registerTransport(0, options.transport, transportContext);
 
-  if (options.channel == "basic") {
-    context->registerChannel(
-        0, "basic", std::make_shared<channel::basic::Context>());
-  } else
-#ifdef TP_ENABLE_CMA
-      if (options.channel == "cma") {
-    context->registerChannel(
-        0, "cma", std::make_shared<channel::cma::Context>());
-  } else
-#endif // TP_ENABLE_CMA
-  {
-    // Should never be here
-    TP_THROW_ASSERT() << "unknown channel: " << options.channel;
-  }
+  auto channelContext = TensorpipeChannelRegistry().create(options.channel);
+  validateChannelContext(channelContext);
+  context->registerChannel(0, options.channel, channelContext);
 
   std::shared_ptr<Pipe> pipe = context->connect(addr);
 

--- a/tensorpipe/benchmark/benchmark_transport.cc
+++ b/tensorpipe/benchmark/benchmark_transport.cc
@@ -100,7 +100,7 @@ static void runServer(const Options& options) {
 
   std::shared_ptr<Context> context;
   context = TensorpipeTransportRegistry().create(options.transport);
-  validateContext(context);
+  validateTransportContext(context);
 
   std::promise<std::shared_ptr<Connection>> connProm;
   std::shared_ptr<Listener> listener = context->listen(addr);
@@ -163,7 +163,7 @@ static void runClient(const Options& options) {
 
   std::shared_ptr<Context> context;
   context = TensorpipeTransportRegistry().create(options.transport);
-  validateContext(context);
+  validateTransportContext(context);
   std::shared_ptr<Connection> conn = context->connect(addr);
 
   std::promise<void> doneProm;

--- a/tensorpipe/benchmark/options.cc
+++ b/tensorpipe/benchmark/options.cc
@@ -13,16 +13,30 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <tensorpipe/channel/registry.h>
 #include <tensorpipe/transport/registry.h>
 
 namespace tensorpipe {
 namespace benchmark {
 
-void validateContext(std::shared_ptr<transport::Context> context) {
+void validateTransportContext(std::shared_ptr<transport::Context> context) {
   if (!context) {
     auto keys = TensorpipeTransportRegistry().keys();
     std::cout
         << "The transport you passed in is not supported. The following transports are valid: ";
+    for (const auto& key : keys) {
+      std::cout << key << ", ";
+    }
+    std::cout << "\n";
+    exit(EXIT_FAILURE);
+  }
+}
+
+void validateChannelContext(std::shared_ptr<channel::Context> context) {
+  if (!context) {
+    auto keys = TensorpipeChannelRegistry().keys();
+    std::cout
+        << "The channel you passed in is not supported. The following channels are valid: ";
     for (const auto& key : keys) {
       std::cout << key << ", ";
     }

--- a/tensorpipe/benchmark/options.h
+++ b/tensorpipe/benchmark/options.h
@@ -10,6 +10,7 @@
 
 #include <string>
 
+#include <tensorpipe/channel/context.h>
 #include <tensorpipe/transport/context.h>
 
 namespace tensorpipe {
@@ -28,7 +29,8 @@ struct Options {
 
 struct Options parseOptions(int argc, char** argv);
 
-void validateContext(std::shared_ptr<transport::Context> context);
+void validateTransportContext(std::shared_ptr<transport::Context> context);
+void validateChannelContext(std::shared_ptr<channel::Context> context);
 
 } // namespace benchmark
 } // namespace tensorpipe

--- a/tensorpipe/channel/basic/context.cc
+++ b/tensorpipe/channel/basic/context.cc
@@ -14,6 +14,7 @@
 #include <tensorpipe/channel/basic/channel.h>
 #include <tensorpipe/channel/error.h>
 #include <tensorpipe/channel/helpers.h>
+#include <tensorpipe/channel/registry.h>
 #include <tensorpipe/common/callback.h>
 #include <tensorpipe/common/defs.h>
 #include <tensorpipe/common/error.h>
@@ -23,6 +24,16 @@
 namespace tensorpipe {
 namespace channel {
 namespace basic {
+
+namespace {
+
+std::shared_ptr<Context> makeBasicChannel() {
+  return std::make_shared<Context>();
+}
+
+TP_REGISTER_CREATOR(TensorpipeChannelRegistry, basic, makeBasicChannel);
+
+} // namespace
 
 class Context::Impl : public Context::PrivateIface,
                       public std::enable_shared_from_this<Context::Impl> {

--- a/tensorpipe/channel/cma/context.cc
+++ b/tensorpipe/channel/cma/context.cc
@@ -20,6 +20,7 @@
 #include <tensorpipe/channel/cma/channel.h>
 #include <tensorpipe/channel/error.h>
 #include <tensorpipe/channel/helpers.h>
+#include <tensorpipe/channel/registry.h>
 #include <tensorpipe/common/callback.h>
 #include <tensorpipe/common/defs.h>
 #include <tensorpipe/common/error_macros.h>
@@ -60,6 +61,12 @@ std::string generateDomainDescriptor() {
   oss << "/" << getegid();
   return oss.str();
 }
+
+std::shared_ptr<Context> makeCmaChannel() {
+  return std::make_shared<Context>();
+}
+
+TP_REGISTER_CREATOR(TensorpipeChannelRegistry, cma, makeCmaChannel);
 
 } // namespace
 

--- a/tensorpipe/channel/registry.cc
+++ b/tensorpipe/channel/registry.cc
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/channel/registry.h>
+
+TP_DEFINE_SHARED_REGISTRY(
+    TensorpipeChannelRegistry,
+    tensorpipe::channel::Context);

--- a/tensorpipe/channel/registry.h
+++ b/tensorpipe/channel/registry.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <tensorpipe/channel/context.h>
+#include <tensorpipe/util/registry/registry.h>
+
+TP_DECLARE_SHARED_REGISTRY(
+    TensorpipeChannelRegistry,
+    tensorpipe::channel::Context);


### PR DESCRIPTION
Summary: Enabling the Channel Registry for Pipe Benchmark - similar to `TensorpipeTransportRegistry` for transports

Differential Revision: D21217114

