### PR TITLE
Export CMake targets from top-level directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,3 +30,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 endif()
 
 add_subdirectory(tensorpipe)
+
+install(EXPORT TensorpipeTargets
+        DESTINATION share/cmake/Tensorpipe
+        FILE TensorpipeTargets.cmake)

--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -148,10 +148,6 @@ endif()
 
 include(GNUInstallDirs)
 install(TARGETS tensorpipe
-        EXPORT tensorpipe-targets
+        EXPORT TensorpipeTargets
         LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
-
-install(EXPORT tensorpipe-targets
-        DESTINATION share/cmake/tensorpipe
-        FILE TensorpipeTargets.cmake)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #200 Use tensorpipe_uv instead of _uv_a for submodule libuv's target
* #199 Don't install the targets provided by libuv's own CMake files
* #198 Allow to build TensorPipe as a static lib
* #197 Allow downstream projects to customize install location
* #196 Gate more optional features behind CMake flags
* #195 Export submodule libuv inside TensorPipe's targets
* **#194 Export CMake targets from top-level directory**

At some point I think I have seen that the location in which that install command is triggered affects the location of the installed file. For us, doing it from the top-level doesn't change anything, so why not play it safe? Also, this is the same that Gloo does (and Gloo also tries to keep most of its CMake logic inside its gloo/ subdir).

Differential Revision: [D22928858](https://our.internmc.facebook.com/intern/diff/D22928858)