### PR TITLE
Export submodule libuv inside TensorPipe's targets

### DIFF
--- a/cmake/Finduv.cmake
+++ b/cmake/Finduv.cmake
@@ -71,10 +71,8 @@ if(NOT uv_FOUND)
   target_compile_options(_uv_a PRIVATE ${_compile_options})
 
   install(TARGETS _uv_a
-          EXPORT libuv-targets
+          EXPORT TensorpipeTargets
           ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
-  install(EXPORT libuv-targets
-          DESTINATION share/cmake/libuv-unofficial)
 
   add_library(uv::uv ALIAS _uv_a)
 endif()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #200 Use tensorpipe_uv instead of _uv_a for submodule libuv's target
* #199 Don't install the targets provided by libuv's own CMake files
* #198 Allow to build TensorPipe as a static lib
* #197 Allow downstream projects to customize install location
* #196 Gate more optional features behind CMake flags
* **#195 Export submodule libuv inside TensorPipe's targets**
* #194 Export CMake targets from top-level directory

That target is a hack we need in order to be able to export the libuv target. I think it would be weird for users to install TensorPipe and then find a weird thing called libuv-unofficial installed on their machine. Why not keep it under our umbrella to make attribution easier? A later PR in this stack will also change the name of the target itself (currently `_uv_a`) as well.

Differential Revision: [D22928856](https://our.internmc.facebook.com/intern/diff/D22928856)