### PR TITLE
Add a channel that multiplexes on transports

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,4 @@
 [submodule "third_party/libuv"]
 	path = third_party/libuv
 	url = https://github.com/libuv/libuv.git
+	branch = v1.x

--- a/cmake/pytorch.cmake
+++ b/cmake/pytorch.cmake
@@ -94,6 +94,14 @@ if(TP_ENABLE_CMA)
     tensorpipe/proto/channel/cma.proto)
 endif()
 
+### mpt
+
+list(APPEND TENSORPIPE_PUBLIC_HEADERS tensorpipe/channel/mpt/context.h)
+list(APPEND TENSORPIPE_SRC
+  tensorpipe/channel/mpt/channel.cc
+  tensorpipe/channel/mpt/context.cc
+  tensorpipe/proto/channel/mpt.proto)
+
 
 ## Transports
 

--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -89,6 +89,14 @@ if(TP_ENABLE_CMA)
   target_compile_definitions(tensorpipe INTERFACE TP_ENABLE_CMA)
 endif()
 
+### mpt
+
+list(APPEND TENSORPIPE_PUBLIC_HEADERS channel/mpt/context.h)
+target_sources(tensorpipe PRIVATE
+  channel/mpt/channel.cc
+  channel/mpt/context.cc
+  proto/channel/mpt.proto)
+
 
 ## Transports
 

--- a/tensorpipe/channel/basic/channel.cc
+++ b/tensorpipe/channel/basic/channel.cc
@@ -65,6 +65,8 @@ class Channel::Impl : public std::enable_shared_from_this<Channel::Impl> {
       size_t length,
       TRecvCallback callback);
 
+  void setIdFromLoop_(std::string id);
+
   void initFromLoop_();
 
   void closeFromLoop_();
@@ -280,8 +282,13 @@ void Channel::setId(std::string id) {
 }
 
 void Channel::Impl::setId(std::string id) {
+  loop_.deferToLoop(
+      [this, id{std::move(id)}]() mutable { setIdFromLoop_(std::move(id)); });
+}
+
+void Channel::Impl::setIdFromLoop_(std::string id) {
+  TP_DCHECK(loop_.inLoop());
   TP_VLOG(4) << "Channel " << id_ << " was renamed to " << id;
-  // FIXME Should we defer this to the loop?
   id_ = std::move(id);
 }
 

--- a/tensorpipe/channel/basic/context.cc
+++ b/tensorpipe/channel/basic/context.cc
@@ -146,6 +146,7 @@ void Context::setId(std::string id) {
 }
 
 void Context::Impl::setId(std::string id) {
+  TP_VLOG(4) << "Channel context " << id_ << " was renamed to " << id;
   id_ = std::move(id);
 }
 

--- a/tensorpipe/channel/cma/channel.cc
+++ b/tensorpipe/channel/cma/channel.cc
@@ -78,6 +78,8 @@ class Channel::Impl : public std::enable_shared_from_this<Channel::Impl> {
       size_t length,
       TRecvCallback callback);
 
+  void setIdFromLoop_(std::string id);
+
   void closeFromLoop_();
 
   void setError_(Error error);
@@ -311,8 +313,13 @@ void Channel::setId(std::string id) {
 }
 
 void Channel::Impl::setId(std::string id) {
+  loop_.deferToLoop(
+      [this, id{std::move(id)}]() mutable { setIdFromLoop_(std::move(id)); });
+}
+
+void Channel::Impl::setIdFromLoop_(std::string id) {
+  TP_DCHECK(loop_.inLoop());
   TP_VLOG(4) << "Channel " << id_ << " was renamed to " << id;
-  // FIXME Should we defer this to the loop?
   id_ = std::move(id);
 }
 

--- a/tensorpipe/channel/cma/context.cc
+++ b/tensorpipe/channel/cma/context.cc
@@ -176,6 +176,7 @@ void Context::setId(std::string id) {
 }
 
 void Context::Impl::setId(std::string id) {
+  TP_VLOG(4) << "Channel context " << id_ << " was renamed to " << id;
   id_ = std::move(id);
 }
 

--- a/tensorpipe/channel/error.cc
+++ b/tensorpipe/channel/error.cc
@@ -38,6 +38,10 @@ std::string EOFError::what() const {
   return "eof";
 }
 
+std::string ContextClosedError::what() const {
+  return "context closed";
+}
+
 std::string ChannelClosedError::what() const {
   return "channel closed";
 }

--- a/tensorpipe/channel/error.h
+++ b/tensorpipe/channel/error.h
@@ -58,6 +58,13 @@ class EOFError final : public BaseError {
   std::string what() const override;
 };
 
+class ContextClosedError final : public BaseError {
+ public:
+  ContextClosedError() {}
+
+  std::string what() const override;
+};
+
 class ChannelClosedError final : public BaseError {
  public:
   ChannelClosedError() {}

--- a/tensorpipe/channel/mpt/channel.cc
+++ b/tensorpipe/channel/mpt/channel.cc
@@ -1,0 +1,615 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/channel/mpt/channel.h>
+
+#include <algorithm>
+#include <sstream>
+
+#include <tensorpipe/channel/error.h>
+#include <tensorpipe/channel/helpers.h>
+#include <tensorpipe/common/callback.h>
+#include <tensorpipe/common/defs.h>
+#include <tensorpipe/common/error_macros.h>
+#include <tensorpipe/proto/channel/mpt.pb.h>
+#include <tensorpipe/transport/context.h>
+#include <tensorpipe/transport/error.h>
+#include <tensorpipe/transport/listener.h>
+
+namespace tensorpipe {
+namespace channel {
+namespace mpt {
+
+namespace {
+
+// State capturing a single send operation.
+struct SendOperation {
+  const uint64_t sequenceNumber;
+  const void* ptr;
+  size_t length;
+  size_t lengthBeingWritten;
+  Channel::TSendCallback callback;
+};
+
+// State capturing a single recv operation.
+struct RecvOperation {
+  const uint64_t sequenceNumber;
+  void* ptr;
+  size_t length;
+  size_t lengthBeingRead;
+  Channel::TRecvCallback callback;
+};
+
+} // namespace
+
+class Channel::Impl : public std::enable_shared_from_this<Channel::Impl> {
+ public:
+  Impl(
+      std::shared_ptr<Context::PrivateIface> context,
+      std::shared_ptr<transport::Connection> connection,
+      Endpoint endpoint,
+      uint64_t numLanes,
+      std::string id);
+
+  // Called by the channel's constructor.
+  void init();
+
+  void send(
+      const void* ptr,
+      size_t length,
+      TDescriptorCallback descriptorCallback,
+      TSendCallback callback);
+
+  void recv(
+      TDescriptor descriptor,
+      void* ptr,
+      size_t length,
+      TRecvCallback callback);
+
+  // Tell the channel what its identifier is.
+  void setId(std::string id);
+
+  void close();
+
+ private:
+  enum State {
+    UNINITIALIZED,
+    CLIENT_READING_HELLO,
+    SERVER_ACCEPTING_LANES,
+    ESTABLISHED,
+  };
+
+  void initFromLoop_();
+
+  void sendFromLoop_(
+      const void* ptr,
+      size_t length,
+      TDescriptorCallback descriptorCallback,
+      TSendCallback callback);
+
+  void recvFromLoop_(
+      TDescriptor descriptor,
+      void* ptr,
+      size_t length,
+      TRecvCallback callback);
+
+  void setIdFromLoop_(std::string id);
+
+  void closeFromLoop_();
+
+  // Called when client reads the server's hello on backbone connection
+  void onClientReadHelloOnConnection_(const proto::Packet& pbPacketIn);
+
+  // Called when server accepts new client connection for lane
+  void onServerAcceptOfLane_(
+      uint64_t laneIdx,
+      std::shared_ptr<transport::Connection> connection);
+
+  // Called when channel endpoint has all lanes established, and processes
+  // operations that were performed in the meantime and queued.
+  void startSendingAndReceivingUponEstablishingChannel_();
+
+  // Performs the chunking and the writing of one send operation.
+  void sendOperation_(SendOperation& op);
+
+  // Performs the chunking and the reading of one recv operation.
+  void recvOperation_(RecvOperation& op);
+
+  // Called when the write of one chunk of a send operation has been completed.
+  void onWriteOfPayload_(SendOperation& op, uint64_t length);
+
+  // Called when the read of one chunk of a recv operation has been completed.
+  void onReadOfPayload_(RecvOperation& op, uint64_t length);
+
+  void setError_(Error error);
+
+  // Helper function to process transport error.
+  // Shared between read and write callback entry points.
+  void handleError_();
+
+  std::shared_ptr<Context::PrivateIface> context_;
+  std::shared_ptr<transport::Connection> connection_;
+  Endpoint endpoint_;
+  State state_{UNINITIALIZED};
+  uint64_t numLanes_;
+  uint64_t numLanesBeingAccepted_{0};
+  std::vector<std::shared_ptr<transport::Connection>> lanes_;
+  std::unordered_map<uint64_t, uint64_t> laneRegistrationIds_;
+
+  // Increasing identifier for send operations.
+  uint64_t nextTensorBeingSent_{0};
+
+  // Increasing identifier for recv operations.
+  uint64_t nextTensorBeingReceived_{0};
+
+  std::deque<SendOperation> sendOperations_;
+  std::deque<RecvOperation> recvOperations_;
+
+  // An identifier for the channel, composed of the identifier for the context,
+  // combined with an increasing sequence number. It will only be used for
+  // logging and debugging purposes.
+  std::string id_;
+
+  OnDemandLoop loop_;
+  Error error_{Error::kSuccess};
+  LazyCallbackWrapper<Impl> lazyCallbackWrapper_{*this, this->loop_};
+  EagerCallbackWrapper<Impl> eagerCallbackWrapper_{*this, this->loop_};
+  ClosingReceiver closingReceiver_;
+
+  // For some odd reason it seems we need to use a qualified name here...
+  template <typename T>
+  friend class tensorpipe::LazyCallbackWrapper;
+  template <typename T>
+  friend class tensorpipe::EagerCallbackWrapper;
+};
+
+Channel::Channel(
+    ConstructorToken /* unused */,
+    std::shared_ptr<Context::PrivateIface> context,
+    std::shared_ptr<transport::Connection> connection,
+    Endpoint endpoint,
+    uint64_t numLanes,
+    std::string id)
+    : impl_(std::make_shared<Impl>(
+          std::move(context),
+          std::move(connection),
+          endpoint,
+          numLanes,
+          std::move(id))) {
+  impl_->init();
+}
+
+Channel::Impl::Impl(
+    std::shared_ptr<Context::PrivateIface> context,
+    std::shared_ptr<transport::Connection> connection,
+    Endpoint endpoint,
+    uint64_t numLanes,
+    std::string id)
+    : context_(std::move(context)),
+      connection_(std::move(connection)),
+      endpoint_(endpoint),
+      numLanes_(numLanes),
+      lanes_(numLanes_),
+      id_(std::move(id)),
+      closingReceiver_(context_, context_->getClosingEmitter()) {}
+
+void Channel::Impl::init() {
+  loop_.deferToLoop([this]() { initFromLoop_(); });
+}
+
+void Channel::Impl::initFromLoop_() {
+  TP_DCHECK(loop_.inLoop());
+  closingReceiver_.activate(*this);
+
+  TP_DCHECK_EQ(state_, UNINITIALIZED);
+  if (endpoint_ == Endpoint::kConnect) {
+    state_ = CLIENT_READING_HELLO;
+    auto packet = std::make_shared<proto::Packet>();
+    TP_VLOG(6) << "Channel " << id_ << " reading proto (server hello)";
+    connection_->read(*packet, lazyCallbackWrapper_([packet](Impl& impl) {
+      TP_VLOG(6) << "Channel " << impl.id_
+                 << " done reading proto (server hello)";
+      impl.onClientReadHelloOnConnection_(*packet);
+    }));
+  } else if (endpoint_ == Endpoint::kListen) {
+    state_ = SERVER_ACCEPTING_LANES;
+    const std::vector<std::string>& addresses = context_->addresses();
+    TP_DCHECK_EQ(addresses.size(), numLanes_);
+    auto packet = std::make_shared<proto::Packet>();
+    proto::ServerHello* pbServerHello = packet->mutable_server_hello();
+    for (uint64_t laneIdx = 0; laneIdx < numLanes_; ++laneIdx) {
+      proto::LaneAdvertisement* pbLaneAdvertisement =
+          pbServerHello->add_lane_advertisements();
+      pbLaneAdvertisement->set_address(addresses[laneIdx]);
+      TP_VLOG(6) << "Channel " << id_ << " requesting connection (for lane "
+                 << laneIdx << ")";
+      uint64_t token = context_->registerConnectionRequest(
+          laneIdx,
+          lazyCallbackWrapper_(
+              [laneIdx](
+                  Impl& impl,
+                  std::shared_ptr<transport::Connection> connection) {
+                TP_VLOG(6) << "Channel " << impl.id_
+                           << " done requesting connection (for lane "
+                           << laneIdx << ")";
+                impl.onServerAcceptOfLane_(laneIdx, std::move(connection));
+              }));
+      laneRegistrationIds_.emplace(laneIdx, token);
+      pbLaneAdvertisement->set_registration_id(token);
+      numLanesBeingAccepted_++;
+    }
+    TP_VLOG(6) << "Channel " << id_ << " writing proto (server hello)";
+    connection_->write(*packet, lazyCallbackWrapper_([packet](Impl& impl) {
+      TP_VLOG(6) << "Channel " << impl.id_
+                 << " done writing proto (server hello)";
+    }));
+  } else {
+    TP_THROW_ASSERT() << "unknown endpoint";
+  }
+}
+
+void Channel::send(
+    const void* ptr,
+    size_t length,
+    TDescriptorCallback descriptorCallback,
+    TSendCallback callback) {
+  impl_->send(ptr, length, std::move(descriptorCallback), std::move(callback));
+}
+
+void Channel::Impl::send(
+    const void* ptr,
+    size_t length,
+    TDescriptorCallback descriptorCallback,
+    TSendCallback callback) {
+  loop_.deferToLoop([this,
+                     ptr,
+                     length,
+                     descriptorCallback{std::move(descriptorCallback)},
+                     callback{std::move(callback)}]() mutable {
+    sendFromLoop_(
+        ptr, length, std::move(descriptorCallback), std::move(callback));
+  });
+}
+
+void Channel::Impl::sendFromLoop_(
+    const void* ptr,
+    size_t length,
+    TDescriptorCallback descriptorCallback,
+    TSendCallback callback) {
+  TP_DCHECK(loop_.inLoop());
+
+  const uint64_t sequenceNumber = nextTensorBeingSent_++;
+  TP_VLOG(4) << "Channel " << id_ << " received a send request (#"
+             << sequenceNumber << ")";
+
+  descriptorCallback = [this,
+                        sequenceNumber,
+                        descriptorCallback{std::move(descriptorCallback)}](
+                           const Error& error, TDescriptor descriptor) {
+    // There is no requirement for the channel to invoke callbacks in order.
+    TP_VLOG(4) << "Channel " << id_ << " is calling a descriptor callback (#"
+               << sequenceNumber << ")";
+    descriptorCallback(error, std::move(descriptor));
+    TP_VLOG(4) << "Channel " << id_ << " done calling a descriptor callback (#"
+               << sequenceNumber << ")";
+  };
+
+  callback = [this, sequenceNumber, callback{std::move(callback)}](
+                 const Error& error) {
+    // There is no requirement for the channel to invoke callbacks in order.
+    TP_VLOG(4) << "Channel " << id_ << " is calling a send callback (#"
+               << sequenceNumber << ")";
+    callback(error);
+    TP_VLOG(4) << "Channel " << id_ << " done calling a send callback (#"
+               << sequenceNumber << ")";
+  };
+
+  if (error_) {
+    descriptorCallback(error_, std::string());
+    callback(error_);
+    return;
+  }
+
+  sendOperations_.emplace_back(
+      SendOperation{sequenceNumber, ptr, length, length, std::move(callback)});
+  SendOperation& op = sendOperations_.back();
+
+  if (state_ == ESTABLISHED) {
+    sendOperation_(op);
+  }
+
+  descriptorCallback(Error::kSuccess, std::string());
+}
+
+void Channel::recv(
+    TDescriptor descriptor,
+    void* ptr,
+    size_t length,
+    TRecvCallback callback) {
+  impl_->recv(std::move(descriptor), ptr, length, std::move(callback));
+}
+
+void Channel::Impl::recv(
+    TDescriptor descriptor,
+    void* ptr,
+    size_t length,
+    TRecvCallback callback) {
+  loop_.deferToLoop([this,
+                     descriptor{std::move(descriptor)},
+                     ptr,
+                     length,
+                     callback{std::move(callback)}]() mutable {
+    recvFromLoop_(std::move(descriptor), ptr, length, std::move(callback));
+  });
+}
+
+void Channel::Impl::recvFromLoop_(
+    TDescriptor descriptor,
+    void* ptr,
+    size_t length,
+    TRecvCallback callback) {
+  TP_DCHECK(loop_.inLoop());
+
+  const uint64_t sequenceNumber = nextTensorBeingReceived_++;
+  TP_VLOG(4) << "Channel " << id_ << " received a recv request (#"
+             << sequenceNumber << ")";
+
+  callback = [this, sequenceNumber, callback{std::move(callback)}](
+                 const Error& error) {
+    // There is no requirement for the channel to invoke callbacks in order.
+    TP_VLOG(4) << "Channel " << id_ << " is calling a recv callback (#"
+               << sequenceNumber << ")";
+    callback(error);
+    TP_VLOG(4) << "Channel " << id_ << " done calling a recv callback (#"
+               << sequenceNumber << ")";
+  };
+
+  if (error_) {
+    callback(error_);
+    return;
+  }
+
+  TP_DCHECK_EQ(descriptor, std::string());
+
+  recvOperations_.emplace_back(
+      RecvOperation{sequenceNumber, ptr, length, length, std::move(callback)});
+  RecvOperation& op = recvOperations_.back();
+
+  if (state_ == ESTABLISHED) {
+    recvOperation_(op);
+  }
+}
+
+void Channel::setId(std::string id) {
+  impl_->setId(std::move(id));
+}
+
+void Channel::Impl::setId(std::string id) {
+  loop_.deferToLoop(
+      [this, id{std::move(id)}]() mutable { setIdFromLoop_(std::move(id)); });
+}
+
+void Channel::Impl::setIdFromLoop_(std::string id) {
+  TP_DCHECK(loop_.inLoop());
+  TP_VLOG(4) << "Channel " << id_ << " was renamed to " << id;
+  id_ = std::move(id);
+}
+
+void Channel::Impl::onClientReadHelloOnConnection_(
+    const proto::Packet& pbPacketIn) {
+  TP_DCHECK(loop_.inLoop());
+  TP_DCHECK_EQ(state_, CLIENT_READING_HELLO);
+  TP_DCHECK_EQ(pbPacketIn.type_case(), proto::Packet::kServerHello);
+
+  const proto::ServerHello& pbServerHello = pbPacketIn.server_hello();
+  TP_DCHECK_EQ(pbServerHello.lane_advertisements().size(), numLanes_);
+  lanes_.resize(numLanes_);
+  for (uint64_t laneIdx = 0; laneIdx < numLanes_; ++laneIdx) {
+    const proto::LaneAdvertisement& pbLaneAdvertisement =
+        pbServerHello.lane_advertisements().Get(laneIdx);
+    std::shared_ptr<transport::Connection> lane =
+        context_->connect(laneIdx, pbLaneAdvertisement.address());
+    auto pbPacketOut = std::make_shared<proto::Packet>();
+    proto::ClientHello* pbClientHello = pbPacketOut->mutable_client_hello();
+    pbClientHello->set_registration_id(pbLaneAdvertisement.registration_id());
+    TP_VLOG(6) << "Channel " << id_ << " writing proto (client hello) on lane "
+               << laneIdx;
+    lane->write(
+        *pbPacketOut, lazyCallbackWrapper_([laneIdx, pbPacketOut](Impl& impl) {
+          TP_VLOG(6) << "Channel " << impl.id_
+                     << " done writing proto (client hello) on lane "
+                     << laneIdx;
+        }));
+    lanes_[laneIdx] = std::move(lane);
+  }
+
+  state_ = ESTABLISHED;
+  startSendingAndReceivingUponEstablishingChannel_();
+}
+
+void Channel::Impl::onServerAcceptOfLane_(
+    uint64_t laneIdx,
+    std::shared_ptr<transport::Connection> connection) {
+  TP_DCHECK(loop_.inLoop());
+  TP_DCHECK_EQ(state_, SERVER_ACCEPTING_LANES);
+
+  TP_DCHECK(!lanes_[laneIdx]);
+  TP_DCHECK_LT(laneIdx, lanes_.size());
+  lanes_[laneIdx] = std::move(connection);
+  auto laneRegistrationIter = laneRegistrationIds_.find(laneIdx);
+  TP_DCHECK(laneRegistrationIter != laneRegistrationIds_.end());
+  context_->unregisterConnectionRequest(laneRegistrationIter->second);
+  laneRegistrationIds_.erase(laneRegistrationIter);
+  numLanesBeingAccepted_--;
+
+  if (numLanesBeingAccepted_ == 0) {
+    state_ = ESTABLISHED;
+    startSendingAndReceivingUponEstablishingChannel_();
+  }
+}
+
+void Channel::Impl::startSendingAndReceivingUponEstablishingChannel_() {
+  TP_DCHECK(loop_.inLoop());
+  TP_DCHECK_EQ(state_, ESTABLISHED);
+
+  for (SendOperation& op : sendOperations_) {
+    sendOperation_(op);
+  }
+  for (RecvOperation& op : recvOperations_) {
+    recvOperation_(op);
+  }
+}
+
+void Channel::Impl::sendOperation_(SendOperation& op) {
+  TP_DCHECK(loop_.inLoop());
+  TP_DCHECK_EQ(state_, ESTABLISHED);
+
+  for (uint64_t laneIdx = 0; laneIdx < lanes_.size(); laneIdx++) {
+    // Insert "cutpoints" at equally-spaced intervals in the buffer, rounding
+    // them down if they don't end up being at an integer position.
+    uint64_t offsetStart = op.length * laneIdx / lanes_.size();
+    uint64_t offsetEnd = op.length * (laneIdx + 1) / lanes_.size();
+    // As void "has no size" we cannot do pointer arithmetic on it. We need to
+    // temporarily convert the pointer to a type that has a size of 1 byte.
+    const void* ptr = reinterpret_cast<const uint8_t*>(op.ptr) + offsetStart;
+    uint64_t length = offsetEnd - offsetStart;
+
+    // Write payload.
+    TP_VLOG(6) << "Channel " << id_ << " writing payload #" << op.sequenceNumber
+               << " on lane " << laneIdx;
+    lanes_[laneIdx]->write(
+        ptr, length, eagerCallbackWrapper_([&op, laneIdx, length](Impl& impl) {
+          TP_VLOG(6) << "Channel " << impl.id_ << " done writing payload #"
+                     << op.sequenceNumber << " on lane " << laneIdx;
+          impl.onWriteOfPayload_(op, length);
+        }));
+  }
+}
+
+void Channel::Impl::recvOperation_(RecvOperation& op) {
+  TP_DCHECK(loop_.inLoop());
+  TP_DCHECK_EQ(state_, ESTABLISHED);
+
+  for (uint64_t laneIdx = 0; laneIdx < lanes_.size(); laneIdx++) {
+    // Insert "cutpoints" at equally-spaced intervals in the buffer, rounding
+    // them down if they don't end up being at an integer position.
+    uint64_t offsetStart = op.length * laneIdx / lanes_.size();
+    uint64_t offsetEnd = op.length * (laneIdx + 1) / lanes_.size();
+    // As void "has no size" we cannot do pointer arithmetic on it. We need to
+    // temporarily convert the pointer to a type that has a size of 1 byte.
+    void* ptr = reinterpret_cast<uint8_t*>(op.ptr) + offsetStart;
+    uint64_t length = offsetEnd - offsetStart;
+
+    // Read payload.
+    TP_VLOG(6) << "Channel " << id_ << " reading payload #" << op.sequenceNumber
+               << " on lane " << laneIdx;
+    lanes_[laneIdx]->read(
+        ptr,
+        length,
+        eagerCallbackWrapper_(
+            [&op, laneIdx, length](
+                Impl& impl, const void* /* unused */, size_t /* unused */) {
+              TP_VLOG(6) << "Channel " << impl.id_ << " done reading payload #"
+                         << op.sequenceNumber << " on lane " << laneIdx;
+              impl.onReadOfPayload_(op, length);
+            }));
+  }
+}
+
+void Channel::close() {
+  impl_->close();
+}
+
+Channel::~Channel() {
+  close();
+}
+
+void Channel::Impl::close() {
+  loop_.deferToLoop([this]() { closeFromLoop_(); });
+}
+
+void Channel::Impl::closeFromLoop_() {
+  TP_DCHECK(loop_.inLoop());
+  TP_VLOG(4) << "Channel " << id_ << " is closing";
+  setError_(TP_CREATE_ERROR(ChannelClosedError));
+}
+
+void Channel::Impl::onWriteOfPayload_(SendOperation& op, uint64_t length) {
+  TP_DCHECK(loop_.inLoop());
+
+  op.lengthBeingWritten -= length;
+  if (op.lengthBeingWritten > 0) {
+    return;
+  }
+
+  op.callback(error_);
+
+  TP_DCHECK(!sendOperations_.empty());
+  TP_DCHECK(&op == &sendOperations_.front());
+  sendOperations_.pop_front();
+}
+
+void Channel::Impl::onReadOfPayload_(RecvOperation& op, uint64_t length) {
+  TP_DCHECK(loop_.inLoop());
+  TP_DCHECK_EQ(state_, ESTABLISHED);
+
+  op.lengthBeingRead -= length;
+  if (op.lengthBeingRead > 0) {
+    return;
+  }
+
+  op.callback(error_);
+
+  TP_DCHECK(!recvOperations_.empty());
+  TP_DCHECK(&op == &recvOperations_.front());
+  recvOperations_.pop_front();
+}
+
+void Channel::Impl::setError_(Error error) {
+  // Don't overwrite an error that's already set.
+  if (error_ || !error) {
+    return;
+  }
+
+  error_ = std::move(error);
+
+  handleError_();
+}
+
+void Channel::Impl::handleError_() {
+  TP_DCHECK(loop_.inLoop());
+  TP_VLOG(5) << "Channel " << id_ << " is handling error " << error_.what();
+
+  if (state_ != ESTABLISHED) {
+    for (SendOperation& op : sendOperations_) {
+      op.callback(error_);
+    }
+    sendOperations_.clear();
+    for (RecvOperation& op : recvOperations_) {
+      op.callback(error_);
+    }
+    recvOperations_.clear();
+  }
+
+  // Close the connections so that all current operations will be aborted. This
+  // will cause their callbacks to be invoked, and only then we'll invoke ours.
+  connection_->close();
+  for (auto& lane : lanes_) {
+    if (lane) {
+      lane->close();
+    }
+  }
+
+  for (const auto& iter : laneRegistrationIds_) {
+    context_->unregisterConnectionRequest(iter.second);
+  }
+}
+
+} // namespace mpt
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/mpt/channel.h
+++ b/tensorpipe/channel/mpt/channel.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <deque>
+#include <list>
+
+#include <tensorpipe/channel/channel.h>
+#include <tensorpipe/channel/mpt/context.h>
+
+namespace tensorpipe {
+namespace channel {
+namespace mpt {
+
+class Channel : public channel::Channel {
+  // Use the passkey idiom to allow make_shared to call what should be a private
+  // constructor. See https://abseil.io/tips/134 for more information.
+  struct ConstructorToken {};
+
+ public:
+  Channel(
+      ConstructorToken,
+      std::shared_ptr<Context::PrivateIface> context,
+      std::shared_ptr<transport::Connection> connection,
+      Endpoint endpoint,
+      uint64_t numLanes,
+      std::string id);
+
+  // Send memory region to peer.
+  void send(
+      const void* ptr,
+      size_t length,
+      TDescriptorCallback descriptorCallback,
+      TSendCallback callback) override;
+
+  // Receive memory region from peer.
+  void recv(
+      TDescriptor descriptor,
+      void* ptr,
+      size_t length,
+      TRecvCallback callback) override;
+
+  // Tell the channel what its identifier is.
+  void setId(std::string id) override;
+
+  void close() override;
+
+  ~Channel() override;
+
+ private:
+  class Impl;
+
+  // Using a shared_ptr allows us to detach the lifetime of the implementation
+  // from the public object's one and perform the destruction asynchronously.
+  std::shared_ptr<Impl> impl_;
+
+  // Allow context to access constructor token.
+  friend class Context;
+};
+
+} // namespace mpt
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/mpt/context.cc
+++ b/tensorpipe/channel/mpt/context.cc
@@ -1,0 +1,441 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/channel/mpt/context.h>
+
+#include <algorithm>
+#include <sstream>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <tensorpipe/channel/channel.h>
+#include <tensorpipe/channel/error.h>
+#include <tensorpipe/channel/helpers.h>
+#include <tensorpipe/channel/mpt/channel.h>
+#include <tensorpipe/channel/registry.h>
+#include <tensorpipe/common/callback.h>
+#include <tensorpipe/common/defs.h>
+#include <tensorpipe/common/error_macros.h>
+#include <tensorpipe/proto/channel/mpt.pb.h>
+#include <tensorpipe/transport/context.h>
+#include <tensorpipe/transport/error.h>
+#include <tensorpipe/transport/listener.h>
+
+namespace tensorpipe {
+namespace channel {
+namespace mpt {
+
+namespace {
+
+std::shared_ptr<Context> makeMptChannel() {
+  throw std::runtime_error("mtp channel requires arguments");
+}
+
+TP_REGISTER_CREATOR(TensorpipeChannelRegistry, mpt, makeMptChannel);
+
+} // namespace
+
+class Context::Impl : public Context::PrivateIface,
+                      public std::enable_shared_from_this<Context::Impl> {
+ public:
+  Impl(
+      std::vector<std::shared_ptr<transport::Context>>,
+      std::vector<std::shared_ptr<transport::Listener>>);
+
+  // Called by the context's constructor.
+  void init();
+
+  const std::string& domainDescriptor() const;
+
+  std::shared_ptr<channel::Channel> createChannel(
+      std::shared_ptr<transport::Connection>,
+      Channel::Endpoint);
+
+  ClosingEmitter& getClosingEmitter() override;
+
+  const std::vector<std::string>& addresses() const override;
+
+  uint64_t registerConnectionRequest(
+      uint64_t laneIdx,
+      connection_request_callback_fn) override;
+
+  void unregisterConnectionRequest(uint64_t) override;
+
+  std::shared_ptr<transport::Connection> connect(
+      uint64_t laneIdx,
+      std::string address) override;
+
+  void setId(std::string id);
+
+  void close();
+
+  void join();
+
+  ~Impl() override = default;
+
+ private:
+  void initFromLoop_();
+
+  void closeFromLoop_();
+
+  void setIdFromLoop_(std::string id);
+
+  void registerConnectionRequestFromLoop_(
+      uint64_t laneIdx,
+      uint64_t registrationId,
+      connection_request_callback_fn);
+
+  void unregisterConnectionRequestFromLoop_(uint64_t);
+
+  void acceptLane_(uint64_t);
+  void onAcceptOfLane_(std::shared_ptr<transport::Connection>);
+  void onReadClientHelloOnLane_(
+      std::shared_ptr<transport::Connection>,
+      const proto::Packet&);
+
+  void setError_(Error error);
+
+  void handleError_();
+
+  std::vector<std::shared_ptr<transport::Context>> contexts_;
+  std::vector<std::shared_ptr<transport::Listener>> listeners_;
+
+  std::string domainDescriptor_;
+  std::atomic<bool> joined_{false};
+  uint64_t numLanes_{0};
+  std::vector<std::string> addresses_;
+
+  // This is atomic because it may be accessed from outside the loop.
+  std::atomic<uint64_t> nextConnectionRequestRegistrationId_{0};
+
+  // Needed to keep them alive.
+  std::unordered_set<std::shared_ptr<transport::Connection>>
+      connectionsWaitingForHello_;
+
+  std::unordered_map<uint64_t, connection_request_callback_fn>
+      connectionRequestRegistrations_;
+
+  // An identifier for the context, composed of the identifier for the context,
+  // combined with the channel's name. It will only be used for logging and
+  // debugging purposes.
+  std::string id_{"N/A"};
+
+  // Sequence numbers for the channels created by this context, used to create
+  // their identifiers based off this context's identifier. They will only be
+  // used for logging and debugging.
+  std::atomic<uint64_t> channelCounter_{0};
+
+  OnDemandLoop loop_;
+  Error error_{Error::kSuccess};
+  LazyCallbackWrapper<Impl> lazyCallbackWrapper_{*this, this->loop_};
+  EagerCallbackWrapper<Impl> eagerCallbackWrapper_{*this, this->loop_};
+  ClosingEmitter closingEmitter_;
+
+  // For some odd reason it seems we need to use a qualified name here...
+  template <typename T>
+  friend class tensorpipe::LazyCallbackWrapper;
+  template <typename T>
+  friend class tensorpipe::EagerCallbackWrapper;
+};
+
+Context::Context(
+    std::vector<std::shared_ptr<transport::Context>> contexts,
+    std::vector<std::shared_ptr<transport::Listener>> listeners)
+    : impl_(std::make_shared<Impl>(std::move(contexts), std::move(listeners))) {
+  impl_->init();
+}
+
+Context::Impl::Impl(
+    std::vector<std::shared_ptr<transport::Context>> contexts,
+    std::vector<std::shared_ptr<transport::Listener>> listeners)
+    : contexts_(std::move(contexts)), listeners_(std::move(listeners)) {
+  TP_THROW_ASSERT_IF(contexts_.size() != listeners_.size());
+  numLanes_ = contexts_.size();
+  // FIXME Escape the contexts' domain descriptors in case they contain a colon?
+  // Or put them all in a protobuf, that'll do the escaping for us.
+  // But is it okay to compare protobufs by equality bitwise?
+  std::ostringstream ss;
+  ss << contexts_.size();
+  for (const auto& context : contexts_) {
+    ss << ":" << context->domainDescriptor();
+  }
+  domainDescriptor_ = ss.str();
+
+  addresses_.reserve(numLanes_);
+  for (const auto& listener : listeners_) {
+    addresses_.emplace_back(listener->addr());
+  }
+}
+
+void Context::Impl::init() {
+  loop_.deferToLoop([this]() { initFromLoop_(); });
+}
+
+void Context::Impl::initFromLoop_() {
+  TP_DCHECK(loop_.inLoop());
+
+  for (uint64_t laneIdx = 0; laneIdx < numLanes_; ++laneIdx) {
+    acceptLane_(laneIdx);
+  }
+}
+
+ClosingEmitter& Context::Impl::getClosingEmitter() {
+  return closingEmitter_;
+}
+
+const std::string& Context::domainDescriptor() const {
+  return impl_->domainDescriptor();
+}
+
+const std::string& Context::Impl::domainDescriptor() const {
+  return domainDescriptor_;
+}
+
+std::shared_ptr<channel::Channel> Context::createChannel(
+    std::shared_ptr<transport::Connection> connection,
+    Channel::Endpoint endpoint) {
+  return impl_->createChannel(std::move(connection), endpoint);
+}
+
+std::shared_ptr<channel::Channel> Context::Impl::createChannel(
+    std::shared_ptr<transport::Connection> connection,
+    Channel::Endpoint endpoint) {
+  std::string channelId = id_ + ".c" + std::to_string(channelCounter_++);
+  TP_VLOG(4) << "Channel context " << id_ << " is opening channel "
+             << channelId;
+  return std::make_shared<Channel>(
+      Channel::ConstructorToken(),
+      std::static_pointer_cast<PrivateIface>(shared_from_this()),
+      std::move(connection),
+      endpoint,
+      numLanes_,
+      std::move(channelId));
+}
+
+const std::vector<std::string>& Context::Impl::addresses() const {
+  // As this is an immutable member (after it has been initialized in
+  // the constructor), we'll access it without deferring to the loop.
+  return addresses_;
+}
+
+uint64_t Context::Impl::registerConnectionRequest(
+    uint64_t laneIdx,
+    connection_request_callback_fn fn) {
+  // We cannot return a value if we defer the function. Thus we obtain an ID
+  // now (and this is why the next ID is an atomic), return it, and defer the
+  // rest of the processing.
+  // FIXME Avoid this hack by doing like we did with the channels' recv: have
+  // this accept a callback that is called with the registration ID.
+  uint64_t registrationId = nextConnectionRequestRegistrationId_++;
+  loop_.deferToLoop(
+      [this, laneIdx, registrationId, fn{std::move(fn)}]() mutable {
+        registerConnectionRequestFromLoop_(
+            laneIdx, registrationId, std::move(fn));
+      });
+  return registrationId;
+}
+
+void Context::Impl::registerConnectionRequestFromLoop_(
+    uint64_t laneIdx,
+    uint64_t registrationId,
+    connection_request_callback_fn fn) {
+  TP_DCHECK(loop_.inLoop());
+
+  TP_VLOG(4) << "Channel context " << id_
+             << " received a connection request registration (#"
+             << registrationId << ") on lane " << laneIdx;
+
+  if (error_) {
+    TP_VLOG(4) << "Channel context " << id_
+               << " calling a connection request registration callback (#"
+               << registrationId << ")";
+    fn(error_, std::shared_ptr<transport::Connection>());
+    TP_VLOG(4) << "Channel context " << id_
+               << " done calling a connection request registration callback (#"
+               << registrationId << ")";
+  } else {
+    connectionRequestRegistrations_.emplace(registrationId, std::move(fn));
+  }
+}
+
+void Context::Impl::unregisterConnectionRequest(uint64_t registrationId) {
+  loop_.deferToLoop([this, registrationId]() {
+    unregisterConnectionRequestFromLoop_(registrationId);
+  });
+}
+
+void Context::Impl::unregisterConnectionRequestFromLoop_(
+    uint64_t registrationId) {
+  TP_DCHECK(loop_.inLoop());
+
+  TP_VLOG(4) << "Channel context " << id_
+             << " received a connection request de-registration (#"
+             << registrationId << ")";
+
+  connectionRequestRegistrations_.erase(registrationId);
+}
+
+std::shared_ptr<transport::Connection> Context::Impl::connect(
+    uint64_t laneIdx,
+    std::string address) {
+  TP_VLOG(4) << "Channel context " << id_ << " opening connection on lane "
+             << laneIdx;
+  return contexts_[laneIdx]->connect(std::move(address));
+}
+
+void Context::Impl::acceptLane_(uint64_t laneIdx) {
+  TP_DCHECK(loop_.inLoop());
+
+  TP_VLOG(6) << "Channel context " << id_ << " accepting connection on lane "
+             << laneIdx;
+  listeners_[laneIdx]->accept(lazyCallbackWrapper_(
+      [laneIdx](Impl& impl, std::shared_ptr<transport::Connection> connection) {
+        TP_VLOG(6) << "Channel context " << impl.id_
+                   << " done accepting connection on lane " << laneIdx;
+        impl.onAcceptOfLane_(std::move(connection));
+        impl.acceptLane_(laneIdx);
+      }));
+}
+
+void Context::Impl::onAcceptOfLane_(
+    std::shared_ptr<transport::Connection> connection) {
+  TP_DCHECK(loop_.inLoop());
+
+  // Keep it alive until we figure out what to do with it.
+  connectionsWaitingForHello_.insert(connection);
+  auto pbPacketIn = std::make_shared<proto::Packet>();
+  TP_VLOG(6) << "Channel context " << id_ << " reading proto (client hello)";
+  connection->read(
+      *pbPacketIn,
+      lazyCallbackWrapper_([pbPacketIn,
+                            weakConnection{std::weak_ptr<transport::Connection>(
+                                connection)}](Impl& impl) mutable {
+        TP_VLOG(6) << "Channel context " << impl.id_
+                   << " done reading proto (client hello)";
+        std::shared_ptr<transport::Connection> connection =
+            weakConnection.lock();
+        TP_DCHECK(connection);
+        impl.connectionsWaitingForHello_.erase(connection);
+        impl.onReadClientHelloOnLane_(std::move(connection), *pbPacketIn);
+      }));
+}
+
+void Context::Impl::onReadClientHelloOnLane_(
+    std::shared_ptr<transport::Connection> connection,
+    const proto::Packet& pbPacketIn) {
+  TP_DCHECK(loop_.inLoop());
+
+  if (pbPacketIn.has_client_hello()) {
+    const proto::ClientHello& pbClientHello = pbPacketIn.client_hello();
+    uint64_t registrationId = pbClientHello.registration_id();
+    auto fn = std::move(connectionRequestRegistrations_.at(registrationId));
+    connectionRequestRegistrations_.erase(registrationId);
+    fn(Error::kSuccess, std::move(connection));
+  } else {
+    TP_LOG_ERROR() << "packet contained unknown content: "
+                   << pbPacketIn.type_case();
+  }
+}
+
+void Context::Impl::setError_(Error error) {
+  // Don't overwrite an error that's already set.
+  if (error_ || !error) {
+    return;
+  }
+
+  error_ = std::move(error);
+
+  handleError_();
+}
+
+void Context::Impl::handleError_() {
+  TP_DCHECK(loop_.inLoop());
+  TP_VLOG(5) << "Channel context " << id_ << " handling error "
+             << error_.what();
+
+  closingEmitter_.close();
+
+  for (auto& iter : connectionRequestRegistrations_) {
+    connection_request_callback_fn fn = std::move(iter.second);
+    fn(error_, std::shared_ptr<transport::Connection>());
+  }
+  connectionRequestRegistrations_.clear();
+
+  connectionsWaitingForHello_.clear();
+  for (auto& listener : listeners_) {
+    listener->close();
+  }
+  for (auto& context : contexts_) {
+    context->close();
+  }
+}
+
+void Context::setId(std::string id) {
+  impl_->setId(std::move(id));
+}
+
+void Context::Impl::setId(std::string id) {
+  loop_.deferToLoop(
+      [this, id{std::move(id)}]() mutable { setIdFromLoop_(std::move(id)); });
+}
+
+void Context::Impl::setIdFromLoop_(std::string id) {
+  TP_DCHECK(loop_.inLoop());
+  TP_VLOG(4) << "Channel context " << id_ << " was renamed to " << id;
+  id_ = std::move(id);
+  for (uint64_t laneIdx = 0; laneIdx < numLanes_; ++laneIdx) {
+    contexts_[laneIdx]->setId(id_ + ".ctx_" + std::to_string(laneIdx));
+    listeners_[laneIdx]->setId(
+        id_ + ".ctx_" + std::to_string(laneIdx) + ".l_" +
+        std::to_string(laneIdx));
+  }
+}
+
+void Context::close() {
+  impl_->close();
+}
+
+void Context::Impl::close() {
+  loop_.deferToLoop([this]() { closeFromLoop_(); });
+}
+
+void Context::Impl::closeFromLoop_() {
+  TP_DCHECK(loop_.inLoop());
+
+  TP_VLOG(4) << "Channel context " << id_ << " is closing";
+
+  setError_(TP_CREATE_ERROR(ContextClosedError));
+
+  TP_VLOG(4) << "Channel context " << id_ << " done closing";
+}
+
+void Context::join() {
+  impl_->join();
+}
+
+void Context::Impl::join() {
+  close();
+
+  if (!joined_.exchange(true)) {
+    TP_VLOG(4) << "Channel context " << id_ << " is joining";
+
+    for (auto& context : contexts_) {
+      context->join();
+    }
+
+    TP_VLOG(4) << "Channel context " << id_ << " done joining";
+  }
+}
+
+Context::~Context() {
+  join();
+}
+
+} // namespace mpt
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/mpt/context.h
+++ b/tensorpipe/channel/mpt/context.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <tensorpipe/channel/context.h>
+#include <tensorpipe/common/callback.h>
+#include <tensorpipe/transport/context.h>
+
+namespace tensorpipe {
+namespace channel {
+namespace mpt {
+
+class Context : public channel::Context {
+ public:
+  Context(
+      std::vector<std::shared_ptr<transport::Context>>,
+      std::vector<std::shared_ptr<transport::Listener>>);
+
+  const std::string& domainDescriptor() const override;
+
+  std::shared_ptr<Channel> createChannel(
+      std::shared_ptr<transport::Connection>,
+      Channel::Endpoint) override;
+
+  void setId(std::string id) override;
+
+  void close() override;
+
+  void join() override;
+
+  ~Context() override;
+
+ private:
+  class PrivateIface {
+   public:
+    virtual ClosingEmitter& getClosingEmitter() = 0;
+
+    using connection_request_callback_fn = std::function<
+        void(const Error&, std::shared_ptr<transport::Connection>)>;
+
+    virtual const std::vector<std::string>& addresses() const = 0;
+
+    virtual uint64_t registerConnectionRequest(
+        uint64_t laneIdx,
+        connection_request_callback_fn) = 0;
+
+    virtual void unregisterConnectionRequest(uint64_t) = 0;
+
+    virtual std::shared_ptr<transport::Connection> connect(
+        uint64_t laneIdx,
+        std::string address) = 0;
+
+    virtual ~PrivateIface() = default;
+  };
+
+  class Impl;
+
+  // The implementation is managed by a shared_ptr because each child object
+  // will also hold a shared_ptr to it (downcast as a shared_ptr to the private
+  // interface). However, its lifetime is tied to the one of this public object,
+  // since when the latter is destroyed the implementation is closed and joined.
+  std::shared_ptr<Impl> impl_;
+
+  // Allow channel to see the private interface.
+  friend class Channel;
+};
+
+} // namespace mpt
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/xth/channel.cc
+++ b/tensorpipe/channel/xth/channel.cc
@@ -66,6 +66,8 @@ class Channel::Impl : public std::enable_shared_from_this<Channel::Impl> {
       size_t length,
       TRecvCallback callback);
 
+  void setIdFromLoop_(std::string id);
+
   void closeFromLoop_();
 
   void setError_(Error error);
@@ -292,8 +294,13 @@ void Channel::setId(std::string id) {
 }
 
 void Channel::Impl::setId(std::string id) {
+  loop_.deferToLoop(
+      [this, id{std::move(id)}]() mutable { setIdFromLoop_(std::move(id)); });
+}
+
+void Channel::Impl::setIdFromLoop_(std::string id) {
+  TP_DCHECK(loop_.inLoop());
   TP_VLOG(4) << "Channel " << id_ << " was renamed to " << id;
-  // FIXME Should we defer this to the loop?
   id_ = std::move(id);
 }
 

--- a/tensorpipe/channel/xth/context.cc
+++ b/tensorpipe/channel/xth/context.cc
@@ -158,6 +158,7 @@ void Context::setId(std::string id) {
 }
 
 void Context::Impl::setId(std::string id) {
+  TP_VLOG(4) << "Channel context " << id_ << " was renamed to " << id;
   id_ = std::move(id);
 }
 

--- a/tensorpipe/proto/channel/mpt.proto
+++ b/tensorpipe/proto/channel/mpt.proto
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+syntax = "proto3";
+
+package tensorpipe.channel.mpt.proto;
+
+message LaneAdvertisement {
+  string address = 1;
+  uint64 registration_id = 2;
+}
+
+message ServerHello {
+  repeated LaneAdvertisement lane_advertisements = 1;
+}
+
+message ClientHello {
+  uint64 registration_id = 1;
+}
+
+message Packet {
+  oneof type {
+    ServerHello server_hello = 1;
+    ClientHello client_hello = 2;
+  }
+}

--- a/tensorpipe/tensorpipe.h
+++ b/tensorpipe/tensorpipe.h
@@ -11,6 +11,8 @@
 #include <tensorpipe/channel/basic/context.h>
 #include <tensorpipe/channel/channel.h>
 #include <tensorpipe/channel/helpers.h>
+#include <tensorpipe/channel/mpt/context.h>
+#include <tensorpipe/channel/xth/context.h>
 #include <tensorpipe/common/address.h>
 #include <tensorpipe/common/callback.h>
 #include <tensorpipe/common/defs.h>

--- a/tensorpipe/test/CMakeLists.txt
+++ b/tensorpipe/test/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(tensorpipe_test
   proto/core_test.cc
   channel/basic/basic_test.cc
   channel/xth/xth_test.cc
+  channel/mpt/mpt_test.cc
   channel/channel_test.cc
   common/system_test.cc
   common/defs_test.cc

--- a/tensorpipe/test/channel/mpt/mpt_test.cc
+++ b/tensorpipe/test/channel/mpt/mpt_test.cc
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/channel/mpt/context.h>
+#include <tensorpipe/test/channel/channel_test.h>
+
+namespace {
+
+class MptChannelTestHelper : public ChannelTestHelper {
+ public:
+  std::shared_ptr<tensorpipe::channel::Context> makeContext(
+      std::string id) override {
+    std::vector<std::shared_ptr<tensorpipe::transport::Context>> contexts = {
+        std::make_shared<tensorpipe::transport::uv::Context>(),
+        std::make_shared<tensorpipe::transport::uv::Context>(),
+        std::make_shared<tensorpipe::transport::uv::Context>()};
+    std::vector<std::shared_ptr<tensorpipe::transport::Listener>> listeners = {
+        contexts[0]->listen("127.0.0.1"),
+        contexts[1]->listen("127.0.0.1"),
+        contexts[2]->listen("127.0.0.1")};
+    auto context = std::make_shared<tensorpipe::channel::mpt::Context>(
+        std::move(contexts), std::move(listeners));
+    context->setId(std::move(id));
+    return context;
+  }
+};
+
+MptChannelTestHelper helper;
+
+} // namespace
+
+INSTANTIATE_TEST_CASE_P(Mpt, ChannelTest, ::testing::Values(&helper));

--- a/tensorpipe/transport/shm/connection.cc
+++ b/tensorpipe/transport/shm/connection.cc
@@ -342,6 +342,8 @@ class Connection::Impl : public std::enable_shared_from_this<Connection::Impl>,
       const google::protobuf::MessageLite& message,
       write_callback_fn fn);
 
+  void setIdFromLoop_(std::string id);
+
   // Shut down the connection and its resources.
   void closeFromLoop();
 
@@ -820,8 +822,15 @@ void Connection::setId(std::string id) {
 }
 
 void Connection::Impl::setId(std::string id) {
+  context_->deferToLoop(
+      [impl{shared_from_this()}, id{std::move(id)}]() mutable {
+        impl->setIdFromLoop_(std::move(id));
+      });
+}
+
+void Connection::Impl::setIdFromLoop_(std::string id) {
+  TP_DCHECK(context_->inLoopThread());
   TP_VLOG(7) << "Connection " << id_ << " was renamed to " << id;
-  // FIXME Should we defer this to the loop?
   id_ = std::move(id);
 }
 

--- a/tensorpipe/transport/shm/context.cc
+++ b/tensorpipe/transport/shm/context.cc
@@ -185,6 +185,7 @@ void Context::setId(std::string id) {
 }
 
 void Context::Impl::setId(std::string id) {
+  TP_VLOG(7) << "Transport context " << id_ << " was renamed to " << id;
   id_ = std::move(id);
 }
 

--- a/tensorpipe/transport/shm/listener.cc
+++ b/tensorpipe/transport/shm/listener.cc
@@ -62,6 +62,8 @@ class Listener::Impl : public std::enable_shared_from_this<Listener::Impl>,
   // Obtain the listener's address.
   std::string addrFromLoop() const;
 
+  void setIdFromLoop_(std::string id);
+
   // Shut down the connection and its resources.
   void closeFromLoop();
 
@@ -257,8 +259,15 @@ void Listener::setId(std::string id) {
 }
 
 void Listener::Impl::setId(std::string id) {
+  context_->deferToLoop(
+      [impl{shared_from_this()}, id{std::move(id)}]() mutable {
+        impl->setIdFromLoop_(std::move(id));
+      });
+}
+
+void Listener::Impl::setIdFromLoop_(std::string id) {
+  TP_DCHECK(context_->inLoopThread());
   TP_VLOG(7) << "Listener " << id_ << " was renamed to " << id;
-  // FIXME Should we defer this to the loop?
   id_ = std::move(id);
 }
 

--- a/tensorpipe/transport/uv/context.cc
+++ b/tensorpipe/transport/uv/context.cc
@@ -273,6 +273,7 @@ void Context::setId(std::string id) {
 }
 
 void Context::Impl::setId(std::string id) {
+  TP_VLOG(7) << "Transport context " << id_ << " was renamed to " << id;
   id_ = std::move(id);
 }
 

--- a/tensorpipe/transport/uv/listener.cc
+++ b/tensorpipe/transport/uv/listener.cc
@@ -50,6 +50,8 @@ class Listener::Impl : public std::enable_shared_from_this<Listener::Impl> {
   // Obtain the listener's address.
   std::string addrFromLoop() const;
 
+  void setIdFromLoop_(std::string id);
+
   // Shut down the connection and its resources.
   void closeFromLoop();
 
@@ -160,8 +162,15 @@ std::string Listener::Impl::addrFromLoop() const {
 }
 
 void Listener::Impl::setId(std::string id) {
+  context_->deferToLoop(
+      [impl{shared_from_this()}, id{std::move(id)}]() mutable {
+        impl->setIdFromLoop_(std::move(id));
+      });
+}
+
+void Listener::Impl::setIdFromLoop_(std::string id) {
+  TP_DCHECK(context_->inLoopThread());
   TP_VLOG(7) << "Listener " << id_ << " was renamed to " << id;
-  // FIXME Should we defer this to the loop?
   id_ = std::move(id);
 }
 


### PR DESCRIPTION
Summary: This is a channel that takes as arguments a set of transport contexts and transport listeners, and then splits each tensor into chunks and sends them over different connections.

Differential Revision: D19765824

