### PR TITLE
Don't install the targets provided by libuv's own CMake files

### DIFF
--- a/cmake/Finduv.cmake
+++ b/cmake/Finduv.cmake
@@ -41,7 +41,8 @@ if(NOT uv_FOUND)
 
   set(libuv_DIR ${PROJECT_SOURCE_DIR}/third_party/libuv)
   add_subdirectory(${libuv_DIR}
-    ${PROJECT_BINARY_DIR}/third_party/libuv)
+    ${PROJECT_BINARY_DIR}/third_party/libuv
+    EXCLUDE_FROM_ALL)
 
   # This hack duplicates the `uv_a` target, so that we can call
   # install(TARGETS ... EXPORT) on it, which is not possible when the target is


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #200 Use tensorpipe_uv instead of _uv_a for submodule libuv's target
* **#199 Don't install the targets provided by libuv's own CMake files**
* #198 Allow to build TensorPipe as a static lib
* #197 Allow downstream projects to customize install location
* #196 Gate more optional features behind CMake flags
* #195 Export submodule libuv inside TensorPipe's targets
* #194 Export CMake targets from top-level directory

The libuv submodule triggers its own install commands, for both a static and a dynamic version of libuv (whose targets are called `uv_a` and `uv`). TensorPipe then also defines its own libuv target, called `_uv_a`). So, right now, when one installs TensorPipe, one ends up with three versions of libuv being installed, two of which are unnecessary. This simple fix avoids the two upstream targets from being installed by default.

Differential Revision: [D22928852](https://our.internmc.facebook.com/intern/diff/D22928852)