### PR TITLE
Move channel types from `channel::Channel::` to `channel::`.

### DIFF
--- a/tensorpipe/channel/basic/context.cc
+++ b/tensorpipe/channel/basic/context.cc
@@ -43,7 +43,7 @@ class Context::Impl : public Context::PrivateIface,
 
   std::shared_ptr<channel::Channel> createChannel(
       std::shared_ptr<transport::Connection>,
-      Channel::Endpoint);
+      Endpoint);
 
   void setId(std::string id);
 
@@ -90,13 +90,13 @@ const std::string& Context::Impl::domainDescriptor() const {
 
 std::shared_ptr<channel::Channel> Context::createChannel(
     std::shared_ptr<transport::Connection> connection,
-    Channel::Endpoint endpoint) {
+    Endpoint endpoint) {
   return impl_->createChannel(std::move(connection), endpoint);
 }
 
 std::shared_ptr<channel::Channel> Context::Impl::createChannel(
     std::shared_ptr<transport::Connection> connection,
-    Channel::Endpoint /* unused */) {
+    Endpoint /* unused */) {
   std::string channelId = id_ + ".c" + std::to_string(channelCounter_++);
   TP_VLOG(4) << "Channel context " << id_ << " is opening channel "
              << channelId;

--- a/tensorpipe/channel/basic/context.h
+++ b/tensorpipe/channel/basic/context.h
@@ -26,7 +26,7 @@ class Context : public channel::Context {
 
   std::shared_ptr<Channel> createChannel(
       std::shared_ptr<transport::Connection>,
-      Channel::Endpoint) override;
+      Endpoint) override;
 
   void setId(std::string id) override;
 

--- a/tensorpipe/channel/channel.h
+++ b/tensorpipe/channel/channel.h
@@ -45,16 +45,16 @@
 namespace tensorpipe {
 namespace channel {
 
+enum class Endpoint : bool { kConnect, kListen };
+
+using TDescriptor = std::string;
+using TDescriptorCallback = std::function<void(const Error&, TDescriptor)>;
+using TSendCallback = std::function<void(const Error&)>;
+using TRecvCallback = std::function<void(const Error&)>;
+
 // Abstract base class for channel classes.
 class Channel {
  public:
-  using TDescriptor = std::string;
-  using TDescriptorCallback = std::function<void(const Error&, TDescriptor)>;
-  using TSendCallback = std::function<void(const Error&)>;
-  using TRecvCallback = std::function<void(const Error&)>;
-
-  enum class Endpoint : bool { kConnect, kListen };
-
   // Send memory region to peer.
   virtual void send(
       const void* ptr,

--- a/tensorpipe/channel/cma/context.cc
+++ b/tensorpipe/channel/cma/context.cc
@@ -75,7 +75,7 @@ class Context::Impl : public Context::PrivateIface,
 
   std::shared_ptr<channel::Channel> createChannel(
       std::shared_ptr<transport::Connection>,
-      Channel::Endpoint);
+      Endpoint);
 
   void setId(std::string id);
 
@@ -195,13 +195,13 @@ const std::string& Context::Impl::domainDescriptor() const {
 
 std::shared_ptr<channel::Channel> Context::createChannel(
     std::shared_ptr<transport::Connection> connection,
-    Channel::Endpoint endpoint) {
+    Endpoint endpoint) {
   return impl_->createChannel(std::move(connection), endpoint);
 }
 
 std::shared_ptr<channel::Channel> Context::Impl::createChannel(
     std::shared_ptr<transport::Connection> connection,
-    Channel::Endpoint /* unused */) {
+    Endpoint /* unused */) {
   TP_THROW_ASSERT_IF(joined_);
   std::string channelId = id_ + ".c" + std::to_string(channelCounter_++);
   TP_VLOG(4) << "Channel context " << id_ << " is opening channel "

--- a/tensorpipe/channel/cma/context.h
+++ b/tensorpipe/channel/cma/context.h
@@ -28,7 +28,7 @@ class Context : public channel::Context {
 
   std::shared_ptr<Channel> createChannel(
       std::shared_ptr<transport::Connection>,
-      Channel::Endpoint) override;
+      Endpoint) override;
 
   void setId(std::string id) override;
 

--- a/tensorpipe/channel/context.h
+++ b/tensorpipe/channel/context.h
@@ -44,7 +44,7 @@ class Context {
   //
   virtual std::shared_ptr<Channel> createChannel(
       std::shared_ptr<transport::Connection>,
-      Channel::Endpoint) = 0;
+      Endpoint) = 0;
 
   // Tell the context what its identifier is.
   //

--- a/tensorpipe/channel/cuda_ipc/channel.cc
+++ b/tensorpipe/channel/cuda_ipc/channel.cc
@@ -107,11 +107,11 @@ int cudaDeviceForPointer(const void* ptr) {
 class SendOperation {
  public:
   uint64_t sequenceNumber;
-  Channel::TSendCallback callback;
+  TSendCallback callback;
 
   SendOperation(
       uint64_t sequenceNumber,
-      Channel::TSendCallback callback,
+      TSendCallback callback,
       const void* ptr,
       cudaStream_t stream)
       : sequenceNumber(sequenceNumber),

--- a/tensorpipe/channel/cuda_ipc/context.cc
+++ b/tensorpipe/channel/cuda_ipc/context.cc
@@ -58,7 +58,7 @@ class Context::Impl : public Context::PrivateIface,
 
   std::shared_ptr<channel::Channel> createChannel(
       std::shared_ptr<transport::Connection>,
-      Channel::Endpoint);
+      Endpoint);
 
   void setId(std::string id);
 
@@ -139,13 +139,13 @@ const std::string& Context::Impl::domainDescriptor() const {
 
 std::shared_ptr<channel::Channel> Context::createChannel(
     std::shared_ptr<transport::Connection> connection,
-    Channel::Endpoint endpoint) {
+    Endpoint endpoint) {
   return impl_->createChannel(std::move(connection), endpoint);
 }
 
 std::shared_ptr<channel::Channel> Context::Impl::createChannel(
     std::shared_ptr<transport::Connection> connection,
-    Channel::Endpoint /* unused */) {
+    Endpoint /* unused */) {
   TP_THROW_ASSERT_IF(joined_);
   std::string channelId = id_ + ".c" + std::to_string(channelCounter_++);
   TP_VLOG(4) << "Channel context " << id_ << " is opening channel "

--- a/tensorpipe/channel/cuda_ipc/context.h
+++ b/tensorpipe/channel/cuda_ipc/context.h
@@ -28,7 +28,7 @@ class Context : public channel::Context {
 
   std::shared_ptr<Channel> createChannel(
       std::shared_ptr<transport::Connection>,
-      Channel::Endpoint) override;
+      Endpoint) override;
 
   void setId(std::string id) override;
 

--- a/tensorpipe/channel/helpers.cc
+++ b/tensorpipe/channel/helpers.cc
@@ -14,9 +14,9 @@
 namespace tensorpipe {
 namespace channel {
 
-Channel::TDescriptor saveDescriptor(const AbstractNopHolder& object) {
+TDescriptor saveDescriptor(const AbstractNopHolder& object) {
   const size_t len = object.getSize();
-  Channel::TDescriptor out(len, '\0');
+  TDescriptor out(len, '\0');
   NopWriter writer(
       const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(out.data())), len);
 
@@ -27,7 +27,7 @@ Channel::TDescriptor saveDescriptor(const AbstractNopHolder& object) {
   return out;
 }
 
-void loadDescriptor(AbstractNopHolder& object, const Channel::TDescriptor& in) {
+void loadDescriptor(AbstractNopHolder& object, const TDescriptor& in) {
   const size_t len = in.size();
   NopReader reader(reinterpret_cast<const uint8_t*>(in.data()), len);
 

--- a/tensorpipe/channel/helpers.h
+++ b/tensorpipe/channel/helpers.h
@@ -16,9 +16,9 @@
 namespace tensorpipe {
 namespace channel {
 
-Channel::TDescriptor saveDescriptor(const AbstractNopHolder& object);
+TDescriptor saveDescriptor(const AbstractNopHolder& object);
 
-void loadDescriptor(AbstractNopHolder& object, const Channel::TDescriptor& in);
+void loadDescriptor(AbstractNopHolder& object, const TDescriptor& in);
 
 } // namespace channel
 } // namespace tensorpipe

--- a/tensorpipe/channel/mpt/channel.cc
+++ b/tensorpipe/channel/mpt/channel.cc
@@ -33,7 +33,7 @@ struct SendOperation {
   const void* ptr;
   size_t length;
   int64_t numChunksBeingWritten{0};
-  Channel::TSendCallback callback;
+  TSendCallback callback;
 };
 
 // State capturing a single recv operation.
@@ -42,7 +42,7 @@ struct RecvOperation {
   void* ptr;
   size_t length;
   int64_t numChunksBeingRead{0};
-  Channel::TRecvCallback callback;
+  TRecvCallback callback;
 };
 
 } // namespace

--- a/tensorpipe/channel/mpt/context.cc
+++ b/tensorpipe/channel/mpt/context.cc
@@ -54,7 +54,7 @@ class Context::Impl : public Context::PrivateIface,
 
   std::shared_ptr<channel::Channel> createChannel(
       std::shared_ptr<transport::Connection>,
-      Channel::Endpoint);
+      Endpoint);
 
   ClosingEmitter& getClosingEmitter() override;
 
@@ -198,13 +198,13 @@ const std::string& Context::Impl::domainDescriptor() const {
 
 std::shared_ptr<channel::Channel> Context::createChannel(
     std::shared_ptr<transport::Connection> connection,
-    Channel::Endpoint endpoint) {
+    Endpoint endpoint) {
   return impl_->createChannel(std::move(connection), endpoint);
 }
 
 std::shared_ptr<channel::Channel> Context::Impl::createChannel(
     std::shared_ptr<transport::Connection> connection,
-    Channel::Endpoint endpoint) {
+    Endpoint endpoint) {
   std::string channelId = id_ + ".c" + std::to_string(channelCounter_++);
   TP_VLOG(4) << "Channel context " << id_ << " is opening channel "
              << channelId;

--- a/tensorpipe/channel/mpt/context.h
+++ b/tensorpipe/channel/mpt/context.h
@@ -30,7 +30,7 @@ class Context : public channel::Context {
 
   std::shared_ptr<Channel> createChannel(
       std::shared_ptr<transport::Connection>,
-      Channel::Endpoint) override;
+      Endpoint) override;
 
   void setId(std::string id) override;
 

--- a/tensorpipe/channel/xth/context.cc
+++ b/tensorpipe/channel/xth/context.cc
@@ -60,7 +60,7 @@ class Context::Impl : public Context::PrivateIface,
 
   std::shared_ptr<channel::Channel> createChannel(
       std::shared_ptr<transport::Connection>,
-      Channel::Endpoint);
+      Endpoint);
 
   void setId(std::string id);
 
@@ -178,13 +178,13 @@ const std::string& Context::Impl::domainDescriptor() const {
 
 std::shared_ptr<channel::Channel> Context::createChannel(
     std::shared_ptr<transport::Connection> connection,
-    Channel::Endpoint endpoint) {
+    Endpoint endpoint) {
   return impl_->createChannel(std::move(connection), endpoint);
 }
 
 std::shared_ptr<channel::Channel> Context::Impl::createChannel(
     std::shared_ptr<transport::Connection> connection,
-    Channel::Endpoint /* unused */) {
+    Endpoint /* unused */) {
   TP_THROW_ASSERT_IF(joined_);
   std::string channelId = id_ + ".c" + std::to_string(channelCounter_++);
   TP_VLOG(4) << "Channel context " << id_ << " is opening channel "

--- a/tensorpipe/channel/xth/context.h
+++ b/tensorpipe/channel/xth/context.h
@@ -28,7 +28,7 @@ class Context : public channel::Context {
 
   std::shared_ptr<Channel> createChannel(
       std::shared_ptr<transport::Connection>,
-      Channel::Endpoint) override;
+      Endpoint) override;
 
   void setId(std::string id) override;
 

--- a/tensorpipe/test/channel/channel_test.cc
+++ b/tensorpipe/test/channel/channel_test.cc
@@ -29,20 +29,19 @@ TEST_P(ChannelTest, ClientToServer) {
   testConnection(
       [&](std::shared_ptr<transport::Connection> conn) {
         std::shared_ptr<Context> ctx = GetParam()->makeContext("server");
-        auto channel =
-            ctx->createChannel(std::move(conn), Channel::Endpoint::kListen);
+        auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
 
         // Initialize with sequential values.
         std::vector<uint8_t> data(dataSize);
         std::iota(data.begin(), data.end(), 0);
 
         // Perform send and wait for completion.
-        std::future<std::tuple<Error, Channel::TDescriptor>> descriptorFuture;
+        std::future<std::tuple<Error, TDescriptor>> descriptorFuture;
         std::future<Error> sendFuture;
         std::tie(descriptorFuture, sendFuture) =
             sendWithFuture(channel, data.data(), data.size());
         Error descriptorError;
-        Channel::TDescriptor descriptor;
+        TDescriptor descriptor;
         std::tie(descriptorError, descriptor) = descriptorFuture.get();
         EXPECT_FALSE(descriptorError) << descriptorError.what();
         peers_->send(PeerGroup::kClient, descriptor);
@@ -56,8 +55,7 @@ TEST_P(ChannelTest, ClientToServer) {
       },
       [&](std::shared_ptr<transport::Connection> conn) {
         std::shared_ptr<Context> ctx = GetParam()->makeContext("client");
-        auto channel =
-            ctx->createChannel(std::move(conn), Channel::Endpoint::kConnect);
+        auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
 
         std::vector<uint8_t> data(dataSize);
 
@@ -86,8 +84,7 @@ TEST_P(ChannelTest, ServerToClient) {
   testConnection(
       [&](std::shared_ptr<transport::Connection> conn) {
         std::shared_ptr<Context> ctx = GetParam()->makeContext("server");
-        auto channel =
-            ctx->createChannel(std::move(conn), Channel::Endpoint::kListen);
+        auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
 
         std::vector<uint8_t> data(dataSize);
 
@@ -110,20 +107,19 @@ TEST_P(ChannelTest, ServerToClient) {
       },
       [&](std::shared_ptr<transport::Connection> conn) {
         std::shared_ptr<Context> ctx = GetParam()->makeContext("client");
-        auto channel =
-            ctx->createChannel(std::move(conn), Channel::Endpoint::kConnect);
+        auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
 
         // Initialize with sequential values.
         std::vector<uint8_t> data(dataSize);
         std::iota(data.begin(), data.end(), 0);
 
         // Perform send and wait for completion.
-        std::future<std::tuple<Error, Channel::TDescriptor>> descriptorFuture;
+        std::future<std::tuple<Error, TDescriptor>> descriptorFuture;
         std::future<Error> sendFuture;
         std::tie(descriptorFuture, sendFuture) =
             sendWithFuture(channel, data.data(), data.size());
         Error descriptorError;
-        Channel::TDescriptor descriptor;
+        TDescriptor descriptor;
         std::tie(descriptorError, descriptor) = descriptorFuture.get();
         EXPECT_FALSE(descriptorError) << descriptorError.what();
         peers_->send(PeerGroup::kServer, descriptor);
@@ -144,8 +140,7 @@ TEST_P(ChannelTest, SendMultipleTensors) {
   testConnection(
       [&](std::shared_ptr<transport::Connection> conn) {
         std::shared_ptr<Context> ctx = GetParam()->makeContext("server");
-        auto channel =
-            ctx->createChannel(std::move(conn), Channel::Endpoint::kListen);
+        auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
 
         // Initialize with sequential values.
         std::vector<uint8_t> data(dataSize);
@@ -156,12 +151,12 @@ TEST_P(ChannelTest, SendMultipleTensors) {
 
         // Perform send and wait for completion.
         for (int i = 0; i < numTensors; i++) {
-          std::future<std::tuple<Error, Channel::TDescriptor>> descriptorFuture;
+          std::future<std::tuple<Error, TDescriptor>> descriptorFuture;
           std::future<Error> sendFuture;
           std::tie(descriptorFuture, sendFuture) =
               sendWithFuture(channel, data.data(), data.size());
           Error descriptorError;
-          Channel::TDescriptor descriptor;
+          TDescriptor descriptor;
           std::tie(descriptorError, descriptor) = descriptorFuture.get();
           EXPECT_FALSE(descriptorError) << descriptorError.what();
           peers_->send(PeerGroup::kClient, descriptor);
@@ -179,8 +174,7 @@ TEST_P(ChannelTest, SendMultipleTensors) {
       },
       [&](std::shared_ptr<transport::Connection> conn) {
         std::shared_ptr<Context> ctx = GetParam()->makeContext("client");
-        auto channel =
-            ctx->createChannel(std::move(conn), Channel::Endpoint::kConnect);
+        auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
 
         std::vector<std::vector<uint8_t>> dataVec(
             numTensors, std::vector<uint8_t>(dataSize));
@@ -220,8 +214,7 @@ TEST_P(ChannelTest, SendTensorsBothWays) {
   testConnection(
       [&](std::shared_ptr<transport::Connection> conn) {
         std::shared_ptr<Context> ctx = GetParam()->makeContext("server");
-        auto channel =
-            ctx->createChannel(std::move(conn), Channel::Endpoint::kListen);
+        auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
 
         // Initialize sendBuffer with sequential values.
         std::vector<uint8_t> sendData(dataSize);
@@ -235,11 +228,11 @@ TEST_P(ChannelTest, SendTensorsBothWays) {
 
         // Perform send.
         {
-          std::future<std::tuple<Error, Channel::TDescriptor>> descriptorFuture;
+          std::future<std::tuple<Error, TDescriptor>> descriptorFuture;
           std::tie(descriptorFuture, sendFuture) =
               sendWithFuture(channel, sendData.data(), sendData.size());
           Error descriptorError;
-          Channel::TDescriptor descriptor;
+          TDescriptor descriptor;
           std::tie(descriptorError, descriptor) = descriptorFuture.get();
           EXPECT_FALSE(descriptorError) << descriptorError.what();
           peers_->send(PeerGroup::kClient, descriptor);
@@ -270,8 +263,7 @@ TEST_P(ChannelTest, SendTensorsBothWays) {
       },
       [&](std::shared_ptr<transport::Connection> conn) {
         std::shared_ptr<Context> ctx = GetParam()->makeContext("client");
-        auto channel =
-            ctx->createChannel(std::move(conn), Channel::Endpoint::kConnect);
+        auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
 
         // Initialize sendBuffer with sequential values.
         std::vector<uint8_t> sendData(dataSize);
@@ -285,11 +277,11 @@ TEST_P(ChannelTest, SendTensorsBothWays) {
 
         // Perform send.
         {
-          std::future<std::tuple<Error, Channel::TDescriptor>> descriptorFuture;
+          std::future<std::tuple<Error, TDescriptor>> descriptorFuture;
           std::tie(descriptorFuture, sendFuture) =
               sendWithFuture(channel, sendData.data(), sendData.size());
           Error descriptorError;
-          Channel::TDescriptor descriptor;
+          TDescriptor descriptor;
           std::tie(descriptorError, descriptor) = descriptorFuture.get();
           EXPECT_FALSE(descriptorError) << descriptorError.what();
           peers_->send(PeerGroup::kServer, descriptor);
@@ -326,16 +318,15 @@ TEST_P(ChannelTest, NullPointer) {
   testConnection(
       [&](std::shared_ptr<transport::Connection> conn) {
         std::shared_ptr<Context> ctx = GetParam()->makeContext("server");
-        auto channel =
-            ctx->createChannel(std::move(conn), Channel::Endpoint::kListen);
+        auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
 
         // Perform send and wait for completion.
-        std::future<std::tuple<Error, Channel::TDescriptor>> descriptorFuture;
+        std::future<std::tuple<Error, TDescriptor>> descriptorFuture;
         std::future<Error> sendFuture;
         std::tie(descriptorFuture, sendFuture) =
             sendWithFuture(channel, nullptr, 0);
         Error descriptorError;
-        Channel::TDescriptor descriptor;
+        TDescriptor descriptor;
         std::tie(descriptorError, descriptor) = descriptorFuture.get();
         EXPECT_FALSE(descriptorError) << descriptorError.what();
         peers_->send(PeerGroup::kClient, descriptor);
@@ -349,8 +340,7 @@ TEST_P(ChannelTest, NullPointer) {
       },
       [&](std::shared_ptr<transport::Connection> conn) {
         std::shared_ptr<Context> ctx = GetParam()->makeContext("client");
-        auto channel =
-            ctx->createChannel(std::move(conn), Channel::Endpoint::kConnect);
+        auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
 
         // Perform recv and wait for completion.
         auto descriptor = peers_->recv(PeerGroup::kClient);
@@ -372,19 +362,18 @@ TEST_P(ChannelTest, EmptyTensor) {
   testConnection(
       [&](std::shared_ptr<transport::Connection> conn) {
         std::shared_ptr<Context> ctx = GetParam()->makeContext("server");
-        auto channel =
-            ctx->createChannel(std::move(conn), Channel::Endpoint::kListen);
+        auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
 
         // Allocate a non-empty vector so that its .data() pointer is non-null.
         std::vector<uint8_t> data(1);
 
         // Perform send and wait for completion.
-        std::future<std::tuple<Error, Channel::TDescriptor>> descriptorFuture;
+        std::future<std::tuple<Error, TDescriptor>> descriptorFuture;
         std::future<Error> sendFuture;
         std::tie(descriptorFuture, sendFuture) =
             sendWithFuture(channel, data.data(), 0);
         Error descriptorError;
-        Channel::TDescriptor descriptor;
+        TDescriptor descriptor;
         std::tie(descriptorError, descriptor) = descriptorFuture.get();
         EXPECT_FALSE(descriptorError) << descriptorError.what();
         peers_->send(PeerGroup::kClient, descriptor);
@@ -398,8 +387,7 @@ TEST_P(ChannelTest, EmptyTensor) {
       },
       [&](std::shared_ptr<transport::Connection> conn) {
         std::shared_ptr<Context> ctx = GetParam()->makeContext("client");
-        auto channel =
-            ctx->createChannel(std::move(conn), Channel::Endpoint::kConnect);
+        auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
 
         // Allocate a non-empty vector so that its .data() pointer is non-null.
         std::vector<uint8_t> data(1);
@@ -425,12 +413,12 @@ TEST_P(ChannelTest, contextIsNotJoined) {
       [&](std::shared_ptr<transport::Connection> conn) {
         std::shared_ptr<Context> context = GetParam()->makeContext("server");
         peers_->send(PeerGroup::kClient, kReady);
-        context->createChannel(std::move(conn), Channel::Endpoint::kListen);
+        context->createChannel(std::move(conn), Endpoint::kListen);
       },
       [&](std::shared_ptr<transport::Connection> conn) {
         std::shared_ptr<Context> context = GetParam()->makeContext("client");
         EXPECT_EQ(kReady, peers_->recv(PeerGroup::kClient));
-        context->createChannel(std::move(conn), Channel::Endpoint::kConnect);
+        context->createChannel(std::move(conn), Endpoint::kConnect);
       });
 }
 
@@ -454,8 +442,7 @@ TEST_P(ChannelTest, CallbacksAreDeferred) {
   testConnection(
       [&](std::shared_ptr<transport::Connection> conn) {
         std::shared_ptr<Context> ctx = GetParam()->makeContext("server");
-        auto channel =
-            ctx->createChannel(std::move(conn), Channel::Endpoint::kListen);
+        auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
 
         // Initialize with sequential values.
         std::vector<uint8_t> data(dataSize);
@@ -464,15 +451,14 @@ TEST_P(ChannelTest, CallbacksAreDeferred) {
         buffer->wrap(data.data());
 
         // Perform send and wait for completion.
-        std::promise<std::tuple<Error, Channel::TDescriptor>> descriptorPromise;
+        std::promise<std::tuple<Error, TDescriptor>> descriptorPromise;
         std::promise<Error> sendPromise;
         std::mutex mutex;
         std::unique_lock<std::mutex> callerLock(mutex);
         channel->send(
             buffer->data(),
             buffer->size(),
-            [&descriptorPromise](
-                const Error& error, Channel::TDescriptor descriptor) {
+            [&descriptorPromise](const Error& error, TDescriptor descriptor) {
               descriptorPromise.set_value(
                   std::make_tuple(error, std::move(descriptor)));
             },
@@ -482,7 +468,7 @@ TEST_P(ChannelTest, CallbacksAreDeferred) {
             });
         callerLock.unlock();
         Error descriptorError;
-        Channel::TDescriptor descriptor;
+        TDescriptor descriptor;
         std::tie(descriptorError, descriptor) =
             descriptorPromise.get_future().get();
         EXPECT_FALSE(descriptorError) << descriptorError.what();
@@ -497,8 +483,7 @@ TEST_P(ChannelTest, CallbacksAreDeferred) {
       },
       [&](std::shared_ptr<transport::Connection> conn) {
         std::shared_ptr<Context> ctx = GetParam()->makeContext("client");
-        auto channel =
-            ctx->createChannel(std::move(conn), Channel::Endpoint::kConnect);
+        auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
 
         // Initialize with zeroes.
         std::vector<uint8_t> data(dataSize);

--- a/tensorpipe/test/channel/channel_test.h
+++ b/tensorpipe/test/channel/channel_test.h
@@ -123,9 +123,8 @@ class ChannelTest : public ::testing::TestWithParam<ChannelTestHelper*> {
   }
 
   [[nodiscard]] std::pair<
-      std::future<std::tuple<
-          tensorpipe::Error,
-          tensorpipe::channel::Channel::TDescriptor>>,
+      std::future<
+          std::tuple<tensorpipe::Error, tensorpipe::channel::TDescriptor>>,
       std::future<tensorpipe::Error>>
   sendWithFuture(
       std::shared_ptr<tensorpipe::channel::Channel> channel,
@@ -155,7 +154,7 @@ class ChannelTest : public ::testing::TestWithParam<ChannelTestHelper*> {
 
   [[nodiscard]] std::future<tensorpipe::Error> recvWithFuture(
       std::shared_ptr<tensorpipe::channel::Channel> channel,
-      tensorpipe::channel::Channel::TDescriptor descriptor,
+      tensorpipe::channel::TDescriptor descriptor,
       void* ptr,
       size_t length) {
     auto promise = std::make_shared<std::promise<tensorpipe::Error>>();

--- a/tensorpipe/test/channel/cuda_ipc/cuda_ipc_test.cc
+++ b/tensorpipe/test/channel/cuda_ipc/cuda_ipc_test.cc
@@ -102,7 +102,7 @@ TEST_P(CudaIpcChannelTest, ReceiverWaitsForStartEvent) {
       [&](std::shared_ptr<transport::Connection> conn) {
         std::shared_ptr<Context> ctx = GetParam()->makeContext("server");
         auto channel = std::static_pointer_cast<cuda_ipc::Channel>(
-            ctx->createChannel(std::move(conn), Channel::Endpoint::kListen));
+            ctx->createChannel(std::move(conn), Endpoint::kListen));
 
         TP_CUDA_CHECK(cudaSetDevice(0));
         cudaStream_t sendStream;
@@ -138,7 +138,7 @@ TEST_P(CudaIpcChannelTest, ReceiverWaitsForStartEvent) {
             sendStream);
 
         Error descriptorError;
-        Channel::TDescriptor descriptor;
+        TDescriptor descriptor;
         std::tie(descriptorError, descriptor) = descriptorFuture.get();
 
         EXPECT_FALSE(descriptorError) << descriptorError.what();
@@ -155,7 +155,7 @@ TEST_P(CudaIpcChannelTest, ReceiverWaitsForStartEvent) {
       [&](std::shared_ptr<transport::Connection> conn) {
         std::shared_ptr<Context> ctx = GetParam()->makeContext("client");
         auto channel = std::static_pointer_cast<cuda_ipc::Channel>(
-            ctx->createChannel(std::move(conn), Channel::Endpoint::kConnect));
+            ctx->createChannel(std::move(conn), Endpoint::kConnect));
 
         TP_CUDA_CHECK(cudaSetDevice(0));
         cudaStream_t recvStream;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #216 Add support for CUDA channels in the Pipe.
* #214 Refactor channel tests.
* #213 Get rid of `channelName()` in channel test helper.
* #212 Make Channel API accept buffer structs rather than raw pointers.
* #211 Add TENSORPIPE_SUPPORTS_CUDA flag.
* **#210 Move channel types from `channel::Channel::` to `channel::`.**

This is a first step towards introducing templated `Channel`/`Context`
classes for CPU/CUDA tensors.

Differential Revision: [D23598034](https://our.internmc.facebook.com/intern/diff/D23598034)