### PR TITLE
Limit number of make parallel jobs during CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,9 @@ jobs:
       cmake_args:
         type: string
         default: ""
+      nproc:
+        type: integer
+        default: 20
     docker:
       - image: << parameters.docker_image >>
     steps:
@@ -49,7 +52,7 @@ jobs:
               -DCMAKE_CXX_COMPILER=<< parameters.cxx_compiler >> \
               -DTP_ENABLE_CMA=OFF \
               << parameters.cmake_args >>
-            make -j
+            make -j<<parameters.nproc>>
       - run:
           name: Test
           command: |


### PR DESCRIPTION
Some CI jobs (with gcc7) would fail due to OOM, caused my unbound `make` parallel jobs (`-j`). Since the CircleCI instances we use have only 4GB ram, this PR limits the number of jobs to 20 (although `nproc` returns 36), which seems to work.