### PR TITLE
move to semaphore

### DIFF
--- a/tensorpipe/transport/shm/reactor.cc
+++ b/tensorpipe/transport/shm/reactor.cc
@@ -27,6 +27,7 @@ void writeToken(util::ringbuffer::Producer& producer, Reactor::TToken token) {
     TP_DCHECK_EQ(rv, sizeof(token));
     break;
   }
+  producer.semPostData();
 }
 
 } // namespace
@@ -41,12 +42,13 @@ Reactor::Reactor() {
   consumer_.emplace(rb);
   producer_.emplace(rb);
   deferredFunctionToken_ = add([this]() { handleDeferredFunctionFromLoop(); });
+  wakeUpToken_ = add([]() { ; });
   thread_ = std::thread(&Reactor::run, this);
 }
 
 void Reactor::close() {
   if (!closed_.exchange(true)) {
-    // No need to wake up the reactor, since it is busy-waiting.
+    trigger(wakeUpToken_);
   }
 }
 
@@ -94,6 +96,11 @@ void Reactor::remove(TToken token) {
   functions_[token] = nullptr;
   reusableTokens_.insert(token);
   functionCount_--;
+  if (functionCount_ >= 2) {
+    // Wake up loop thread upon each token removal except for the
+    // two used to defer and wake up.
+    writeToken(producer_.value(), wakeUpToken_);
+  }
 }
 
 void Reactor::trigger(TToken token) {
@@ -108,14 +115,13 @@ std::tuple<int, int> Reactor::fds() const {
 void Reactor::run() {
   setThreadName("TP_SHM_reactor");
   // Stop when another thread has asked the reactor the close and when
-  // all functions have been removed except for the one used to defer.
-  while (!closed_ || functionCount_ > 1) {
+  // all functions have been removed except for the two used to defer
+  // and wakeup.
+  while (!closed_ || functionCount_ > 2) {
     uint32_t token;
+    consumer_->semWaitData();
     auto ret = consumer_->copy(sizeof(token), &token);
-    if (ret == -ENODATA) {
-      std::this_thread::yield();
-      continue;
-    }
+    TP_DCHECK_NE(ret, -ENODATA);
 
     TFunction fn;
 
@@ -133,6 +139,7 @@ void Reactor::run() {
   }
   TP_DCHECK(deferredFunctionList_.empty());
   remove(deferredFunctionToken_);
+  remove(wakeUpToken_);
 }
 
 Reactor::Trigger::Trigger(Fd&& headerFd, Fd&& dataFd)

--- a/tensorpipe/transport/shm/reactor.h
+++ b/tensorpipe/transport/shm/reactor.h
@@ -83,6 +83,7 @@ class Reactor final {
   std::atomic<bool> closed_{false};
   std::atomic<bool> joined_{false};
 
+  TToken wakeUpToken_;
   TToken deferredFunctionToken_;
   std::mutex deferredFunctionMutex_;
   std::list<TDeferredFunction> deferredFunctionList_;

--- a/tensorpipe/util/ringbuffer/consumer.h
+++ b/tensorpipe/util/ringbuffer/consumer.h
@@ -154,6 +154,10 @@ class Consumer : public RingBufferWrapper {
     return static_cast<ssize_t>(size);
   }
 
+  void semWaitData() {
+    semWait_();
+  }
+
  protected:
   bool inTx_{false};
 

--- a/tensorpipe/util/ringbuffer/producer.h
+++ b/tensorpipe/util/ringbuffer/producer.h
@@ -119,6 +119,10 @@ class Producer : public RingBufferWrapper {
     return writeInTx(sizeof(T), &d);
   }
 
+  void semPostData() {
+    semPost_();
+  }
+
   [[nodiscard]] std::pair<ssize_t, void*> reserveContiguousInTx(
       const size_t size) {
     if (unlikely(size == 0)) {


### PR DESCRIPTION
Summary: sched_yield looping results in much higher latency in highly concurrent pipe I/O. It's not strictly busy wait, but relinquish CPU and move to the end of priority task queue while no immediately available data. http://man7.org/linux/man-pages/man2/sched_yield.2.html. The overhead of re-scheduling and context switch could be high. Conversely, modern semaphore/mutex is kind hybrid locking of spinlock and sleep-lock - performs spinklock for the first part of remained scheduled CPU time and sleep after if lock is unavailable. It avoids both frequent re-scheduling and eating up CPU with spin. In practice it's always performs better than pure spinlock or re-schedule, even to protect lightweight operations like counter update.

Differential Revision: D21446104

