### PR TITLE
Replace compare_exchange_strong with exchange in Transports

### DIFF
--- a/tensorpipe/channel/basic/context.cc
+++ b/tensorpipe/channel/basic/context.cc
@@ -98,9 +98,7 @@ void Context::close() {
 }
 
 void Context::Impl::close() {
-  bool wasClosed = false;
-  closed_.compare_exchange_strong(wasClosed, true);
-  if (!wasClosed) {
+  if (!closed_.exchange(true)) {
     closingEmitter_.close();
   }
 }
@@ -112,9 +110,7 @@ void Context::join() {
 void Context::Impl::join() {
   close();
 
-  bool wasJoined = false;
-  joined_.compare_exchange_strong(wasJoined, true);
-  if (!wasJoined) {
+  if (!joined_.exchange(true)) {
     // Nothing to do?
   }
 }

--- a/tensorpipe/channel/cma/context.cc
+++ b/tensorpipe/channel/cma/context.cc
@@ -131,9 +131,7 @@ void Context::close() {
 }
 
 void Context::Impl::close() {
-  bool wasClosed = false;
-  closed_.compare_exchange_strong(wasClosed, true);
-  if (!wasClosed) {
+  if (!closed_.exchange(true)) {
     closingEmitter_.close();
     requests_.push(nullopt);
   }
@@ -146,9 +144,7 @@ void Context::join() {
 void Context::Impl::join() {
   close();
 
-  bool wasJoined = false;
-  joined_.compare_exchange_strong(wasJoined, true);
-  if (!wasJoined) {
+  if (!joined_.exchange(true)) {
     thread_.join();
     // TP_DCHECK(requests_.empty());
   }

--- a/tensorpipe/core/context.cc
+++ b/tensorpipe/core/context.cc
@@ -234,7 +234,6 @@ void Context::close() {
 
 void Context::Impl::close() {
   if (!closed_.exchange(true)) {
-
     TP_VLOG() << "Context " << id_ << " is closing";
 
     closingEmitter_.close();

--- a/tensorpipe/core/context.cc
+++ b/tensorpipe/core/context.cc
@@ -233,9 +233,7 @@ void Context::close() {
 }
 
 void Context::Impl::close() {
-  bool wasClosed = false;
-  if (closed_.compare_exchange_strong(wasClosed, true)) {
-    TP_DCHECK(!wasClosed);
+  if (!closed_.exchange(true)) {
 
     TP_VLOG() << "Context " << id_ << " is closing";
 
@@ -257,10 +255,7 @@ void Context::join() {
 void Context::Impl::join() {
   close();
 
-  bool wasJoined = false;
-  if (joined_.compare_exchange_strong(wasJoined, true)) {
-    TP_DCHECK(!wasJoined);
-
+  if (!joined_.exchange(true)) {
     for (auto& iter : transports_) {
       iter.second->join();
     }

--- a/tensorpipe/transport/shm/context.cc
+++ b/tensorpipe/transport/shm/context.cc
@@ -96,9 +96,7 @@ void Context::close() {
 }
 
 void Context::Impl::close() {
-  bool wasClosed = false;
-  closed_.compare_exchange_strong(wasClosed, true);
-  if (!wasClosed) {
+  if (!closed_.exchange(true)) {
     closingEmitter_.close();
     loop_.close();
   }
@@ -111,9 +109,7 @@ void Context::join() {
 void Context::Impl::join() {
   close();
 
-  bool wasJoined = false;
-  joined_.compare_exchange_strong(wasJoined, true);
-  if (!wasJoined) {
+  if (!joined_.exchange(true)) {
     loop_.join();
   }
 }

--- a/tensorpipe/transport/shm/loop.cc
+++ b/tensorpipe/transport/shm/loop.cc
@@ -77,9 +77,7 @@ Loop::Loop() {
 }
 
 void Loop::close() {
-  bool wasClosed = false;
-  closed_.compare_exchange_strong(wasClosed, true);
-  if (!wasClosed) {
+  if (!closed_.exchange(true)) {
     reactor_.close();
     wakeup();
   }
@@ -88,9 +86,7 @@ void Loop::close() {
 void Loop::join() {
   close();
 
-  bool wasJoined = false;
-  joined_.compare_exchange_strong(wasJoined, true);
-  if (!wasJoined) {
+  if (!joined_.exchange(true)) {
     reactor_.join();
     thread_.join();
   }

--- a/tensorpipe/transport/shm/reactor.cc
+++ b/tensorpipe/transport/shm/reactor.cc
@@ -45,9 +45,7 @@ Reactor::Reactor() {
 }
 
 void Reactor::close() {
-  bool wasClosed = false;
-  closed_.compare_exchange_strong(wasClosed, true);
-  if (!wasClosed) {
+  if (!closed_.exchange(true)) {
     // No need to wake up the reactor, since it is busy-waiting.
   }
 }
@@ -55,9 +53,7 @@ void Reactor::close() {
 void Reactor::join() {
   close();
 
-  bool wasJoined = false;
-  joined_.compare_exchange_strong(wasJoined, true);
-  if (!wasJoined) {
+  if (!joined_.exchange(true)) {
     thread_.join();
   }
 }

--- a/tensorpipe/transport/uv/context.cc
+++ b/tensorpipe/transport/uv/context.cc
@@ -86,9 +86,7 @@ void Context::close() {
 }
 
 void Context::Impl::close() {
-  bool wasClosed = false;
-  closed_.compare_exchange_strong(wasClosed, true);
-  if (!wasClosed) {
+  if (!closed_.exchange(true)) {
     closingEmitter_.close();
     loop_.close();
   }
@@ -101,9 +99,7 @@ void Context::join() {
 void Context::Impl::join() {
   close();
 
-  bool wasJoined = false;
-  joined_.compare_exchange_strong(wasJoined, true);
-  if (!wasJoined) {
+  if (!joined_.exchange(true)) {
     loop_.join();
   }
 }

--- a/tensorpipe/transport/uv/loop.cc
+++ b/tensorpipe/transport/uv/loop.cc
@@ -29,9 +29,7 @@ Loop::Loop()
 }
 
 void Loop::close() {
-  bool wasClosed = false;
-  closed_.compare_exchange_strong(wasClosed, true);
-  if (!wasClosed) {
+  if (!closed_.exchange(true)) {
     // It's fine to capture this because the loop won't be destroyed until join
     // has completed, and join won't complete until this operation is performed.
     deferToLoop(
@@ -42,9 +40,7 @@ void Loop::close() {
 void Loop::join() {
   close();
 
-  bool wasJoined = false;
-  joined_.compare_exchange_strong(wasJoined, true);
-  if (!wasJoined) {
+  if (!joined_.exchange(true)) {
     // Wait for event loop thread to terminate.
     thread_.join();
 


### PR DESCRIPTION
Summary:
In transports, replace compare_exchange_strong with exchange
when checking the value of atomic boolean variables.

Differential Revision: D21313777

