### PR TITLE
Add TENSORPIPE_SUPPORTS_CUDA flag.

### DIFF
--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -10,12 +10,18 @@ else()
   set(LINUX OFF)
 endif()
 
+include(CMakeDependentOption)
+
+# TODO: Default to ON if CUDA available.
+option(TP_ENABLE_CUDA "Enable support for CUDA tensors" OFF)
+
 # Transports
 option(TP_ENABLE_SHM "Enable shm transport" ${LINUX})
 
 # Channels
 option(TP_ENABLE_CMA "Enable cma channel" ${LINUX})
-option(TP_ENABLE_CUDA_IPC "Enable CUDA IPC channel" ${LINUX})
+cmake_dependent_option(TP_ENABLE_CUDA_IPC "Enable CUDA IPC channel" ON
+                       TP_ENABLE_CUDA OFF)
 
 # Optional features
 option(TP_BUILD_BENCHMARK "Build benchmarks" OFF)

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -13,7 +13,7 @@ endif()
 include(CMakeDependentOption)
 
 # TODO: Default to ON if CUDA available.
-option(TP_ENABLE_CUDA "Enable support for CUDA tensors" OFF)
+option(TP_USE_CUDA "Enable support for CUDA tensors" OFF)
 
 # Transports
 option(TP_ENABLE_SHM "Enable shm transport" ${LINUX})
@@ -21,7 +21,7 @@ option(TP_ENABLE_SHM "Enable shm transport" ${LINUX})
 # Channels
 option(TP_ENABLE_CMA "Enable cma channel" ${LINUX})
 cmake_dependent_option(TP_ENABLE_CUDA_IPC "Enable CUDA IPC channel" ON
-                       TP_ENABLE_CUDA OFF)
+                       "TP_USE_CUDA" OFF)
 
 # Optional features
 option(TP_BUILD_BENCHMARK "Build benchmarks" OFF)

--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -58,17 +58,22 @@ target_sources(tensorpipe PRIVATE
   channel/mpt/channel.cc
   channel/mpt/context.cc)
 
-### cuda_ipc
+## CUDA channels
 
-if(TP_ENABLE_CUDA_IPC)
-  target_sources(tensorpipe PRIVATE
-    channel/cuda_ipc/channel.cc
-    channel/cuda_ipc/context.cc)
-  set(TENSORPIPE_HAS_CUDA_IPC_CHANNEL 1)
-
+if(TP_ENABLE_CUDA)
   find_package(CUDA REQUIRED)
   target_link_libraries(tensorpipe PUBLIC ${CUDA_LIBRARIES})
   target_include_directories(tensorpipe PUBLIC ${CUDA_INCLUDE_DIRS})
+  set(TENSORPIPE_HAS_CUDA 1)
+
+  ### cuda_ipc
+
+  if(TP_ENABLE_CUDA_IPC)
+    target_sources(tensorpipe PRIVATE
+      channel/cuda_ipc/channel.cc
+      channel/cuda_ipc/context.cc)
+    set(TENSORPIPE_HAS_CUDA_IPC_CHANNEL 1)
+  endif()
 endif()
 
 ## Transports
@@ -119,7 +124,7 @@ endif()
 
 ## Config
 
-configure_file(tensorpipe.h.in tensorpipe.h)
+configure_file(config.h.in config.h)
 
 
 ## Libnop

--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -60,11 +60,11 @@ target_sources(tensorpipe PRIVATE
 
 ## CUDA channels
 
-if(TP_ENABLE_CUDA)
+if(TP_USE_CUDA)
   find_package(CUDA REQUIRED)
   target_link_libraries(tensorpipe PUBLIC ${CUDA_LIBRARIES})
   target_include_directories(tensorpipe PUBLIC ${CUDA_INCLUDE_DIRS})
-  set(TENSORPIPE_HAS_CUDA 1)
+  set(TENSORPIPE_SUPPORTS_CUDA 1)
 
   ### cuda_ipc
 

--- a/tensorpipe/config.h.in
+++ b/tensorpipe/config.h.in
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#cmakedefine01 TENSORPIPE_HAS_CUDA
+
+#cmakedefine01 TENSORPIPE_HAS_SHM_TRANSPORT
+
+#cmakedefine01 TENSORPIPE_HAS_CMA_CHANNEL
+#cmakedefine01 TENSORPIPE_HAS_CUDA_IPC_CHANNEL

--- a/tensorpipe/config.h.in
+++ b/tensorpipe/config.h.in
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#cmakedefine01 TENSORPIPE_HAS_CUDA
+#cmakedefine01 TENSORPIPE_SUPPORTS_CUDA
 
 #cmakedefine01 TENSORPIPE_HAS_SHM_TRANSPORT
 

--- a/tensorpipe/tensorpipe.h
+++ b/tensorpipe/tensorpipe.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <tensorpipe/config.h>
+
 // High-level API
 
 #include <tensorpipe/core/context.h>
@@ -24,7 +26,6 @@
 #include <tensorpipe/transport/uv/context.h>
 #include <tensorpipe/transport/uv/error.h>
 
-#cmakedefine01 TENSORPIPE_HAS_SHM_TRANSPORT
 #if TENSORPIPE_HAS_SHM_TRANSPORT
 #include <tensorpipe/transport/shm/context.h>
 #endif // TENSORPIPE_HAS_SHM_TRANSPORT
@@ -38,12 +39,10 @@
 #include <tensorpipe/channel/mpt/context.h>
 #include <tensorpipe/channel/xth/context.h>
 
-#cmakedefine01 TENSORPIPE_HAS_CMA_CHANNEL
 #if TENSORPIPE_HAS_CMA_CHANNEL
 #include <tensorpipe/channel/cma/context.h>
 #endif // TENSORPIPE_HAS_CMA_CHANNEL
 
-#cmakedefine01 TENSORPIPE_HAS_CUDA_IPC_CHANNEL
 #if TENSORPIPE_HAS_CUDA_IPC_CHANNEL
 #include <tensorpipe/channel/cuda_ipc/context.h>
 #endif // TENSORPIPE_HAS_CUDA_IPC_CHANNEL


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #216 Add support for CUDA channels in the Pipe.
* #214 Refactor channel tests.
* #213 Get rid of `channelName()` in channel test helper.
* #212 Make Channel API accept buffer structs rather than raw pointers.
* **#211 Add TENSORPIPE_SUPPORTS_CUDA flag.**
* #210 Move channel types from `channel::Channel::` to `channel::`.

+ Add a generic `TENSORPIPE_SUPPORTS_CUDA` config macro (controlled by the
`TP_USE_CUDA` CMake flag) intended to indicate support for CUDA
tensors throughout TensorPipe.
+ Move definition of config macros (`TENSORPIPE_HAS_XXX`) to a
separate config.h header to avoid circular include
dependencies (having xxx.h including tensorpipe.h for accessing config
macros and tensorpipe.h including xxx.h for convenience).

Differential Revision: [D23598039](https://our.internmc.facebook.com/intern/diff/D23598039)