### PR TITLE
Allow to build TensorPipe as a static lib

### DIFF
--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -21,6 +21,14 @@ option(TP_BUILD_BENCHMARK "Build benchmarks" OFF)
 option(TP_BUILD_PYTHON "Build python bindings" OFF)
 option(TP_BUILD_TESTING "Build tests" OFF)
 
+# Whether to build a static or shared library
+if(BUILD_SHARED_LIBS)
+  set(TP_STATIC_OR_SHARED SHARED CACHE STRING "")
+else()
+  set(TP_STATIC_OR_SHARED STATIC CACHE STRING "")
+endif()
+mark_as_advanced(TP_STATIC_OR_SHARED)
+
 # Force to build libuv from the included submodule
 option(TP_BUILD_LIBUV "Build libuv from source" OFF)
 

--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 add_library(tensorpipe
+  ${TP_STATIC_OR_SHARED}
   channel/error.cc
   channel/helpers.cc
   channel/registry.cc
@@ -118,6 +119,11 @@ endif()
 
 target_link_libraries(tensorpipe PRIVATE protobuf::libprotobuf)
 protobuf_generate(TARGET tensorpipe)
+
+
+if(BUILD_SHARED_LIBS)
+  set_target_properties(tensorpipe PROPERTIES POSITION_INDEPENDENT_CODE 1)
+endif()
 
 
 ## Config


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #200 Use tensorpipe_uv instead of _uv_a for submodule libuv's target
* #199 Don't install the targets provided by libuv's own CMake files
* **#198 Allow to build TensorPipe as a static lib**
* #197 Allow downstream projects to customize install location
* #196 Gate more optional features behind CMake flags
* #195 Export submodule libuv inside TensorPipe's targets
* #194 Export CMake targets from top-level directory

Sometimes (I'm looking at you, PyTorch) users include TensorPipe as a submodule in a project, where they want to build the top-level library as shared, and thus BUILD_SHARED_LIBS is enabled, but they want to build and link TensorPipe *statically* into that shared library. So we should offer a way for users to override the default behavior. (However, even when TensorPipe is built statically, if the final result is dynamic we must build position-independent code).

Differential Revision: [D22928857](https://our.internmc.facebook.com/intern/diff/D22928857)