### PR TITLE
Channel/transport test refactor for process based tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,10 @@ jobs:
       - run:
           name: Test
           command: |
+            export CTEST_OUTPUT_ON_FAILURE=1
+            export TSAN_OPTIONS="suppressions=$(realpath ./sanitizer_bl.txt)"
             cd build
-            CTEST_OUTPUT_ON_FAILURE=1 make test
+            make test
       - run:
           name: Install
           command: |

--- a/sanitizer_bl.txt
+++ b/sanitizer_bl.txt
@@ -1,0 +1,2 @@
+# There is a harmless data race in libuv on linux during the choice of a fast clock.
+race:uv__hrtime

--- a/tensorpipe/test/peer_group.h
+++ b/tensorpipe/test/peer_group.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <array>
 #include <string>
 #include <thread>
 
@@ -53,7 +54,7 @@ class PeerGroup {
  private:
   const std::string kDone = "done";
   std::mutex m_;
-  std::array<bool, 2> done_ = {false, false};
+  std::array<bool, 2> done_{{false, false}};
   std::array<std::condition_variable, 2> condVar_;
 };
 

--- a/tensorpipe/test/peer_group.h
+++ b/tensorpipe/test/peer_group.h
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+#include <thread>
+
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+#include <tensorpipe/common/defs.h>
+#include <tensorpipe/common/queue.h>
+
+class PeerGroup {
+ public:
+  static constexpr int kServer = 0;
+  static constexpr int kClient = 1;
+
+  virtual ~PeerGroup() = default;
+
+  // Send message to given peer.
+  virtual void send(int peerId, const std::string&) = 0;
+
+  // Read next message for given peer. This method is blocking.
+  virtual std::string recv(int peerId) = 0;
+
+  // Spawn two peers each running one of the provided functions.
+  virtual void spawn(std::function<void()>, std::function<void()>) = 0;
+
+  // Signal other peers that this peer is done.
+  void done(int peerId) {
+    send(1 - peerId, kDone);
+    std::unique_lock<std::mutex> lock(m_);
+    done_[peerId] = true;
+    condVar_[peerId].notify_one();
+  }
+
+  // Wait for all peers (including this one) to be done.
+  void join(int peerId) {
+    EXPECT_EQ(kDone, recv(peerId));
+
+    std::unique_lock<std::mutex> lock(m_);
+    condVar_[peerId].wait(lock, [&] { return done_[peerId]; });
+  }
+
+ private:
+  const std::string kDone = "done";
+  std::mutex m_;
+  std::array<bool, 2> done_ = {false, false};
+  std::array<std::condition_variable, 2> condVar_;
+};
+
+class ThreadPeerGroup : public PeerGroup {
+ public:
+  void send(int peerId, const std::string& str) override {
+    q_[peerId].push(str);
+  }
+
+  std::string recv(int peerId) override {
+    return q_[peerId].pop();
+  }
+
+  void spawn(std::function<void()> f1, std::function<void()> f2) override {
+    std::array<std::function<void()>, 2> fns = {std::move(f1), std::move(f2)};
+    std::array<std::thread, 2> ts;
+
+    for (int i = 0; i < 2; ++i) {
+      ts[i] = std::thread(fns[i]);
+    }
+
+    for (auto& t : ts) {
+      t.join();
+    }
+  }
+
+ private:
+  std::array<tensorpipe::Queue<std::string>, 2> q_;
+};
+
+class ProcessPeerGroup : public PeerGroup {
+ public:
+  void send(int peerId, const std::string& str) override {
+    uint64_t len = str.length();
+
+    int ret;
+
+    ret = write(pipefd_[peerId][1], &len, sizeof(len));
+    TP_THROW_SYSTEM_IF(ret < 0, errno) << "Failed to write to pipe";
+    EXPECT_EQ(sizeof(len), ret);
+
+    ret = write(pipefd_[peerId][1], str.c_str(), len);
+    TP_THROW_SYSTEM_IF(ret < 0, errno) << "Failed to write to pipe";
+    EXPECT_EQ(len, ret);
+  }
+
+  std::string recv(int peerId) override {
+    int ret;
+
+    uint64_t len;
+    ret = read(pipefd_[peerId][0], &len, sizeof(len));
+    TP_THROW_SYSTEM_IF(ret < 0, errno) << "Failed to read from pipe";
+    EXPECT_EQ(sizeof(len), ret);
+
+    std::string str(len, 0);
+    ret = read(pipefd_[peerId][0], &str[0], len);
+    TP_THROW_SYSTEM_IF(ret < 0, errno) << "Failed to read from pipe";
+    EXPECT_EQ(len, ret);
+
+    return str;
+  }
+
+  void spawn(std::function<void()> f1, std::function<void()> f2) override {
+    std::array<std::function<void()>, 2> fns = {std::move(f1), std::move(f2)};
+    std::array<pid_t, 2> pids = {-1, -1};
+
+    for (int i = 0; i < 2; ++i) {
+      TP_THROW_SYSTEM_IF(pipe(pipefd_[i].data()) < 0, errno)
+          << "Failed to create pipe";
+    }
+
+    for (int i = 0; i < 2; ++i) {
+      pids[i] = fork();
+      TP_THROW_SYSTEM_IF(pids[i] < 0, errno) << "Failed to fork";
+      if (pids[i] == 0) {
+        // Close writing end of our pipe.
+        TP_THROW_SYSTEM_IF(close(pipefd_[i][1]) < 0, errno)
+            << "Failed to close fd";
+        // Close reading end of other pipe.
+        TP_THROW_SYSTEM_IF(close(pipefd_[1 - i][0]) < 0, errno)
+            << "Failed to close fd";
+
+        fns[i]();
+
+        std::exit(testing::Test::HasFailure());
+      } else {
+        // TODO: Print child PID.
+      }
+    }
+
+    // Close all pipes in parent process.
+    for (int i = 0; i < 2; ++i) {
+      for (int j = 0; j < 2; ++j) {
+        TP_THROW_SYSTEM_IF(close(pipefd_[i][j]) < 0, errno)
+            << "Failed to close fd";
+      }
+    }
+
+    for (int i = 0; i < 2; ++i) {
+      int status;
+      TP_THROW_SYSTEM_IF(waitpid(-1, &status, 0) < 0, errno)
+          << "Failed to wait for child process";
+      EXPECT_TRUE(WIFEXITED(status));
+      const int exit_status = WEXITSTATUS(status);
+      EXPECT_EQ(0, exit_status);
+    }
+  }
+
+ private:
+  std::array<std::array<int, 2>, 2> pipefd_;
+};

--- a/tensorpipe/test/transport/connection_test.cc
+++ b/tensorpipe/test/transport/connection_test.cc
@@ -18,49 +18,38 @@ using namespace tensorpipe::transport;
 TEST_P(TransportTest, Connection_Initialization) {
   constexpr size_t numBytes = 13;
   std::array<char, numBytes> garbage;
-  std::promise<void> writeCompletedProm;
-  std::promise<void> readCompletedProm;
-  std::future<void> writeCompletedFuture = writeCompletedProm.get_future();
-  std::future<void> readCompletedFuture = readCompletedProm.get_future();
 
-  this->testConnection(
+  testConnection(
       [&](std::shared_ptr<Connection> conn) {
-        this->doRead(
+        doRead(
             conn,
-            [&, conn](
-                const Error& error, const void* /* unused */, size_t len) {
+            [&](const Error& error, const void* /* unused */, size_t len) {
               ASSERT_FALSE(error) << error.what();
               ASSERT_EQ(len, garbage.size());
-              readCompletedProm.set_value();
+              peers_->done(PeerGroup::kServer);
             });
-        writeCompletedFuture.wait();
-        readCompletedFuture.wait();
+        peers_->join(PeerGroup::kServer);
       },
       [&](std::shared_ptr<Connection> conn) {
-        this->doWrite(
-            conn,
-            garbage.data(),
-            garbage.size(),
-            [&, conn](const Error& error) {
-              ASSERT_FALSE(error) << error.what();
-              writeCompletedProm.set_value();
-            });
-        writeCompletedFuture.wait();
-        readCompletedFuture.wait();
+        doWrite(conn, garbage.data(), garbage.size(), [&](const Error& error) {
+          ASSERT_FALSE(error) << error.what();
+          peers_->done(PeerGroup::kClient);
+        });
+        peers_->join(PeerGroup::kClient);
       });
 }
 
 TEST_P(TransportTest, Connection_InitializationError) {
   int numRequests = 10;
 
-  this->testConnection(
+  testConnection(
       [&](std::shared_ptr<Connection> /* unused */) {
         // Closes connection
       },
       [&](std::shared_ptr<Connection> conn) {
         for (int i = 0; i < numRequests; i++) {
           std::promise<void> readCompletedProm;
-          this->doRead(
+          doRead(
               conn,
               [&, conn](
                   const Error& error,
@@ -76,7 +65,7 @@ TEST_P(TransportTest, Connection_InitializationError) {
 
 // Disabled because no one really knows what this test was meant to check.
 TEST_P(TransportTest, DISABLED_Connection_DestroyConnectionFromCallback) {
-  this->testConnection(
+  testConnection(
       [&](std::shared_ptr<Connection> /* unused */) {
         // Closes connection
       },
@@ -87,7 +76,7 @@ TEST_P(TransportTest, DISABLED_Connection_DestroyConnectionFromCallback) {
         // the only instance we have from the callback itself. This
         // tests that the transport keeps the connection alive as long
         // as it's executing a callback.
-        this->doRead(
+        doRead(
             conn,
             [conn](
                 const Error& /* unused */,
@@ -102,22 +91,17 @@ TEST_P(TransportTest, DISABLED_Connection_DestroyConnectionFromCallback) {
 
 TEST_P(TransportTest, Connection_ProtobufWrite) {
   constexpr size_t kSize = 0x42;
-  std::promise<void> writeCompletedProm;
-  std::promise<void> readCompletedProm;
-  std::future<void> writeCompletedFuture = writeCompletedProm.get_future();
-  std::future<void> readCompletedFuture = readCompletedProm.get_future();
 
-  this->testConnection(
+  testConnection(
       [&](std::shared_ptr<Connection> conn) {
         auto message = std::make_shared<
             tensorpipe::proto::MessageDescriptor::PayloadDescriptor>();
         conn->read(*message, [&, conn, message](const Error& error) {
           ASSERT_FALSE(error) << error.what();
           ASSERT_EQ(message->size_in_bytes(), kSize);
-          readCompletedProm.set_value();
+          peers_->done(PeerGroup::kServer);
         });
-        writeCompletedFuture.wait();
-        readCompletedFuture.wait();
+        peers_->join(PeerGroup::kServer);
       },
       [&](std::shared_ptr<Connection> conn) {
         auto message = std::make_shared<
@@ -125,10 +109,9 @@ TEST_P(TransportTest, Connection_ProtobufWrite) {
         message->set_size_in_bytes(kSize);
         conn->write(*message, [&, conn, message](const Error& error) {
           ASSERT_FALSE(error) << error.what();
-          writeCompletedProm.set_value();
+          peers_->done(PeerGroup::kClient);
         });
-        writeCompletedFuture.wait();
-        readCompletedFuture.wait();
+        peers_->join(PeerGroup::kClient);
       });
 }
 
@@ -140,34 +123,26 @@ TEST_P(TransportTest, Connection_QueueWritesBeforeReads) {
   for (int i = 0; i < numMsg; i++) {
     msg[i] = std::string(kMsgSize, static_cast<char>(i));
   }
-  std::promise<void> writeScheduledProm;
-  std::promise<void> writeCompletedProm;
-  std::promise<void> readCompletedProm;
-  std::future<void> writeCompletedFuture = writeCompletedProm.get_future();
-  std::future<void> readCompletedFuture = readCompletedProm.get_future();
 
-  this->testConnection(
+  testConnection(
       [&](std::shared_ptr<Connection> conn) {
         for (int i = 0; i < numMsg; i++) {
-          this->doWrite(
+          doWrite(
               conn,
               msg[i].c_str(),
               msg[i].length(),
               [&, conn, i](const Error& error) {
                 ASSERT_FALSE(error) << error.what();
                 if (i == numMsg - 1) {
-                  writeCompletedProm.set_value();
+                  peers_->done(PeerGroup::kServer);
                 }
               });
         }
-        writeScheduledProm.set_value();
-        writeCompletedFuture.wait();
-        readCompletedFuture.wait();
+        peers_->join(PeerGroup::kServer);
       },
       [&](std::shared_ptr<Connection> conn) {
-        writeScheduledProm.get_future().get();
         for (int i = 0; i < numMsg; i++) {
-          this->doRead(
+          doRead(
               conn,
               [&, conn, i](const Error& error, const void* data, size_t len) {
                 ASSERT_FALSE(error) << error.what();
@@ -179,12 +154,11 @@ TEST_P(TransportTest, Connection_QueueWritesBeforeReads) {
                                           << " of " << msg[i].length();
                 }
                 if (i == numMsg - 1) {
-                  readCompletedProm.set_value();
+                  peers_->done(PeerGroup::kClient);
                 }
               });
         }
-        writeCompletedFuture.wait();
-        readCompletedFuture.wait();
+        peers_->join(PeerGroup::kClient);
       });
 }
 
@@ -192,19 +166,15 @@ TEST_P(TransportTest, Connection_QueueWritesBeforeReads) {
 TEST_P(TransportTest, DISABLED_Connection_EmptyBuffer) {
   constexpr size_t numBytes = 13;
   std::array<char, numBytes> garbage;
-  std::promise<void> writeCompletedProm;
-  std::promise<void> readCompletedProm;
-  std::future<void> writeCompletedFuture = writeCompletedProm.get_future();
-  std::future<void> readCompletedFuture = readCompletedProm.get_future();
   int ioNum = 100;
 
-  this->testConnection(
+  testConnection(
       [&](std::shared_ptr<Connection> conn) {
         std::atomic<int> n(ioNum);
         for (int i = 0; i < ioNum; i++) {
           if (i % 2 == 0) {
             // Empty buffer
-            this->doRead(
+            doRead(
                 conn,
                 nullptr,
                 0,
@@ -213,52 +183,52 @@ TEST_P(TransportTest, DISABLED_Connection_EmptyBuffer) {
                   ASSERT_EQ(len, 0);
                   ASSERT_EQ(ptr, nullptr);
                   if (--n == 0) {
-                    readCompletedProm.set_value();
+                    peers_->done(PeerGroup::kServer);
                   }
                 });
           } else {
             // Garbage buffer
-            this->doRead(
+            doRead(
                 conn,
                 [&, conn](
                     const Error& error, const void* /* unused */, size_t len) {
                   ASSERT_FALSE(error) << error.what();
                   ASSERT_EQ(len, garbage.size());
                   if (--n == 0) {
-                    readCompletedProm.set_value();
+                    peers_->done(PeerGroup::kServer);
                   }
                 });
           }
         }
-        writeCompletedFuture.wait();
-        readCompletedFuture.wait();
+
+        peers_->join(PeerGroup::kServer);
       },
       [&](std::shared_ptr<Connection> conn) {
         std::atomic<int> n(ioNum);
         for (int i = 0; i < ioNum; i++) {
           if ((i & 1) == 0) {
             // Empty buffer
-            this->doWrite(conn, nullptr, 0, [&, conn](const Error& error) {
+            doWrite(conn, nullptr, 0, [&, conn](const Error& error) {
               ASSERT_FALSE(error) << error.what();
               if (--n == 0) {
-                writeCompletedProm.set_value();
+                peers_->done(PeerGroup::kClient);
               }
             });
           } else {
             // Garbage buffer
-            this->doWrite(
+            doWrite(
                 conn,
                 garbage.data(),
                 garbage.size(),
                 [&, conn](const Error& error) {
                   ASSERT_FALSE(error) << error.what();
                   if (--n == 0) {
-                    writeCompletedProm.set_value();
+                    peers_->done(PeerGroup::kClient);
                   }
                 });
           }
         }
-        writeCompletedFuture.wait();
-        readCompletedFuture.wait();
+
+        peers_->join(PeerGroup::kClient);
       });
 }

--- a/tensorpipe/test/transport/shm/connection_test.cc
+++ b/tensorpipe/test/transport/shm/connection_test.cc
@@ -30,14 +30,10 @@ TEST_P(ShmTransportTest, Chunking) {
   const int kMsgSize = 5 * kBufferSize;
   std::string srcBuf(kMsgSize, 0x42);
   auto dstBuf = std::make_unique<char[]>(kMsgSize);
-  std::promise<void> writeCompletedProm;
-  std::promise<void> readCompletedProm;
-  std::future<void> writeCompletedFuture = writeCompletedProm.get_future();
-  std::future<void> readCompletedFuture = readCompletedProm.get_future();
 
-  this->testConnection(
+  testConnection(
       [&](std::shared_ptr<Connection> conn) {
-        this->doRead(
+        doRead(
             conn,
             dstBuf.get(),
             kMsgSize,
@@ -48,22 +44,20 @@ TEST_P(ShmTransportTest, Chunking) {
               for (int i = 0; i < kMsgSize; ++i) {
                 ASSERT_EQ(dstBuf[i], srcBuf[i]);
               }
-              readCompletedProm.set_value();
+              peers_->done(PeerGroup::kServer);
             });
-        writeCompletedFuture.wait();
-        readCompletedFuture.wait();
+        peers_->join(PeerGroup::kServer);
       },
       [&](std::shared_ptr<Connection> conn) {
-        this->doWrite(
+        doWrite(
             conn,
             srcBuf.c_str(),
             srcBuf.length(),
             [&, conn](const Error& error) {
               ASSERT_FALSE(error) << error.what();
-              writeCompletedProm.set_value();
+              peers_->done(PeerGroup::kClient);
             });
-        writeCompletedFuture.wait();
-        readCompletedFuture.wait();
+        peers_->join(PeerGroup::kClient);
       });
 }
 
@@ -71,33 +65,26 @@ TEST_P(ShmTransportTest, ChunkingImplicitRead) {
   // This is larger than the default ring buffer size.
   const size_t kMsgSize = 5 * kBufferSize;
   std::string msg(kMsgSize, 0x42);
-  std::promise<void> writeCompletedProm;
-  std::promise<void> readCompletedProm;
-  std::future<void> writeCompletedFuture = writeCompletedProm.get_future();
-  std::future<void> readCompletedFuture = readCompletedProm.get_future();
 
-  this->testConnection(
+  testConnection(
       [&](std::shared_ptr<Connection> conn) {
-        this->doRead(
+        doRead(
             conn, [&, conn](const Error& error, const void* ptr, size_t len) {
               ASSERT_FALSE(error) << error.what();
               ASSERT_EQ(len, kMsgSize);
               for (int i = 0; i < kMsgSize; ++i) {
                 ASSERT_EQ(static_cast<const uint8_t*>(ptr)[i], msg[i]);
               }
-              readCompletedProm.set_value();
+              peers_->done(PeerGroup::kServer);
             });
-        writeCompletedFuture.wait();
-        readCompletedFuture.wait();
+        peers_->join(PeerGroup::kServer);
       },
       [&](std::shared_ptr<Connection> conn) {
-        this->doWrite(
-            conn, msg.c_str(), msg.length(), [&, conn](const Error& error) {
-              ASSERT_FALSE(error) << error.what();
-              writeCompletedProm.set_value();
-            });
-        writeCompletedFuture.wait();
-        readCompletedFuture.wait();
+        doWrite(conn, msg.c_str(), msg.length(), [&, conn](const Error& error) {
+          ASSERT_FALSE(error) << error.what();
+          peers_->done(PeerGroup::kClient);
+        });
+        peers_->join(PeerGroup::kClient);
       });
 }
 
@@ -106,58 +93,50 @@ TEST_P(ShmTransportTest, QueueWrites) {
   // the same time.
   constexpr int numMsg = 2;
   constexpr size_t numBytes = (3 * kBufferSize) / 4;
+  const std::string kReady = "ready";
   std::array<char, numBytes> garbage;
-  std::promise<void> writeScheduledProm;
-  std::promise<void> writeCompletedProm;
-  std::promise<void> readCompletedProm;
-  std::future<void> writeCompletedFuture = writeCompletedProm.get_future();
-  std::future<void> readCompletedFuture = readCompletedProm.get_future();
 
-  this->testConnection(
+  testConnection(
       [&](std::shared_ptr<Connection> conn) {
-        writeScheduledProm.get_future().get();
+        // Wait for peer to queue up writes before attempting to read
+        EXPECT_EQ(kReady, peers_->recv(PeerGroup::kServer));
+
         for (int i = 0; i < numMsg; ++i) {
-          this->doRead(
+          doRead(
               conn,
               [&, conn, i](const Error& error, const void* ptr, size_t len) {
                 ASSERT_FALSE(error) << error.what();
                 ASSERT_EQ(len, numBytes);
                 if (i == numMsg - 1) {
-                  readCompletedProm.set_value();
+                  peers_->done(PeerGroup::kServer);
                 }
               });
         }
-        writeCompletedFuture.wait();
-        readCompletedFuture.wait();
+        peers_->join(PeerGroup::kServer);
       },
       [&](std::shared_ptr<Connection> conn) {
         for (int i = 0; i < numMsg; ++i) {
-          this->doWrite(
+          doWrite(
               conn,
               garbage.data(),
               garbage.size(),
               [&, conn, i](const Error& error) {
                 ASSERT_FALSE(error) << error.what();
                 if (i == numMsg - 1) {
-                  writeCompletedProm.set_value();
+                  peers_->done(PeerGroup::kClient);
                 }
               });
         }
-        writeScheduledProm.set_value();
-        writeCompletedFuture.wait();
-        readCompletedFuture.wait();
+        peers_->send(PeerGroup::kServer, kReady);
+        peers_->join(PeerGroup::kClient);
       });
 }
 
 TEST_P(ShmTransportTest, ProtobufWriteWrapAround) {
   constexpr int numMsg = 2;
   constexpr size_t kSize = (3 * kBufferSize) / 4;
-  std::promise<void> writeCompletedProm;
-  std::promise<void> readCompletedProm;
-  std::future<void> writeCompletedFuture = writeCompletedProm.get_future();
-  std::future<void> readCompletedFuture = readCompletedProm.get_future();
 
-  this->testConnection(
+  testConnection(
       [&](std::shared_ptr<Connection> conn) {
         for (int i = 0; i < numMsg; ++i) {
           auto message =
@@ -166,12 +145,11 @@ TEST_P(ShmTransportTest, ProtobufWriteWrapAround) {
             ASSERT_FALSE(error) << error.what();
             ASSERT_EQ(message->domain_descriptor().length(), kSize);
             if (i == numMsg - 1) {
-              readCompletedProm.set_value();
+              peers_->done(PeerGroup::kServer);
             }
           });
         }
-        writeCompletedFuture.wait();
-        readCompletedFuture.wait();
+        peers_->join(PeerGroup::kServer);
       },
       [&](std::shared_ptr<Connection> conn) {
         for (int i = 0; i < numMsg; ++i) {
@@ -181,12 +159,11 @@ TEST_P(ShmTransportTest, ProtobufWriteWrapAround) {
           conn->write(*message, [&, conn, message, i](const Error& error) {
             ASSERT_FALSE(error) << error.what();
             if (i == numMsg - 1) {
-              writeCompletedProm.set_value();
+              peers_->done(PeerGroup::kClient);
             }
           });
         }
-        writeCompletedFuture.wait();
-        readCompletedFuture.wait();
+        peers_->join(PeerGroup::kClient);
       });
 }
 


### PR DESCRIPTION
Introduce `PeerGroup` class, along with its subclasses `ThreadPeerGroup` and `ProcessPeerGroup`. Those abstract spawning/joining a group of peers, as well as communication and synchronization among them.

The rationale behind this is to pave the way for testing CUDA channels.