### PR TITLE
Make git submodule track branch v1.x of libuv.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           name: Initialize submodules
           command: |
             git submodule init
-            git submodule update --remote
+            git submodule update
       - run:
           name: Build
           command: |
@@ -74,7 +74,7 @@ jobs:
           name: Initialize submodules
           command: |
             git submodule init
-            git submodule update --remote
+            git submodule update
       - run:
           name: Build
           command: |
@@ -120,7 +120,7 @@ jobs:
           name: Initialize submodules
           command: |
             git submodule init
-            git submodule update --remote
+            git submodule update
       - run:
           name: Build
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,6 @@ jobs:
           name: Test
           command: |
             export CTEST_OUTPUT_ON_FAILURE=1
-            export TSAN_OPTIONS="suppressions=$(realpath ./tsan_suppressions.txt)"
             cd build
             make test
       - run:

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,4 @@
 [submodule "third_party/libuv"]
 	path = third_party/libuv
 	url = https://github.com/libuv/libuv.git
+	branch = v1.x

--- a/tsan_suppressions.txt
+++ b/tsan_suppressions.txt
@@ -1,3 +1,0 @@
-# There is a harmless data race in libuv on linux during the choice of a fast clock.
-# Cf. https://github.com/libuv/libuv/issues/2884
-race:uv__hrtime


### PR DESCRIPTION
~~The PR is sound, but the `uv__hrtime()` data race is actually still present on libuv master. It seems they ended up fixing similar races in different places, but `uv__hrtime()` did not get this treatment.~~ They now fixed it (cf. https://github.com/libuv/libuv/issues/2884).

This PR removes the `--remote` flag from the `git submodule update` call, so that CI always tests against the same version of libuv. We could add a separate CI job to test against the latest commit of libuv if needed.