### PR TITLE
Gate more optional features behind CMake flags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,12 +46,12 @@ jobs:
               -DCMAKE_C_COMPILER=<< parameters.c_compiler >> \
               -DCMAKE_CXX_COMPILER=<< parameters.cxx_compiler >> \
               -DTP_ENABLE_CMA=OFF \
+              -DTP_BUILD_TESTING=ON \
               << parameters.cmake_args >>
             make -j<<parameters.nproc>>
       - run:
           name: Test
           command: |
-            export CTEST_OUTPUT_ON_FAILURE=1
             cd build
             ./tensorpipe/test/tensorpipe_test
       - run:
@@ -80,7 +80,8 @@ jobs:
             cd build
             cmake ../ \
               -DCMAKE_C_FLAGS="-Werror -Wno-deprecated-declarations" \
-              -DCMAKE_CXX_FLAGS="-Werror -Wno-deprecated-declarations"
+              -DCMAKE_CXX_FLAGS="-Werror -Wno-deprecated-declarations" \
+              -DTP_BUILD_TESTING=ON
             make -j
       - run:
           name: Test

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -10,7 +10,16 @@ else()
   set(LINUX OFF)
 endif()
 
+# Transports
 option(TP_ENABLE_SHM "Enable shm transport" ${LINUX})
+
+# Channels
 option(TP_ENABLE_CMA "Enable cma channel" ${LINUX})
+
+# Optional features
+option(TP_BUILD_BENCHMARK "Build benchmarks" OFF)
 option(TP_BUILD_PYTHON "Build python bindings" OFF)
+option(TP_BUILD_TESTING "Build tests" OFF)
+
+# Force to build libuv from the included submodule
 option(TP_BUILD_LIBUV "Build libuv from source" OFF)

--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -134,12 +134,14 @@ endif()
 
 ## Benchmarks
 
-add_subdirectory(benchmark)
+if (TP_BUILD_BENCHMARK)
+  add_subdirectory(benchmark)
+endif()
 
 
 ## Tests
 
-if(BUILD_TESTING)
+if(TP_BUILD_TESTING)
   add_subdirectory(test)
 endif()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #200 Use tensorpipe_uv instead of _uv_a for submodule libuv's target
* #199 Don't install the targets provided by libuv's own CMake files
* #198 Allow to build TensorPipe as a static lib
* #197 Allow downstream projects to customize install location
* **#196 Gate more optional features behind CMake flags**
* #195 Export submodule libuv inside TensorPipe's targets
* #194 Export CMake targets from top-level directory

The idea here is that most people who build TensorPipe do it for the library itself, it's just us developers that need to build tests, or benchmarks, etc. So why not leave them disabled by default, so that there's no risk of users getting it wrong?

Differential Revision: [D22928853](https://our.internmc.facebook.com/intern/diff/D22928853)