### PR TITLE
Make debugging counters atomic

### DIFF
--- a/tensorpipe/channel/basic/context.cc
+++ b/tensorpipe/channel/basic/context.cc
@@ -70,7 +70,7 @@ class Context::Impl : public Context::PrivateIface,
   // Sequence numbers for the channels created by this context, used to create
   // their identifiers based off this context's identifier. They will only be
   // used for logging and debugging.
-  uint64_t channelCounter_{0};
+  std::atomic<uint64_t> channelCounter_{0};
 };
 
 Context::Context() : impl_(std::make_shared<Impl>()) {}

--- a/tensorpipe/channel/cma/context.cc
+++ b/tensorpipe/channel/cma/context.cc
@@ -121,7 +121,7 @@ class Context::Impl : public Context::PrivateIface,
   // Sequence numbers for the channels created by this context, used to create
   // their identifiers based off this context's identifier. They will only be
   // used for logging and debugging.
-  uint64_t channelCounter_{0};
+  std::atomic<uint64_t> channelCounter_{0};
 
   void handleCopyRequests_();
 };

--- a/tensorpipe/core/context.cc
+++ b/tensorpipe/core/context.cc
@@ -91,8 +91,8 @@ class Context::Impl : public Context::PrivateIface,
   // Sequence numbers for the listeners and pipes created by this context, used
   // to create their identifiers based off this context's identifier. They will
   // only be used for logging and debugging.
-  uint64_t listenerCounter_{0};
-  uint64_t pipeCounter_{0};
+  std::atomic<uint64_t> listenerCounter_{0};
+  std::atomic<uint64_t> pipeCounter_{0};
 
   // A user-provided name for this context which should be semantically
   // meaningful. It will only be used for logging and debugging purposes, to

--- a/tensorpipe/core/listener.cc
+++ b/tensorpipe/core/listener.cc
@@ -72,7 +72,7 @@ class Listener::Impl : public Listener::PrivateIface,
   // Sequence numbers for the pipes created by this listener, used to create
   // their identifiers based off this listener's identifier. They will only be
   // used for logging and debugging.
-  uint64_t pipeCounter_{0};
+  std::atomic<uint64_t> pipeCounter_{0};
 
   std::unordered_map<std::string, std::shared_ptr<transport::Listener>>
       listeners_;

--- a/tensorpipe/transport/shm/context.cc
+++ b/tensorpipe/transport/shm/context.cc
@@ -97,8 +97,8 @@ class Context::Impl : public Context::PrivateIface,
   // Sequence numbers for the listeners and connections created by this context,
   // used to create their identifiers based off this context's identifier. They
   // will only be used for logging and debugging.
-  uint64_t listenerCounter_{0};
-  uint64_t connectionCounter_{0};
+  std::atomic<uint64_t> listenerCounter_{0};
+  std::atomic<uint64_t> connectionCounter_{0};
 };
 
 Context::Context() : impl_(std::make_shared<Impl>()) {}

--- a/tensorpipe/transport/shm/listener.cc
+++ b/tensorpipe/transport/shm/listener.cc
@@ -86,7 +86,7 @@ class Listener::Impl : public std::enable_shared_from_this<Listener::Impl>,
   // Sequence numbers for the connections created by this listener, used to
   // create their identifiers based off this listener's identifier. They will
   // only be used for logging and debugging.
-  uint64_t connectionCounter_{0};
+  std::atomic<uint64_t> connectionCounter_{0};
 };
 
 Listener::Impl::Impl(

--- a/tensorpipe/transport/uv/context.cc
+++ b/tensorpipe/transport/uv/context.cc
@@ -86,8 +86,8 @@ class Context::Impl : public Context::PrivateIface,
   // Sequence numbers for the listeners and connections created by this context,
   // used to create their identifiers based off this context's identifier. They
   // will only be used for logging and debugging.
-  uint64_t listenerCounter_{0};
-  uint64_t connectionCounter_{0};
+  std::atomic<uint64_t> listenerCounter_{0};
+  std::atomic<uint64_t> connectionCounter_{0};
 };
 
 Context::Context() : impl_(std::make_shared<Impl>()) {}

--- a/tensorpipe/transport/uv/listener.cc
+++ b/tensorpipe/transport/uv/listener.cc
@@ -90,7 +90,7 @@ class Listener::Impl : public std::enable_shared_from_this<Listener::Impl> {
   // Sequence numbers for the connections created by this listener, used to
   // create their identifiers based off this listener's identifier. They will
   // only be used for logging and debugging.
-  uint64_t connectionCounter_{0};
+  std::atomic<uint64_t> connectionCounter_{0};
 
   // By having the instance store a shared_ptr to itself we create a reference
   // cycle which will "leak" the instance. This allows us to detach its


### PR DESCRIPTION
Summary:
TSAN is reporting a failure becuase of this: https://app.circleci.com/pipelines/github/pytorch/tensorpipe/651/workflows/1805bd9d-4d9d-4536-9f34-6c3718df6d00/jobs/4276/steps

Some of these counters don't actually need to be atomic, in particular the listener ones, because they will only be incremented from the loop, but for consistency (and to avoid a future copy-and-paste to reintroduce the problem) I'm making them all atomic.

Differential Revision: D21525299

