### PR TITLE
Remove unused x86intrin include

### DIFF
--- a/tensorpipe/common/system.h
+++ b/tensorpipe/common/system.h
@@ -15,8 +15,6 @@
 #include <sstream>
 #include <string>
 
-#include <x86intrin.h>
-
 #include <tensorpipe/common/defs.h>
 #include <tensorpipe/common/optional.h>
 


### PR DESCRIPTION
Summary: It seems we don't use it. I guess it was left around after D20381912.

Reviewed By: osalpekar

Differential Revision: D21432867

