### PR TITLE
Avoid overly-strict atomics in ringbuffer

### DIFF
--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -90,13 +90,14 @@ target_link_libraries(tensorpipe PRIVATE uv::uv)
 
 if(TP_ENABLE_SHM)
   target_sources(tensorpipe PRIVATE
+    common/fd.cc
+    common/socket.cc
     transport/shm/context.cc
     transport/shm/connection.cc
-    transport/shm/fd.cc
     transport/shm/listener.cc
     transport/shm/loop.cc
     transport/shm/reactor.cc
-    transport/shm/socket.cc
+    transport/shm/sockaddr.cc
     util/ringbuffer/shm.cc
     util/shm/segment.cc)
   set(TENSORPIPE_HAS_SHM_TRANSPORT 1)

--- a/tensorpipe/common/error.cc
+++ b/tensorpipe/common/error.cc
@@ -8,6 +8,7 @@
 
 #include <tensorpipe/common/error.h>
 
+#include <cstring>
 #include <sstream>
 
 #include <tensorpipe/common/defs.h>
@@ -19,6 +20,26 @@ const Error Error::kSuccess = Error();
 std::string Error::what() const {
   TP_DCHECK(error_);
   return error_->what();
+}
+
+std::string SystemError::what() const {
+  std::ostringstream ss;
+  ss << syscall_ << ": " << strerror(error_);
+  return ss.str();
+}
+
+std::string ShortReadError::what() const {
+  std::ostringstream ss;
+  ss << "short read: got " << actual_ << " bytes while expecting to read "
+     << expected_ << " bytes";
+  return ss.str();
+}
+
+std::string ShortWriteError::what() const {
+  std::ostringstream ss;
+  ss << "short write: wrote " << actual_ << " bytes while expecting to write "
+     << expected_ << " bytes";
+  return ss.str();
 }
 
 } // namespace tensorpipe

--- a/tensorpipe/common/error.h
+++ b/tensorpipe/common/error.h
@@ -71,4 +71,40 @@ class Error final {
   std::shared_ptr<BaseError> error_;
 };
 
+class SystemError final : public BaseError {
+ public:
+  explicit SystemError(const char* syscall, int error)
+      : syscall_(syscall), error_(error) {}
+
+  std::string what() const override;
+
+ private:
+  const char* syscall_;
+  const int error_;
+};
+
+class ShortReadError final : public BaseError {
+ public:
+  ShortReadError(ssize_t expected, ssize_t actual)
+      : expected_(expected), actual_(actual) {}
+
+  std::string what() const override;
+
+ private:
+  const ssize_t expected_;
+  const ssize_t actual_;
+};
+
+class ShortWriteError final : public BaseError {
+ public:
+  ShortWriteError(ssize_t expected, ssize_t actual)
+      : expected_(expected), actual_(actual) {}
+
+  std::string what() const override;
+
+ private:
+  const ssize_t expected_;
+  const ssize_t actual_;
+};
+
 } // namespace tensorpipe

--- a/tensorpipe/common/fd.cc
+++ b/tensorpipe/common/fd.cc
@@ -6,17 +6,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <tensorpipe/transport/shm/fd.h>
+#include <tensorpipe/common/fd.h>
 
 #include <unistd.h>
 
 #include <tensorpipe/common/defs.h>
+#include <tensorpipe/common/error.h>
 #include <tensorpipe/common/error_macros.h>
-#include <tensorpipe/transport/error.h>
 
 namespace tensorpipe {
-namespace transport {
-namespace shm {
 
 Fd::~Fd() {
   if (fd_ >= 0) {
@@ -73,6 +71,4 @@ Error Fd::writeFull(const void* buf, size_t count) {
   return Error::kSuccess;
 }
 
-} // namespace shm
-} // namespace transport
 } // namespace tensorpipe

--- a/tensorpipe/common/fd.h
+++ b/tensorpipe/common/fd.h
@@ -16,12 +16,10 @@
 #include <tensorpipe/common/error.h>
 
 namespace tensorpipe {
-namespace transport {
-namespace shm {
 
 class Fd {
  public:
-  /* implicit */ Fd() {}
+  Fd() = default;
 
   explicit Fd(int fd) : fd_(fd) {}
 
@@ -34,12 +32,12 @@ class Fd {
   Fd& operator=(const Fd&) = delete;
 
   // Custom move constructor.
-  Fd(Fd&& other) {
+  Fd(Fd&& other) noexcept {
     std::swap(fd_, other.fd_);
   }
 
   // Custom move assignment.
-  Fd& operator=(Fd&& other) {
+  Fd& operator=(Fd&& other) noexcept {
     std::swap(fd_, other.fd_);
     return *this;
   }
@@ -47,13 +45,6 @@ class Fd {
   // Return underlying file descriptor.
   inline int fd() const {
     return fd_;
-  }
-
-  // Release underlying file descriptor.
-  int release() {
-    auto fd = fd_;
-    fd_ = -1;
-    return fd;
   }
 
   // Proxy to read(2) with EINTR retry.
@@ -108,6 +99,4 @@ class Fd {
   int fd_{-1};
 };
 
-} // namespace shm
-} // namespace transport
 } // namespace tensorpipe

--- a/tensorpipe/common/socket.cc
+++ b/tensorpipe/common/socket.cc
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <tensorpipe/transport/shm/socket.h>
+#include <tensorpipe/common/socket.h>
 
 #include <fcntl.h>
 #include <sys/un.h>
@@ -17,38 +17,6 @@
 #include <tensorpipe/common/defs.h>
 
 namespace tensorpipe {
-namespace transport {
-namespace shm {
-
-Sockaddr Sockaddr::createAbstractUnixAddr(const std::string& name) {
-  struct sockaddr_un sun;
-  sun.sun_family = AF_UNIX;
-  std::memset(&sun.sun_path, 0, sizeof(sun.sun_path));
-  constexpr size_t offset = 1;
-  const size_t len = std::min(sizeof(sun.sun_path) - offset, name.size());
-  std::strncpy(&sun.sun_path[offset], name.c_str(), len);
-
-  // Note: instead of using sizeof(sun) we compute the addrlen from
-  // the string length of the abstract socket name. If we use
-  // sizeof(sun), lsof shows all the trailing NUL characters.
-  return Sockaddr(
-      reinterpret_cast<struct sockaddr*>(&sun),
-      sizeof(sun.sun_family) + offset + len + 1);
-};
-
-Sockaddr::Sockaddr(struct sockaddr* addr, socklen_t addrlen) {
-  TP_ARG_CHECK_LE(addrlen, sizeof(addr_));
-  std::memcpy(&addr_, addr, addrlen);
-  addrlen_ = addrlen;
-}
-
-std::string Sockaddr::str() const {
-  const struct sockaddr_un* sun{
-      reinterpret_cast<const struct sockaddr_un*>(&addr_)};
-  constexpr size_t offset = 1;
-  const size_t len = addrlen_ - sizeof(sun->sun_family) - offset - 1;
-  return std::string(&sun->sun_path[offset], len);
-}
 
 std::tuple<Error, std::shared_ptr<Socket>> Socket::createForFamily(
     sa_family_t ai_family) {
@@ -132,6 +100,4 @@ Error Socket::connect(const Sockaddr& addr) {
   return Error::kSuccess;
 }
 
-} // namespace shm
-} // namespace transport
 } // namespace tensorpipe

--- a/tensorpipe/test/transport/shm/loop_test.cc
+++ b/tensorpipe/test/transport/shm/loop_test.cc
@@ -15,6 +15,7 @@
 
 #include <gtest/gtest.h>
 
+using namespace tensorpipe;
 using namespace tensorpipe::transport::shm;
 
 namespace {

--- a/tensorpipe/test/transport/shm/reactor_test.cc
+++ b/tensorpipe/test/transport/shm/reactor_test.cc
@@ -11,11 +11,12 @@
 
 #include <tensorpipe/common/defs.h>
 #include <tensorpipe/common/queue.h>
+#include <tensorpipe/common/socket.h>
 #include <tensorpipe/transport/shm/reactor.h>
-#include <tensorpipe/transport/shm/socket.h>
 
 #include <gtest/gtest.h>
 
+using namespace tensorpipe;
 using namespace tensorpipe::transport::shm;
 
 namespace {

--- a/tensorpipe/test/transport/shm/sockaddr_test.cc
+++ b/tensorpipe/test/transport/shm/sockaddr_test.cc
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <tensorpipe/transport/shm/socket.h>
+#include <tensorpipe/transport/shm/sockaddr.h>
 
 #include <gtest/gtest.h>
 

--- a/tensorpipe/test/util/ringbuffer/ringbuffer_test.cc
+++ b/tensorpipe/test/util/ringbuffer/ringbuffer_test.cc
@@ -26,13 +26,20 @@ struct TestData {
   }
 };
 
-std::shared_ptr<RingBuffer> makeRingBuffer(size_t size) {
-  auto header = std::make_shared<RingBufferHeader>(size);
-  // In C++20 use std::make_shared<uint8_t[]>(size)
-  auto data = std::shared_ptr<uint8_t>(
-      new uint8_t[header->kDataPoolByteSize], std::default_delete<uint8_t[]>());
-  return std::make_shared<RingBuffer>(std::move(header), std::move(data));
-}
+// Holds and owns the memory for the ringbuffer's header and data.
+class RingBufferStorage {
+ public:
+  explicit RingBufferStorage(size_t size) : header_(size) {}
+
+  RingBuffer getRb() {
+    return {&header_, data_.get()};
+  }
+
+ private:
+  RingBufferHeader header_;
+  std::unique_ptr<uint8_t[]> data_ =
+      std::make_unique<uint8_t[]>(header_.kDataPoolByteSize);
+};
 
 TEST(RingBuffer, WriteCopy) {
   EXPECT_EQ(sizeof(TestData), 6);
@@ -40,13 +47,14 @@ TEST(RingBuffer, WriteCopy) {
   // 16 bytes buffer. Fits two full TestData (each 6).
   size_t size = 1u << 4;
 
-  auto rb = makeRingBuffer(size);
+  RingBufferStorage storage(size);
+  RingBuffer rb = storage.getRb();
   // Make a producer.
   Producer p{rb};
   // Make a consumer.
   Consumer c{rb};
 
-  EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
+  EXPECT_EQ(rb.getHeader().usedSizeWeak(), 0);
 
   TestData d0{.a = 0xBA98, .b = 0x7654, .c = 0xA312};
   TestData d1{.a = 0xA987, .b = 0x7777, .c = 0x2812};
@@ -56,13 +64,13 @@ TEST(RingBuffer, WriteCopy) {
     ssize_t ret = p.write(&d0, sizeof(d0));
     EXPECT_EQ(ret, sizeof(TestData));
   }
-  EXPECT_EQ(rb->getHeader().usedSizeWeak(), 6);
+  EXPECT_EQ(rb.getHeader().usedSizeWeak(), 6);
 
   {
     ssize_t ret = p.write(&d1, sizeof(d1));
     EXPECT_EQ(ret, sizeof(TestData));
   }
-  EXPECT_EQ(rb->getHeader().usedSizeWeak(), 12);
+  EXPECT_EQ(rb.getHeader().usedSizeWeak(), 12);
 
   {
     ssize_t ret = p.write(&d2, sizeof(d2));
@@ -84,7 +92,7 @@ TEST(RingBuffer, WriteCopy) {
     EXPECT_EQ(r, d1);
   }
   // It should be empty by now.
-  EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
+  EXPECT_EQ(rb.getHeader().usedSizeWeak(), 0);
 
   {
     ssize_t ret = p.write(&d2, sizeof(d2));
@@ -96,20 +104,21 @@ TEST(RingBuffer, WriteCopy) {
     EXPECT_EQ(r, d2);
   }
   // It should be empty by now.
-  EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
+  EXPECT_EQ(rb.getHeader().usedSizeWeak(), 0);
 }
 
 TEST(RingBuffer, ReadMultipleElems) {
   // 256 bytes buffer.
   size_t size = 1u << 8u;
 
-  auto rb = makeRingBuffer(size);
+  RingBufferStorage storage(size);
+  RingBuffer rb = storage.getRb();
   // Make a producer.
   Producer p{rb};
   // Make a consumer.
   Consumer c{rb};
 
-  EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
+  EXPECT_EQ(rb.getHeader().usedSizeWeak(), 0);
 
   uint16_t n = 0xACAC; // fits 128 times
 
@@ -120,7 +129,7 @@ TEST(RingBuffer, ReadMultipleElems) {
     }
 
     // It must be full by now.
-    EXPECT_EQ(rb->getHeader().usedSizeWeak(), 256);
+    EXPECT_EQ(rb.getHeader().usedSizeWeak(), 256);
 
     ssize_t ret = p.write(&n, sizeof(n));
     EXPECT_EQ(ret, -ENOSPC);
@@ -183,26 +192,27 @@ TEST(RingBuffer, CopyWrapping) {
   // 8 bytes buffer.
   size_t size = 1u << 3;
 
-  auto rb = makeRingBuffer(size);
+  RingBufferStorage storage(size);
+  RingBuffer rb = storage.getRb();
   // Make a producer.
   Producer p{rb};
   // Make a consumer.
   Consumer c{rb};
 
-  EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
+  EXPECT_EQ(rb.getHeader().usedSizeWeak(), 0);
 
   uint8_t ch = 0xA7;
   uint64_t n = 0xFFFFFFFFFFFFFFFF;
 
   // Put one byte.
-  EXPECT_EQ(rb->getHeader().readHead(), 0);
-  EXPECT_EQ(rb->getHeader().readTail(), 0);
-  EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
+  EXPECT_EQ(rb.getHeader().readHead(), 0);
+  EXPECT_EQ(rb.getHeader().readTail(), 0);
+  EXPECT_EQ(rb.getHeader().usedSizeWeak(), 0);
   ssize_t ret = p.write(&ch, sizeof(ch));
   EXPECT_EQ(ret, sizeof(ch));
-  EXPECT_EQ(rb->getHeader().readHead(), 1);
-  EXPECT_EQ(rb->getHeader().readTail(), 0);
-  EXPECT_EQ(rb->getHeader().usedSizeWeak(), 1);
+  EXPECT_EQ(rb.getHeader().readHead(), 1);
+  EXPECT_EQ(rb.getHeader().readTail(), 0);
+  EXPECT_EQ(rb.getHeader().usedSizeWeak(), 1);
 
   // Next 8 bytes won't fit.
   ret = p.write(&n, sizeof(n));
@@ -217,47 +227,48 @@ TEST(RingBuffer, CopyWrapping) {
   ret = c.read(&cr, sizeof(cr));
   EXPECT_EQ(ret, sizeof(cr));
   EXPECT_EQ(cr, ch);
-  EXPECT_EQ(rb->getHeader().readHead(), 1);
-  EXPECT_EQ(rb->getHeader().readTail(), 1);
+  EXPECT_EQ(rb.getHeader().readHead(), 1);
+  EXPECT_EQ(rb.getHeader().readTail(), 1);
 
   // Next 8 bytes will fit, but wrap.
   ret = p.write(&n, sizeof(n));
   EXPECT_EQ(ret, sizeof(n));
-  EXPECT_EQ(rb->getHeader().readHead(), 9);
-  EXPECT_EQ(rb->getHeader().readTail(), 1);
+  EXPECT_EQ(rb.getHeader().readHead(), 9);
+  EXPECT_EQ(rb.getHeader().readTail(), 1);
 
   ret = c.read(&nr, sizeof(nr));
   EXPECT_EQ(ret, sizeof(nr));
   EXPECT_EQ(nr, n);
-  EXPECT_EQ(rb->getHeader().readHead(), 9);
-  EXPECT_EQ(rb->getHeader().readTail(), 9);
+  EXPECT_EQ(rb.getHeader().readHead(), 9);
+  EXPECT_EQ(rb.getHeader().readTail(), 9);
 }
 
 TEST(RingBuffer, ReadTxWrappingOneCons) {
   // 8 bytes buffer.
   size_t size = 1u << 3;
 
-  auto rb = makeRingBuffer(size);
+  RingBufferStorage storage(size);
+  RingBuffer rb = storage.getRb();
   // Make a producer.
   Producer p{rb};
   // Make a consumer.
   Consumer c1{rb};
 
-  EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
+  EXPECT_EQ(rb.getHeader().usedSizeWeak(), 0);
 
   uint8_t ch = 0xA7;
   uint64_t n = 0xFFFFFFFFFFFFFFFF;
 
   // Put one byte.
   {
-    EXPECT_EQ(rb->getHeader().readHead(), 0);
-    EXPECT_EQ(rb->getHeader().readTail(), 0);
-    EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
+    EXPECT_EQ(rb.getHeader().readHead(), 0);
+    EXPECT_EQ(rb.getHeader().readTail(), 0);
+    EXPECT_EQ(rb.getHeader().usedSizeWeak(), 0);
     ssize_t ret = p.write(&ch, sizeof(ch));
     EXPECT_EQ(ret, sizeof(ch));
-    EXPECT_EQ(rb->getHeader().readHead(), 1);
-    EXPECT_EQ(rb->getHeader().readTail(), 0);
-    EXPECT_EQ(rb->getHeader().usedSizeWeak(), 1);
+    EXPECT_EQ(rb.getHeader().readHead(), 1);
+    EXPECT_EQ(rb.getHeader().readTail(), 0);
+    EXPECT_EQ(rb.getHeader().usedSizeWeak(), 1);
   }
 
   // Next 8 bytes won't fit.
@@ -281,8 +292,8 @@ TEST(RingBuffer, ReadTxWrappingOneCons) {
     ret = c1.readInTx</*allowPartial=*/false>(&rch, sizeof(rch));
     EXPECT_EQ(ret, sizeof(uint8_t));
     EXPECT_EQ(rch, ch);
-    EXPECT_EQ(rb->getHeader().readHead(), 1);
-    EXPECT_EQ(rb->getHeader().readTail(), 0);
+    EXPECT_EQ(rb.getHeader().readHead(), 1);
+    EXPECT_EQ(rb.getHeader().readTail(), 0);
     EXPECT_TRUE(c1.inTx());
   }
 
@@ -290,8 +301,8 @@ TEST(RingBuffer, ReadTxWrappingOneCons) {
     // Complete c1's Tx.
     ssize_t ret = c1.commitTx();
     EXPECT_EQ(ret, 0);
-    EXPECT_EQ(rb->getHeader().readHead(), 1);
-    EXPECT_EQ(rb->getHeader().readTail(), 1);
+    EXPECT_EQ(rb.getHeader().readHead(), 1);
+    EXPECT_EQ(rb.getHeader().readTail(), 1);
   }
   {
     // Retrying to commit should fail.
@@ -303,8 +314,8 @@ TEST(RingBuffer, ReadTxWrappingOneCons) {
     // Next 8 bytes will fit, but wrap.
     ssize_t ret = p.write(&n, sizeof(n));
     EXPECT_EQ(ret, sizeof(n));
-    EXPECT_EQ(rb->getHeader().readHead(), 9);
-    EXPECT_EQ(rb->getHeader().readTail(), 1);
+    EXPECT_EQ(rb.getHeader().readHead(), 9);
+    EXPECT_EQ(rb.getHeader().readTail(), 1);
   }
 
   {
@@ -317,8 +328,8 @@ TEST(RingBuffer, ReadTxWrappingOneCons) {
     ret = c1.readInTx</*allowPartial=*/false>(&rn, sizeof(rn));
     EXPECT_EQ(ret, sizeof(uint64_t));
     EXPECT_EQ(rn, n);
-    EXPECT_EQ(rb->getHeader().readHead(), 9);
-    EXPECT_EQ(rb->getHeader().readTail(), 1);
+    EXPECT_EQ(rb.getHeader().readHead(), 9);
+    EXPECT_EQ(rb.getHeader().readTail(), 1);
     EXPECT_TRUE(c1.inTx());
   }
 
@@ -334,8 +345,8 @@ TEST(RingBuffer, ReadTxWrappingOneCons) {
     // Next 8 bytes will fit, but wrap.
     ssize_t ret = p.write(&n, sizeof(n));
     EXPECT_EQ(ret, sizeof(n));
-    EXPECT_EQ(rb->getHeader().readHead(), 17);
-    EXPECT_EQ(rb->getHeader().readTail(), 9);
+    EXPECT_EQ(rb.getHeader().readHead(), 17);
+    EXPECT_EQ(rb.getHeader().readTail(), 9);
   }
   {
     ssize_t ret;
@@ -346,8 +357,8 @@ TEST(RingBuffer, ReadTxWrappingOneCons) {
     ret = c1.readInTx</*allowPartial=*/false>(&rn, sizeof(rn));
     EXPECT_EQ(ret, sizeof(uint64_t));
     EXPECT_EQ(rn, n);
-    EXPECT_EQ(rb->getHeader().readHead(), 17);
-    EXPECT_EQ(rb->getHeader().readTail(), 9);
+    EXPECT_EQ(rb.getHeader().readHead(), 17);
+    EXPECT_EQ(rb.getHeader().readTail(), 9);
   }
 
   {
@@ -366,8 +377,8 @@ TEST(RingBuffer, ReadTxWrappingOneCons) {
     ret = c1.readInTx</*allowPartial=*/false>(&rn, sizeof(rn));
     EXPECT_EQ(ret, sizeof(uint64_t));
     EXPECT_EQ(rn, n);
-    EXPECT_EQ(rb->getHeader().readHead(), 17);
-    EXPECT_EQ(rb->getHeader().readTail(), 9);
+    EXPECT_EQ(rb.getHeader().readHead(), 17);
+    EXPECT_EQ(rb.getHeader().readTail(), 9);
   }
 
   {
@@ -382,28 +393,29 @@ TEST(RingBuffer, ReadTxWrapping) {
   // 8 bytes buffer.
   size_t size = 1u << 3;
 
-  auto rb = makeRingBuffer(size);
+  RingBufferStorage storage(size);
+  RingBuffer rb = storage.getRb();
   // Make a producer.
   Producer p{rb};
   // Make consumers.
   Consumer c1{rb};
   Consumer c2{rb};
 
-  EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
+  EXPECT_EQ(rb.getHeader().usedSizeWeak(), 0);
 
   uint8_t ch = 0xA7;
   uint64_t n = 0x3333333333333333;
 
   // Put one byte.
   {
-    EXPECT_EQ(rb->getHeader().readHead(), 0);
-    EXPECT_EQ(rb->getHeader().readTail(), 0);
-    EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
+    EXPECT_EQ(rb.getHeader().readHead(), 0);
+    EXPECT_EQ(rb.getHeader().readTail(), 0);
+    EXPECT_EQ(rb.getHeader().usedSizeWeak(), 0);
     ssize_t ret = p.write(&ch, sizeof(ch));
     EXPECT_EQ(ret, sizeof(ch));
-    EXPECT_EQ(rb->getHeader().readHead(), 1);
-    EXPECT_EQ(rb->getHeader().readTail(), 0);
-    EXPECT_EQ(rb->getHeader().usedSizeWeak(), 1);
+    EXPECT_EQ(rb.getHeader().readHead(), 1);
+    EXPECT_EQ(rb.getHeader().readTail(), 0);
+    EXPECT_EQ(rb.getHeader().usedSizeWeak(), 1);
   }
 
   // Next 8 bytes won't fit.
@@ -428,8 +440,8 @@ TEST(RingBuffer, ReadTxWrapping) {
     ret = c1.readInTx</*allowPartial=*/false>(&rch, sizeof(rch));
     EXPECT_EQ(ret, sizeof(uint8_t));
     EXPECT_EQ(rch, ch);
-    EXPECT_EQ(rb->getHeader().readHead(), 1);
-    EXPECT_EQ(rb->getHeader().readTail(), 0);
+    EXPECT_EQ(rb.getHeader().readHead(), 1);
+    EXPECT_EQ(rb.getHeader().readTail(), 0);
     EXPECT_TRUE(c1.inTx());
   }
 
@@ -437,8 +449,8 @@ TEST(RingBuffer, ReadTxWrapping) {
     // Complete c1's Tx.
     ssize_t ret = c1.commitTx();
     EXPECT_EQ(ret, 0);
-    EXPECT_EQ(rb->getHeader().readHead(), 1);
-    EXPECT_EQ(rb->getHeader().readTail(), 1);
+    EXPECT_EQ(rb.getHeader().readHead(), 1);
+    EXPECT_EQ(rb.getHeader().readTail(), 1);
   }
   {
     // Retrying to commit should fail.
@@ -450,8 +462,8 @@ TEST(RingBuffer, ReadTxWrapping) {
     // Next 8 bytes will fit, but wrap.
     ssize_t ret = p.write(&n, sizeof(n));
     EXPECT_EQ(ret, sizeof(n));
-    EXPECT_EQ(rb->getHeader().readHead(), 9);
-    EXPECT_EQ(rb->getHeader().readTail(), 1);
+    EXPECT_EQ(rb.getHeader().readHead(), 9);
+    EXPECT_EQ(rb.getHeader().readTail(), 1);
   }
 
   {
@@ -464,8 +476,8 @@ TEST(RingBuffer, ReadTxWrapping) {
     ret = c1.readInTx</*allowPartial=*/false>(&rn, sizeof(rn));
     EXPECT_EQ(ret, sizeof(uint64_t));
     EXPECT_EQ(rn, n);
-    EXPECT_EQ(rb->getHeader().readHead(), 9);
-    EXPECT_EQ(rb->getHeader().readTail(), 1);
+    EXPECT_EQ(rb.getHeader().readHead(), 9);
+    EXPECT_EQ(rb.getHeader().readTail(), 1);
     EXPECT_TRUE(c1.inTx());
   }
 
@@ -488,8 +500,8 @@ TEST(RingBuffer, ReadTxWrapping) {
     // Next 8 bytes will fit, but wrap.
     ssize_t ret = p.write(&n, sizeof(n));
     EXPECT_EQ(ret, sizeof(n));
-    EXPECT_EQ(rb->getHeader().readHead(), 17);
-    EXPECT_EQ(rb->getHeader().readTail(), 9);
+    EXPECT_EQ(rb.getHeader().readHead(), 17);
+    EXPECT_EQ(rb.getHeader().readTail(), 9);
   }
   {
     ssize_t ret;
@@ -500,8 +512,8 @@ TEST(RingBuffer, ReadTxWrapping) {
     ret = c2.readInTx</*allowPartial=*/false>(&rn, sizeof(rn));
     EXPECT_EQ(ret, sizeof(uint64_t));
     EXPECT_EQ(rn, n);
-    EXPECT_EQ(rb->getHeader().readHead(), 17);
-    EXPECT_EQ(rb->getHeader().readTail(), 9);
+    EXPECT_EQ(rb.getHeader().readHead(), 17);
+    EXPECT_EQ(rb.getHeader().readTail(), 9);
   }
 
   {
@@ -520,8 +532,8 @@ TEST(RingBuffer, ReadTxWrapping) {
     ret = c1.readInTx</*allowPartial=*/false>(&rn, sizeof(rn));
     EXPECT_EQ(ret, sizeof(uint64_t));
     EXPECT_EQ(rn, n);
-    EXPECT_EQ(rb->getHeader().readHead(), 17);
-    EXPECT_EQ(rb->getHeader().readTail(), 9);
+    EXPECT_EQ(rb.getHeader().readHead(), 17);
+    EXPECT_EQ(rb.getHeader().readTail(), 9);
   }
 
   {
@@ -537,13 +549,14 @@ TEST(RingBuffer, accessContiguousInTx) {
   // 256 bytes buffer.
   size_t size = 1u << 8u;
 
-  auto rb = makeRingBuffer(size);
+  RingBufferStorage storage(size);
+  RingBuffer rb = storage.getRb();
   // Make a producer.
   Producer p{rb};
   // Make a consumer.
   Consumer c{rb};
 
-  EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
+  EXPECT_EQ(rb.getHeader().usedSizeWeak(), 0);
 
   // Use different values for the three writing passes to tell them apart.
   uint16_t value1 = 0xACAC; // fits 128 times
@@ -557,7 +570,7 @@ TEST(RingBuffer, accessContiguousInTx) {
     }
 
     // It must be full by now.
-    EXPECT_EQ(rb->getHeader().usedSizeWeak(), 256);
+    EXPECT_EQ(rb.getHeader().usedSizeWeak(), 256);
 
     uint8_t b = 0xEE;
     ssize_t ret = p.write(&b, sizeof(b));
@@ -579,7 +592,7 @@ TEST(RingBuffer, accessContiguousInTx) {
     }
     ret = c.commitTx();
     EXPECT_EQ(ret, 0);
-    EXPECT_EQ(rb->getHeader().usedSizeWeak(), 128);
+    EXPECT_EQ(rb.getHeader().usedSizeWeak(), 128);
   }
 
   {
@@ -589,7 +602,7 @@ TEST(RingBuffer, accessContiguousInTx) {
     }
 
     // It must be full again by now.
-    EXPECT_EQ(rb->getHeader().usedSizeWeak(), 256);
+    EXPECT_EQ(rb.getHeader().usedSizeWeak(), 256);
   }
 
   {
@@ -611,7 +624,7 @@ TEST(RingBuffer, accessContiguousInTx) {
     }
     ret = c.commitTx();
     EXPECT_EQ(ret, 0);
-    EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
+    EXPECT_EQ(rb.getHeader().usedSizeWeak(), 0);
   }
 
   {
@@ -625,7 +638,7 @@ TEST(RingBuffer, accessContiguousInTx) {
     }
 
     // It must be full again by now.
-    EXPECT_EQ(rb->getHeader().usedSizeWeak(), 256);
+    EXPECT_EQ(rb.getHeader().usedSizeWeak(), 256);
   }
 
   {
@@ -643,7 +656,7 @@ TEST(RingBuffer, accessContiguousInTx) {
     }
     ret = c.commitTx();
     EXPECT_EQ(ret, 0);
-    EXPECT_EQ(rb->getHeader().usedSizeWeak(), 128);
+    EXPECT_EQ(rb.getHeader().usedSizeWeak(), 128);
   }
 
   {
@@ -653,7 +666,7 @@ TEST(RingBuffer, accessContiguousInTx) {
     }
 
     // It must be full again by now.
-    EXPECT_EQ(rb->getHeader().usedSizeWeak(), 256);
+    EXPECT_EQ(rb.getHeader().usedSizeWeak(), 256);
   }
 
   {
@@ -671,7 +684,7 @@ TEST(RingBuffer, accessContiguousInTx) {
     }
     ret = c.commitTx();
     EXPECT_EQ(ret, 0);
-    EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
+    EXPECT_EQ(rb.getHeader().usedSizeWeak(), 0);
   }
 
   {
@@ -685,6 +698,6 @@ TEST(RingBuffer, accessContiguousInTx) {
     EXPECT_EQ(ret, 0);
     ret = c.commitTx();
     EXPECT_EQ(ret, 0);
-    EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
+    EXPECT_EQ(rb.getHeader().usedSizeWeak(), 0);
   }
 }

--- a/tensorpipe/test/util/ringbuffer/ringbuffer_test.cc
+++ b/tensorpipe/test/util/ringbuffer/ringbuffer_test.cc
@@ -73,13 +73,13 @@ TEST(RingBuffer, WriteCopy) {
   TestData r;
 
   {
-    ssize_t ret = c.copy(sizeof(r), &r);
+    ssize_t ret = c.read(&r, sizeof(r));
     EXPECT_EQ(ret, sizeof(r));
     EXPECT_EQ(r, d0);
   }
 
   {
-    ssize_t ret = c.copy(sizeof(r), &r);
+    ssize_t ret = c.read(&r, sizeof(r));
     EXPECT_EQ(ret, sizeof(r));
     EXPECT_EQ(r, d1);
   }
@@ -91,7 +91,7 @@ TEST(RingBuffer, WriteCopy) {
     EXPECT_EQ(ret, sizeof(TestData));
   }
   {
-    ssize_t ret = c.copy(sizeof(r), &r);
+    ssize_t ret = c.read(&r, sizeof(r));
     EXPECT_EQ(ret, sizeof(r));
     EXPECT_EQ(r, d2);
   }
@@ -140,7 +140,7 @@ TEST(RingBuffer, ReadMultipleElems) {
     EXPECT_EQ(ret, 0);
 
     std::array<uint8_t, 3> r;
-    ret = c.copyInTx(sizeof(r), r.data());
+    ret = c.readInTx</*allowPartial=*/false>(r.data(), sizeof(r));
     EXPECT_EQ(ret, 3);
     EXPECT_EQ(r[0], 0xAC);
     EXPECT_EQ(r[1], 0xAC);
@@ -156,7 +156,7 @@ TEST(RingBuffer, ReadMultipleElems) {
     EXPECT_EQ(ret, 0);
 
     std::array<uint8_t, 253> r;
-    ret = c.copyInTx(sizeof(r), r.data());
+    ret = c.readInTx</*allowPartial=*/false>(r.data(), sizeof(r));
     EXPECT_EQ(ret, 253);
     for (int i = 0; i < 253; ++i) {
       EXPECT_EQ(r[i], 0xAC);
@@ -171,7 +171,7 @@ TEST(RingBuffer, ReadMultipleElems) {
     ret = c.startTx();
     EXPECT_EQ(ret, 0);
     uint8_t ch;
-    ret = c.copyInTx(sizeof(ch), &ch);
+    ret = c.readInTx</*allowPartial=*/false>(&ch, sizeof(ch));
     EXPECT_EQ(ret, -ENODATA);
     ret = c.cancelTx();
     EXPECT_EQ(ret, 0);
@@ -214,7 +214,7 @@ TEST(RingBuffer, CopyWrapping) {
   uint8_t cr;
   uint64_t nr;
 
-  ret = c.copy(sizeof(cr), &cr);
+  ret = c.read(&cr, sizeof(cr));
   EXPECT_EQ(ret, sizeof(cr));
   EXPECT_EQ(cr, ch);
   EXPECT_EQ(rb->getHeader().readHead(), 1);
@@ -226,7 +226,7 @@ TEST(RingBuffer, CopyWrapping) {
   EXPECT_EQ(rb->getHeader().readHead(), 9);
   EXPECT_EQ(rb->getHeader().readTail(), 1);
 
-  ret = c.copy(sizeof(nr), &nr);
+  ret = c.read(&nr, sizeof(nr));
   EXPECT_EQ(ret, sizeof(nr));
   EXPECT_EQ(nr, n);
   EXPECT_EQ(rb->getHeader().readHead(), 9);
@@ -278,7 +278,7 @@ TEST(RingBuffer, ReadTxWrappingOneCons) {
     EXPECT_EQ(ret, 0);
 
     uint8_t rch;
-    ret = c1.copyInTx(sizeof(rch), &rch);
+    ret = c1.readInTx</*allowPartial=*/false>(&rch, sizeof(rch));
     EXPECT_EQ(ret, sizeof(uint8_t));
     EXPECT_EQ(rch, ch);
     EXPECT_EQ(rb->getHeader().readHead(), 1);
@@ -314,7 +314,7 @@ TEST(RingBuffer, ReadTxWrappingOneCons) {
     EXPECT_EQ(ret, 0);
 
     uint64_t rn;
-    ret = c1.copyInTx(sizeof(rn), &rn);
+    ret = c1.readInTx</*allowPartial=*/false>(&rn, sizeof(rn));
     EXPECT_EQ(ret, sizeof(uint64_t));
     EXPECT_EQ(rn, n);
     EXPECT_EQ(rb->getHeader().readHead(), 9);
@@ -343,7 +343,7 @@ TEST(RingBuffer, ReadTxWrappingOneCons) {
     EXPECT_EQ(ret, 0);
 
     uint64_t rn;
-    ret = c1.copyInTx(sizeof(rn), &rn);
+    ret = c1.readInTx</*allowPartial=*/false>(&rn, sizeof(rn));
     EXPECT_EQ(ret, sizeof(uint64_t));
     EXPECT_EQ(rn, n);
     EXPECT_EQ(rb->getHeader().readHead(), 17);
@@ -363,7 +363,7 @@ TEST(RingBuffer, ReadTxWrappingOneCons) {
     EXPECT_EQ(ret, 0);
 
     uint64_t rn;
-    ret = c1.copyInTx(sizeof(rn), &rn);
+    ret = c1.readInTx</*allowPartial=*/false>(&rn, sizeof(rn));
     EXPECT_EQ(ret, sizeof(uint64_t));
     EXPECT_EQ(rn, n);
     EXPECT_EQ(rb->getHeader().readHead(), 17);
@@ -425,7 +425,7 @@ TEST(RingBuffer, ReadTxWrapping) {
     EXPECT_EQ(ret, 0);
 
     uint8_t rch;
-    ret = c1.copyInTx(sizeof(rch), &rch);
+    ret = c1.readInTx</*allowPartial=*/false>(&rch, sizeof(rch));
     EXPECT_EQ(ret, sizeof(uint8_t));
     EXPECT_EQ(rch, ch);
     EXPECT_EQ(rb->getHeader().readHead(), 1);
@@ -461,7 +461,7 @@ TEST(RingBuffer, ReadTxWrapping) {
     EXPECT_EQ(ret, 0);
 
     uint64_t rn;
-    ret = c1.copyInTx(sizeof(rn), &rn);
+    ret = c1.readInTx</*allowPartial=*/false>(&rn, sizeof(rn));
     EXPECT_EQ(ret, sizeof(uint64_t));
     EXPECT_EQ(rn, n);
     EXPECT_EQ(rb->getHeader().readHead(), 9);
@@ -497,7 +497,7 @@ TEST(RingBuffer, ReadTxWrapping) {
     EXPECT_EQ(ret, 0);
 
     uint64_t rn;
-    ret = c2.copyInTx(sizeof(rn), &rn);
+    ret = c2.readInTx</*allowPartial=*/false>(&rn, sizeof(rn));
     EXPECT_EQ(ret, sizeof(uint64_t));
     EXPECT_EQ(rn, n);
     EXPECT_EQ(rb->getHeader().readHead(), 17);
@@ -517,7 +517,7 @@ TEST(RingBuffer, ReadTxWrapping) {
     EXPECT_EQ(ret, 0);
 
     uint64_t rn;
-    ret = c1.copyInTx(sizeof(rn), &rn);
+    ret = c1.readInTx</*allowPartial=*/false>(&rn, sizeof(rn));
     EXPECT_EQ(ret, sizeof(uint64_t));
     EXPECT_EQ(rn, n);
     EXPECT_EQ(rb->getHeader().readHead(), 17);
@@ -533,7 +533,7 @@ TEST(RingBuffer, ReadTxWrapping) {
   }
 }
 
-TEST(RingBuffer, readContiguousAtMostInTx) {
+TEST(RingBuffer, accessContiguousInTx) {
   // 256 bytes buffer.
   size_t size = 1u << 8u;
 
@@ -545,12 +545,15 @@ TEST(RingBuffer, readContiguousAtMostInTx) {
 
   EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
 
-  uint16_t n = 0xACAC; // fits 128 times
+  // Use different values for the three writing passes to tell them apart.
+  uint16_t value1 = 0xACAC; // fits 128 times
+  uint16_t value2 = 0xDCDC; // fits 128 times
+  uint16_t value3 = 0xEFEF; // fits 128 times
 
   {
     for (int i = 0; i < 128; ++i) {
-      ssize_t ret = p.write(&n, sizeof(n));
-      EXPECT_EQ(ret, sizeof(n));
+      ssize_t ret = p.write(&value1, sizeof(value1));
+      EXPECT_EQ(ret, sizeof(value1));
     }
 
     // It must be full by now.
@@ -562,26 +565,27 @@ TEST(RingBuffer, readContiguousAtMostInTx) {
   }
 
   {
-    // Read the first 200 bytes at once.
+    // Read a 128-byte buffer that is left-aligned with the start.
     ssize_t ret;
     ret = c.startTx();
     EXPECT_EQ(ret, 0);
 
-    const uint8_t* ptr;
-    std::tie(ret, ptr) = c.readContiguousAtMostInTx(200);
-    EXPECT_EQ(ret, 200);
-    for (int i = 0; i < 200; ++i) {
-      EXPECT_EQ(ptr[i], 0xAC);
+    std::array<Consumer::Buffer, 2> buffers;
+    std::tie(ret, buffers) = c.accessContiguousInTx</*allowPartial=*/true>(128);
+    EXPECT_EQ(ret, 1);
+    EXPECT_EQ(buffers[0].len, 128);
+    for (int i = 0; i < 128; ++i) {
+      EXPECT_EQ(buffers[0].ptr[i], 0xAC);
     }
     ret = c.commitTx();
     EXPECT_EQ(ret, 0);
-    EXPECT_EQ(rb->getHeader().usedSizeWeak(), 56);
+    EXPECT_EQ(rb->getHeader().usedSizeWeak(), 128);
   }
 
   {
-    for (int i = 0; i < 100; ++i) {
-      ssize_t ret = p.write(&n, sizeof(n));
-      EXPECT_EQ(ret, sizeof(n));
+    for (int i = 0; i < 64; ++i) {
+      ssize_t ret = p.write(&value2, sizeof(value2));
+      EXPECT_EQ(ret, sizeof(value2));
     }
 
     // It must be full again by now.
@@ -589,26 +593,63 @@ TEST(RingBuffer, readContiguousAtMostInTx) {
   }
 
   {
-    // Attempt reading the next 200 bytes, but only 56 available contiguously.
+    // Read a 256-byte buffer that wraps around halfway through.
     ssize_t ret;
     ret = c.startTx();
     EXPECT_EQ(ret, 0);
 
-    const uint8_t* ptr;
-    std::tie(ret, ptr) = c.readContiguousAtMostInTx(200);
-    EXPECT_EQ(ret, 56);
-    for (int i = 0; i < 56; ++i) {
-      EXPECT_EQ(ptr[i], 0xAC);
+    std::array<Consumer::Buffer, 2> buffers;
+    std::tie(ret, buffers) = c.accessContiguousInTx</*allowPartial=*/true>(256);
+    EXPECT_EQ(ret, 2);
+    EXPECT_EQ(buffers[0].len, 128);
+    for (int i = 0; i < 128; ++i) {
+      EXPECT_EQ(buffers[0].ptr[i], 0xAC);
+    }
+    EXPECT_EQ(buffers[1].len, 128);
+    for (int i = 0; i < 128; ++i) {
+      EXPECT_EQ(buffers[1].ptr[i], 0xDC);
     }
     ret = c.commitTx();
     EXPECT_EQ(ret, 0);
-    EXPECT_EQ(rb->getHeader().usedSizeWeak(), 200);
+    EXPECT_EQ(rb->getHeader().usedSizeWeak(), 0);
   }
 
   {
-    for (int i = 0; i < 28; ++i) {
-      ssize_t ret = p.write(&n, sizeof(n));
-      EXPECT_EQ(ret, sizeof(n));
+    for (int i = 0; i < 64; ++i) {
+      ssize_t ret = p.write(&value2, sizeof(value2));
+      EXPECT_EQ(ret, sizeof(value2));
+    }
+    for (int i = 0; i < 64; ++i) {
+      ssize_t ret = p.write(&value3, sizeof(value3));
+      EXPECT_EQ(ret, sizeof(value3));
+    }
+
+    // It must be full again by now.
+    EXPECT_EQ(rb->getHeader().usedSizeWeak(), 256);
+  }
+
+  {
+    // Read a 128-byte buffer that is right-aligned with the end.
+    ssize_t ret;
+    ret = c.startTx();
+    EXPECT_EQ(ret, 0);
+
+    std::array<Consumer::Buffer, 2> buffers;
+    std::tie(ret, buffers) = c.accessContiguousInTx</*allowPartial=*/true>(128);
+    EXPECT_EQ(ret, 1);
+    EXPECT_EQ(buffers[0].len, 128);
+    for (int i = 0; i < 128; ++i) {
+      EXPECT_EQ(buffers[0].ptr[i], 0xDC);
+    }
+    ret = c.commitTx();
+    EXPECT_EQ(ret, 0);
+    EXPECT_EQ(rb->getHeader().usedSizeWeak(), 128);
+  }
+
+  {
+    for (int i = 0; i < 64; ++i) {
+      ssize_t ret = p.write(&value3, sizeof(value3));
+      EXPECT_EQ(ret, sizeof(value3));
     }
 
     // It must be full again by now.
@@ -621,11 +662,12 @@ TEST(RingBuffer, readContiguousAtMostInTx) {
     ret = c.startTx();
     EXPECT_EQ(ret, 0);
 
-    const uint8_t* ptr;
-    std::tie(ret, ptr) = c.readContiguousAtMostInTx(256);
-    EXPECT_EQ(ret, 256);
+    std::array<Consumer::Buffer, 2> buffers;
+    std::tie(ret, buffers) = c.accessContiguousInTx</*allowPartial=*/true>(256);
+    EXPECT_EQ(ret, 1);
+    EXPECT_EQ(buffers[0].len, 256);
     for (int i = 0; i < 256; ++i) {
-      EXPECT_EQ(ptr[i], 0xAC);
+      EXPECT_EQ(buffers[0].ptr[i], 0xEF);
     }
     ret = c.commitTx();
     EXPECT_EQ(ret, 0);
@@ -638,8 +680,8 @@ TEST(RingBuffer, readContiguousAtMostInTx) {
     ret = c.startTx();
     EXPECT_EQ(ret, 0);
 
-    const uint8_t* ptr;
-    std::tie(ret, ptr) = c.readContiguousAtMostInTx(200);
+    std::array<Consumer::Buffer, 2> buffers;
+    std::tie(ret, buffers) = c.accessContiguousInTx</*allowPartial=*/true>(200);
     EXPECT_EQ(ret, 0);
     ret = c.commitTx();
     EXPECT_EQ(ret, 0);

--- a/tensorpipe/test/util/ringbuffer/shm_ringbuffer_test.cc
+++ b/tensorpipe/test/util/ringbuffer/shm_ringbuffer_test.cc
@@ -55,7 +55,7 @@ TEST(ShmRingBuffer, SameProducerConsumer) {
     int i = 0;
     while (i < 2000) {
       int value;
-      ssize_t ret = cons.copy(sizeof(value), &value);
+      ssize_t ret = cons.read(&value, sizeof(value));
       EXPECT_EQ(ret, sizeof(value));
       EXPECT_EQ(value, i);
       ++i;
@@ -140,7 +140,7 @@ TEST(ShmRingBuffer, SingleProducer_SingleConsumer) {
   int i = 0;
   while (i < 2000) {
     int value;
-    ssize_t ret = cons.copy(sizeof(value), &value);
+    ssize_t ret = cons.read(&value, sizeof(value));
     if (ret == -ENODATA) {
       std::this_thread::yield();
       continue;

--- a/tensorpipe/transport/error.cc
+++ b/tensorpipe/transport/error.cc
@@ -8,31 +8,8 @@
 
 #include <tensorpipe/transport/error.h>
 
-#include <cstring>
-#include <sstream>
-
 namespace tensorpipe {
 namespace transport {
-
-std::string SystemError::what() const {
-  std::ostringstream ss;
-  ss << syscall_ << ": " << strerror(error_);
-  return ss.str();
-}
-
-std::string ShortReadError::what() const {
-  std::ostringstream ss;
-  ss << "short read: got " << actual_ << " bytes while expecting to read "
-     << expected_ << " bytes";
-  return ss.str();
-}
-
-std::string ShortWriteError::what() const {
-  std::ostringstream ss;
-  ss << "short write: wrote " << actual_ << " bytes while expecting to write "
-     << expected_ << " bytes";
-  return ss.str();
-}
 
 std::string EOFError::what() const {
   return "eof";

--- a/tensorpipe/transport/error.h
+++ b/tensorpipe/transport/error.h
@@ -15,42 +15,6 @@
 namespace tensorpipe {
 namespace transport {
 
-class SystemError final : public BaseError {
- public:
-  explicit SystemError(const char* syscall, int error)
-      : syscall_(syscall), error_(error) {}
-
-  std::string what() const override;
-
- private:
-  const char* syscall_;
-  const int error_;
-};
-
-class ShortReadError final : public BaseError {
- public:
-  ShortReadError(ssize_t expected, ssize_t actual)
-      : expected_(expected), actual_(actual) {}
-
-  std::string what() const override;
-
- private:
-  const ssize_t expected_;
-  const ssize_t actual_;
-};
-
-class ShortWriteError final : public BaseError {
- public:
-  ShortWriteError(ssize_t expected, ssize_t actual)
-      : expected_(expected), actual_(actual) {}
-
-  std::string what() const override;
-
- private:
-  const ssize_t expected_;
-  const ssize_t actual_;
-};
-
 class EOFError final : public BaseError {
  public:
   EOFError() {}

--- a/tensorpipe/transport/shm/connection.cc
+++ b/tensorpipe/transport/shm/connection.cc
@@ -19,7 +19,7 @@
 #include <tensorpipe/transport/error.h>
 #include <tensorpipe/transport/shm/loop.h>
 #include <tensorpipe/transport/shm/reactor.h>
-#include <tensorpipe/transport/shm/socket.h>
+#include <tensorpipe/transport/shm/sockaddr.h>
 #include <tensorpipe/util/ringbuffer/consumer.h>
 #include <tensorpipe/util/ringbuffer/producer.h>
 #include <tensorpipe/util/ringbuffer/shm.h>
@@ -921,7 +921,7 @@ void Connection::Impl::handleEventInFromLoop() {
     // Load ringbuffer for outbox.
     std::tie(outboxHeaderSegment_, outboxDataSegment_, outboxRb_) =
         util::ringbuffer::shm::load(
-            outboxHeaderFd.release(), outboxDataFd.release());
+            std::move(outboxHeaderFd), std::move(outboxDataFd));
 
     // Initialize remote reactor trigger.
     peerReactorTrigger_.emplace(

--- a/tensorpipe/transport/shm/connection.cc
+++ b/tensorpipe/transport/shm/connection.cc
@@ -30,6 +30,8 @@ namespace shm {
 
 namespace {
 
+constexpr auto kBufferSize = 2 * 1024 * 1024;
+
 // Reads happen only if the user supplied a callback (and optionally
 // a destination buffer). The callback is run from the event loop
 // thread upon receiving a notification from our peer.
@@ -46,13 +48,15 @@ class ReadOperation {
 
  public:
   using read_callback_fn = Connection::read_callback_fn;
-  using read_fn = std::function<ssize_t(util::ringbuffer::Consumer&)>;
+  // Read into a user-provided buffer of known length.
   explicit ReadOperation(void* ptr, size_t len, read_callback_fn fn);
-  explicit ReadOperation(read_fn reader, read_callback_fn fn);
+  // Read into an auto-allocated buffer, whose length is read from the wire.
   explicit ReadOperation(read_callback_fn fn);
+  // Read into a user-provided libnop object, read length from the wire.
+  explicit ReadOperation(AbstractNopHolder* nopObject, read_callback_fn fn);
 
   // Processes a pending read.
-  bool handleRead(util::ringbuffer::Consumer& consumer);
+  size_t handleRead(util::ringbuffer::Consumer& consumer);
 
   bool completed() const {
     return (mode_ == READ_PAYLOAD && bytesRead_ == len_);
@@ -63,12 +67,17 @@ class ReadOperation {
  private:
   Mode mode_{READ_LENGTH};
   void* ptr_{nullptr};
-  read_fn reader_;
+  AbstractNopHolder* nopObject_{nullptr};
   std::unique_ptr<uint8_t[]> buf_;
   size_t len_{0};
   size_t bytesRead_{0};
   read_callback_fn fn_;
+  // Use a separare flag, rather than checking if ptr_ == nullptr, to catch the
+  // case of a user explicitly passing in a nullptr with length zero, in which
+  // case we must check that the length matches the header we see on the wire.
   const bool ptrProvided_;
+
+  ssize_t readNopObject_(util::ringbuffer::Consumer& consumer);
 };
 
 // Writes happen only if the user supplied a memory pointer, the
@@ -86,11 +95,12 @@ class WriteOperation {
 
  public:
   using write_callback_fn = Connection::write_callback_fn;
-  using write_fn = std::function<ssize_t(util::ringbuffer::Producer&)>;
+  // Write from a user-provided buffer of known length.
   WriteOperation(const void* ptr, size_t len, write_callback_fn fn);
-  WriteOperation(write_fn writer, write_callback_fn fn);
+  // Write from a user-provided libnop object.
+  WriteOperation(const AbstractNopHolder* nopObject, write_callback_fn fn);
 
-  bool handleWrite(util::ringbuffer::Producer& producer);
+  size_t handleWrite(util::ringbuffer::Producer& producer);
 
   bool completed() const {
     return (mode_ == WRITE_PAYLOAD && bytesWritten_ == len_);
@@ -101,100 +111,98 @@ class WriteOperation {
  private:
   Mode mode_{WRITE_LENGTH};
   const void* ptr_{nullptr};
-  write_fn writer_;
+  const AbstractNopHolder* nopObject_{nullptr};
   size_t len_{0};
   size_t bytesWritten_{0};
   write_callback_fn fn_;
+
+  ssize_t writeNopObject_(util::ringbuffer::Producer& producer);
 };
 
 ReadOperation::ReadOperation(void* ptr, size_t len, read_callback_fn fn)
     : ptr_(ptr), len_(len), fn_(std::move(fn)), ptrProvided_(true) {}
 
-ReadOperation::ReadOperation(read_fn reader, read_callback_fn fn)
-    : reader_(std::move(reader)), fn_(std::move(fn)), ptrProvided_(false) {}
-
 ReadOperation::ReadOperation(read_callback_fn fn)
     : fn_(std::move(fn)), ptrProvided_(false) {}
 
-bool ReadOperation::handleRead(util::ringbuffer::Consumer& inbox) {
-  // Start read transaction.
-  // Retry because this must succeed.
-  for (;;) {
-    const auto ret = inbox.startTx();
-    TP_DCHECK(ret >= 0 || ret == -EAGAIN);
-    if (ret < 0) {
-      continue;
-    }
-    break;
-  }
+ReadOperation::ReadOperation(AbstractNopHolder* nopObject, read_callback_fn fn)
+    : nopObject_(nopObject), fn_(std::move(fn)), ptrProvided_(false) {}
 
-  bool lengthRead = false;
-  if (reader_) {
-    auto ret = reader_(inbox);
-    if (ret == -ENODATA) {
-      ret = inbox.cancelTx();
-      TP_THROW_SYSTEM_IF(ret < 0, -ret);
-      return false;
-    }
-    TP_THROW_SYSTEM_IF(ret < 0, -ret);
+size_t ReadOperation::handleRead(util::ringbuffer::Consumer& inbox) {
+  ssize_t ret;
+  size_t bytesReadNow = 0;
 
-    mode_ = READ_PAYLOAD;
-    bytesRead_ = len_ = ret;
-  } else {
-    if (mode_ == READ_LENGTH) {
-      uint32_t length;
-      {
-        ssize_t ret;
-        ret = inbox.readInTx</*allowPartial=*/false>(&length, sizeof(length));
-        if (ret == -ENODATA) {
-          ret = inbox.cancelTx();
-          TP_THROW_SYSTEM_IF(ret < 0, -ret);
-          return false;
-        }
-        TP_THROW_SYSTEM_IF(ret < 0, -ret);
-      }
+  // Start read transaction. This end of the connection is the only consumer for
+  // this ringbuffer, and all reads are done from the reactor thread, so there
+  // cannot be another transaction already going on. Fail hard in case.
+  ret = inbox.startTx();
+  TP_THROW_SYSTEM_IF(ret < 0, -ret);
 
-      if (ptrProvided_) {
+  if (mode_ == READ_LENGTH) {
+    uint32_t length;
+    ret = inbox.readInTx</*allowPartial=*/false>(&length, sizeof(length));
+    if (likely(ret >= 0)) {
+      mode_ = READ_PAYLOAD;
+      bytesReadNow += ret;
+      if (nopObject_ != nullptr) {
+        len_ = length;
+        TP_THROW_ASSERT_IF(len_ > kBufferSize);
+      } else if (ptrProvided_) {
         TP_DCHECK_EQ(length, len_);
       } else {
         len_ = length;
         buf_ = std::make_unique<uint8_t[]>(len_);
         ptr_ = buf_.get();
       }
-      mode_ = READ_PAYLOAD;
-      lengthRead = true;
+    } else if (unlikely(ret != -ENODATA)) {
+      TP_THROW_SYSTEM(-ret);
     }
+  }
 
-    // If reading empty buffer, skip payload read.
-    if (len_ > 0) {
-      const auto ret = inbox.readInTx</*allowPartial=*/true>(
+  if (mode_ == READ_PAYLOAD) {
+    if (nopObject_ != nullptr) {
+      ret = readNopObject_(inbox);
+    } else {
+      ret = inbox.readInTx</*allowPartial=*/true>(
           reinterpret_cast<uint8_t*>(ptr_) + bytesRead_, len_ - bytesRead_);
-      if (ret == -ENODATA) {
-        if (lengthRead) {
-          const auto ret = inbox.commitTx();
-          TP_THROW_SYSTEM_IF(ret < 0, -ret);
-          return true;
-        } else {
-          const auto ret = inbox.cancelTx();
-          TP_THROW_SYSTEM_IF(ret < 0, -ret);
-          return false;
-        }
-      }
-      TP_THROW_SYSTEM_IF(ret < 0, -ret);
+    }
+    if (likely(ret >= 0)) {
       bytesRead_ += ret;
+      bytesReadNow += ret;
+    } else if (unlikely(ret != -ENODATA)) {
+      TP_THROW_SYSTEM(-ret);
     }
   }
 
-  {
-    const auto ret = inbox.commitTx();
-    TP_THROW_SYSTEM_IF(ret < 0, -ret);
-  }
+  ret = inbox.commitTx();
+  TP_THROW_SYSTEM_IF(ret < 0, -ret);
 
   if (completed()) {
     fn_(Error::kSuccess, ptr_, len_);
   }
 
-  return true;
+  return bytesReadNow;
+}
+
+ssize_t ReadOperation::readNopObject_(util::ringbuffer::Consumer& inbox) {
+  ssize_t numBuffers;
+  std::array<util::ringbuffer::Consumer::Buffer, 2> buffers;
+  std::tie(numBuffers, buffers) =
+      inbox.accessContiguousInTx</*allowPartial=*/false>(len_);
+  if (unlikely(numBuffers < 0)) {
+    return numBuffers;
+  }
+
+  NopReader reader(
+      buffers[0].ptr, buffers[0].len, buffers[1].ptr, buffers[1].len);
+  nop::Status<void> status = nopObject_->read(reader);
+  if (status.error() == nop::ErrorStatus::ReadLimitReached) {
+    return -ENODATA;
+  } else if (status.has_error()) {
+    return -EINVAL;
+  }
+
+  return len_;
 }
 
 void ReadOperation::handleError(const Error& error) {
@@ -207,67 +215,79 @@ WriteOperation::WriteOperation(
     write_callback_fn fn)
     : ptr_(ptr), len_(len), fn_(std::move(fn)) {}
 
-WriteOperation::WriteOperation(write_fn writer, write_callback_fn fn)
-    : writer_(std::move(writer)), fn_(std::move(fn)) {}
+WriteOperation::WriteOperation(
+    const AbstractNopHolder* nopObject,
+    write_callback_fn fn)
+    : nopObject_(nopObject), len_(nopObject_->getSize()), fn_(std::move(fn)) {
+  TP_THROW_ASSERT_IF(len_ > kBufferSize);
+}
 
-bool WriteOperation::handleWrite(util::ringbuffer::Producer& outbox) {
-  // Start write transaction.
-  // Retry because this must succeed.
-  // TODO: fallback if it doesn't.
-  for (;;) {
-    const auto ret = outbox.startTx();
-    TP_DCHECK(ret >= 0 || ret == -EAGAIN);
-    if (ret < 0) {
-      continue;
+size_t WriteOperation::handleWrite(util::ringbuffer::Producer& outbox) {
+  ssize_t ret;
+  size_t bytesWrittenNow = 0;
+
+  // Start write transaction. This end of the connection is the only producer
+  // for this ringbuffer, and all writes are done from the reactor thread, so
+  // there cannot be another transaction already going on. Fail hard in case.
+  ret = outbox.startTx();
+  TP_THROW_SYSTEM_IF(ret < 0, -ret);
+
+  if (mode_ == WRITE_LENGTH) {
+    uint32_t length = len_;
+    ret = outbox.writeInTx</*allowPartial=*/false>(&length, sizeof(length));
+    if (likely(ret >= 0)) {
+      mode_ = WRITE_PAYLOAD;
+      bytesWrittenNow += ret;
+    } else if (unlikely(ret != -ENOSPC)) {
+      TP_THROW_SYSTEM(-ret);
     }
-    break;
   }
 
-  ssize_t ret;
-  if (writer_) {
-    ret = writer_(outbox);
-    if (ret > 0) {
-      mode_ = WRITE_PAYLOAD;
-      bytesWritten_ = len_ = ret;
-    }
-  } else {
-    if (mode_ == WRITE_LENGTH) {
-      uint32_t length = len_;
-      ret = outbox.writeInTx</*allowPartial=*/false>(&length, sizeof(length));
-      if (ret > 0) {
-        mode_ = WRITE_PAYLOAD;
-      }
-    }
-
-    // If writing empty buffer, skip payload write because ptr_
-    // could be nullptr.
-    if (mode_ == WRITE_PAYLOAD && len_ > 0) {
+  if (mode_ == WRITE_PAYLOAD) {
+    if (nopObject_ != nullptr) {
+      ret = writeNopObject_(outbox);
+    } else {
       ret = outbox.writeInTx</*allowPartial=*/true>(
           reinterpret_cast<const uint8_t*>(ptr_) + bytesWritten_,
           len_ - bytesWritten_);
-      if (ret > 0) {
-        bytesWritten_ += ret;
-      }
+    }
+    if (likely(ret >= 0)) {
+      bytesWritten_ += ret;
+      bytesWrittenNow += ret;
+    } else if (unlikely(ret != -ENOSPC)) {
+      TP_THROW_SYSTEM(-ret);
     }
   }
 
-  if (ret == -ENOSPC) {
-    const auto ret = outbox.cancelTx();
-    TP_THROW_SYSTEM_IF(ret < 0, -ret);
-    return false;
-  }
+  ret = outbox.commitTx();
   TP_THROW_SYSTEM_IF(ret < 0, -ret);
-
-  {
-    const auto ret = outbox.commitTx();
-    TP_THROW_SYSTEM_IF(ret < 0, -ret);
-  }
 
   if (completed()) {
     fn_(Error::kSuccess);
   }
 
-  return true;
+  return bytesWrittenNow;
+}
+
+ssize_t WriteOperation::writeNopObject_(util::ringbuffer::Producer& outbox) {
+  ssize_t numBuffers;
+  std::array<util::ringbuffer::Producer::Buffer, 2> buffers;
+  std::tie(numBuffers, buffers) =
+      outbox.accessContiguousInTx</*allowPartial=*/false>(len_);
+  if (unlikely(numBuffers < 0)) {
+    return numBuffers;
+  }
+
+  NopWriter writer(
+      buffers[0].ptr, buffers[0].len, buffers[1].ptr, buffers[1].len);
+  nop::Status<void> status = nopObject_->write(writer);
+  if (status.error() == nop::ErrorStatus::WriteLimitReached) {
+    return -ENOSPC;
+  } else if (status.has_error()) {
+    return -EINVAL;
+  }
+
+  return len_;
 }
 
 void WriteOperation::handleError(const Error& error) {
@@ -278,8 +298,6 @@ void WriteOperation::handleError(const Error& error) {
 
 class Connection::Impl : public std::enable_shared_from_this<Connection::Impl>,
                          public EventHandler {
-  static constexpr auto kBufferSize = 2 * 1024 * 1024;
-
   enum State {
     INITIALIZING = 1,
     SEND_FDS,
@@ -619,40 +637,7 @@ void Connection::Impl::readFromLoop(
   }
 
   readOperations_.emplace_back(
-      [&object](util::ringbuffer::Consumer& inbox) -> ssize_t {
-        uint32_t len;
-        {
-          const auto ret =
-              inbox.readInTx</*allowPartial=*/false>(&len, sizeof(len));
-          if (ret == -ENODATA) {
-            return -ENODATA;
-          }
-          TP_THROW_SYSTEM_IF(ret < 0, -ret);
-        }
-
-        if (len + sizeof(uint32_t) > kBufferSize) {
-          return -EPERM;
-        }
-
-        ssize_t numBuffers;
-        std::array<util::ringbuffer::Consumer::Buffer, 2> buffers;
-        std::tie(numBuffers, buffers) =
-            inbox.accessContiguousInTx</*allowPartial=*/false>(len);
-        if (unlikely(numBuffers < 0)) {
-          return numBuffers;
-        }
-
-        NopReader reader(
-            buffers[0].ptr, buffers[0].len, buffers[1].ptr, buffers[1].len);
-        nop::Status<void> status = object.read(reader);
-        if (status.error() == nop::ErrorStatus::ReadLimitReached) {
-          return -ENODATA;
-        } else if (status.has_error()) {
-          return -EINVAL;
-        }
-
-        return len;
-      },
+      &object,
       [fn{std::move(fn)}](
           const Error& error, const void* /* unused */, size_t /* unused */) {
         fn(error);
@@ -791,39 +776,7 @@ void Connection::Impl::writeFromLoop(
     return;
   }
 
-  writeOperations_.emplace_back(
-      [&object](util::ringbuffer::Producer& outbox) -> ssize_t {
-        uint32_t len = object.getSize();
-        if (len + sizeof(uint32_t) > kBufferSize) {
-          return -EPERM;
-        }
-
-        const auto ret =
-            outbox.writeInTx</*allowPartial=*/false>(&len, sizeof(len));
-        if (ret < 0) {
-          return ret;
-        }
-
-        ssize_t numBuffers;
-        std::array<util::ringbuffer::Producer::Buffer, 2> buffers;
-        std::tie(numBuffers, buffers) =
-            outbox.accessContiguousInTx</*allowPartial=*/false>(len);
-        if (unlikely(numBuffers < 0)) {
-          return numBuffers;
-        }
-
-        NopWriter writer(
-            buffers[0].ptr, buffers[0].len, buffers[1].ptr, buffers[1].len);
-        nop::Status<void> status = object.write(writer);
-        if (status.error() == nop::ErrorStatus::WriteLimitReached) {
-          return -ENOSPC;
-        } else if (status.has_error()) {
-          return -EINVAL;
-        }
-
-        return len;
-      },
-      std::move(fn));
+  writeOperations_.emplace_back(&object, std::move(fn));
 
   // If the outbox has some free space, we may be able to process this operation
   // right away.
@@ -991,13 +944,13 @@ void Connection::Impl::processReadOperationsFromLoop() {
   // Serve read operations
   util::ringbuffer::Consumer inboxConsumer(inboxRb_);
   while (!readOperations_.empty()) {
-    auto readOperation = std::move(readOperations_.front());
-    readOperations_.pop_front();
-    if (readOperation.handleRead(inboxConsumer)) {
+    ReadOperation& readOperation = readOperations_.front();
+    if (readOperation.handleRead(inboxConsumer) > 0) {
       peerReactorTrigger_->run(peerOutboxReactorToken_.value());
     }
-    if (!readOperation.completed()) {
-      readOperations_.push_front(std::move(readOperation));
+    if (readOperation.completed()) {
+      readOperations_.pop_front();
+    } else {
       break;
     }
   }
@@ -1012,13 +965,13 @@ void Connection::Impl::processWriteOperationsFromLoop() {
 
   util::ringbuffer::Producer outboxProducer(outboxRb_);
   while (!writeOperations_.empty()) {
-    auto writeOperation = std::move(writeOperations_.front());
-    writeOperations_.pop_front();
-    if (writeOperation.handleWrite(outboxProducer)) {
+    WriteOperation& writeOperation = writeOperations_.front();
+    if (writeOperation.handleWrite(outboxProducer) > 0) {
       peerReactorTrigger_->run(peerInboxReactorToken_.value());
     }
-    if (!writeOperation.completed()) {
-      writeOperations_.push_front(writeOperation);
+    if (writeOperation.completed()) {
+      writeOperations_.pop_front();
+    } else {
       break;
     }
   }

--- a/tensorpipe/transport/shm/connection.h
+++ b/tensorpipe/transport/shm/connection.h
@@ -15,12 +15,14 @@
 #include <tensorpipe/transport/shm/context.h>
 
 namespace tensorpipe {
+
+class Socket;
+
 namespace transport {
 namespace shm {
 
 class Listener;
 class Loop;
-class Socket;
 
 class Connection final : public transport::Connection {
   // Use the passkey idiom to allow make_shared to call what should be a private

--- a/tensorpipe/transport/shm/context.cc
+++ b/tensorpipe/transport/shm/context.cc
@@ -13,7 +13,6 @@
 #include <tensorpipe/transport/shm/connection.h>
 #include <tensorpipe/transport/shm/listener.h>
 #include <tensorpipe/transport/shm/loop.h>
-#include <tensorpipe/transport/shm/socket.h>
 
 namespace tensorpipe {
 namespace transport {

--- a/tensorpipe/transport/shm/listener.cc
+++ b/tensorpipe/transport/shm/listener.cc
@@ -19,7 +19,7 @@
 #include <tensorpipe/transport/error.h>
 #include <tensorpipe/transport/shm/connection.h>
 #include <tensorpipe/transport/shm/loop.h>
-#include <tensorpipe/transport/shm/socket.h>
+#include <tensorpipe/transport/shm/sockaddr.h>
 
 namespace tensorpipe {
 namespace transport {

--- a/tensorpipe/transport/shm/listener.h
+++ b/tensorpipe/transport/shm/listener.h
@@ -14,12 +14,14 @@
 #include <tensorpipe/transport/shm/context.h>
 
 namespace tensorpipe {
+
+class Sockaddr;
+
 namespace transport {
 namespace shm {
 
 class Context;
 class Loop;
-class Sockaddr;
 
 class Listener final : public transport::Listener {
   // Use the passkey idiom to allow make_shared to call what should be a private

--- a/tensorpipe/transport/shm/loop.h
+++ b/tensorpipe/transport/shm/loop.h
@@ -21,7 +21,7 @@
 #include <sys/epoll.h>
 
 #include <tensorpipe/common/callback.h>
-#include <tensorpipe/transport/shm/fd.h>
+#include <tensorpipe/common/fd.h>
 #include <tensorpipe/transport/shm/reactor.h>
 
 namespace tensorpipe {

--- a/tensorpipe/transport/shm/reactor.cc
+++ b/tensorpipe/transport/shm/reactor.cc
@@ -169,11 +169,11 @@ void Reactor::run() {
   }
 }
 
-Reactor::Trigger::Trigger(Fd&& headerFd, Fd&& dataFd) {
+Reactor::Trigger::Trigger(Fd headerFd, Fd dataFd) {
   // The header and data segment objects take over ownership
   // of file descriptors. Release them to avoid double close.
   std::tie(headerSegment_, dataSegment_, rb_) =
-      util::ringbuffer::shm::load(headerFd.release(), dataFd.release());
+      util::ringbuffer::shm::load(std::move(headerFd), std::move(dataFd));
 }
 
 void Reactor::Trigger::run(TToken token) {

--- a/tensorpipe/transport/shm/reactor.cc
+++ b/tensorpipe/transport/shm/reactor.cc
@@ -122,7 +122,7 @@ void Reactor::run() {
   // all functions have been removed.
   while (!closed_ || functionCount_ > 0) {
     uint32_t token;
-    auto ret = consumer_->copy(sizeof(token), &token);
+    auto ret = consumer_->read(&token, sizeof(token));
     if (ret == -ENODATA) {
       if (deferredFunctionCount_ > 0) {
         decltype(deferredFunctionList_) fns;

--- a/tensorpipe/transport/shm/reactor.cc
+++ b/tensorpipe/transport/shm/reactor.cc
@@ -132,6 +132,7 @@ void Reactor::run() {
       }
       continue;
     }
+    TP_THROW_SYSTEM_IF(ret < 0, -ret);
 
     TFunction fn;
 

--- a/tensorpipe/transport/shm/reactor.h
+++ b/tensorpipe/transport/shm/reactor.h
@@ -18,8 +18,8 @@
 #include <vector>
 
 #include <tensorpipe/common/callback.h>
+#include <tensorpipe/common/fd.h>
 #include <tensorpipe/common/optional.h>
-#include <tensorpipe/transport/shm/fd.h>
 #include <tensorpipe/util/ringbuffer/consumer.h>
 #include <tensorpipe/util/ringbuffer/producer.h>
 #include <tensorpipe/util/shm/segment.h>
@@ -154,7 +154,7 @@ class Reactor final {
  public:
   class Trigger {
    public:
-    Trigger(Fd&& header, Fd&& data);
+    Trigger(Fd header, Fd data);
 
     void run(TToken token);
 

--- a/tensorpipe/transport/shm/reactor.h
+++ b/tensorpipe/transport/shm/reactor.h
@@ -22,6 +22,7 @@
 #include <tensorpipe/transport/shm/fd.h>
 #include <tensorpipe/util/ringbuffer/consumer.h>
 #include <tensorpipe/util/ringbuffer/producer.h>
+#include <tensorpipe/util/shm/segment.h>
 
 namespace tensorpipe {
 namespace transport {
@@ -87,9 +88,6 @@ class Reactor final {
   // Removes function associated with token from reactor.
   void remove(TToken token);
 
-  // Trigger reactor with specified token.
-  void trigger(TToken token);
-
   // Returns the file descriptors for the underlying ring buffer.
   std::tuple<int, int> fds() const;
 
@@ -110,10 +108,9 @@ class Reactor final {
   ~Reactor();
 
  private:
-  Fd headerFd_;
-  Fd dataFd_;
-  optional<util::ringbuffer::Consumer> consumer_;
-  optional<util::ringbuffer::Producer> producer_;
+  util::shm::Segment headerSegment_;
+  util::shm::Segment dataSegment_;
+  util::ringbuffer::RingBuffer rb_;
 
   std::mutex mutex_;
   std::thread thread_;
@@ -162,7 +159,9 @@ class Reactor final {
     void run(TToken token);
 
    private:
-    util::ringbuffer::Producer producer_;
+    util::shm::Segment headerSegment_;
+    util::shm::Segment dataSegment_;
+    util::ringbuffer::RingBuffer rb_;
   };
 };
 

--- a/tensorpipe/transport/shm/sockaddr.cc
+++ b/tensorpipe/transport/shm/sockaddr.cc
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/transport/shm/sockaddr.h>
+
+#include <fcntl.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <cstring>
+
+#include <tensorpipe/common/defs.h>
+
+namespace tensorpipe {
+namespace transport {
+namespace shm {
+
+Sockaddr Sockaddr::createAbstractUnixAddr(const std::string& name) {
+  struct sockaddr_un sun;
+  sun.sun_family = AF_UNIX;
+  std::memset(&sun.sun_path, 0, sizeof(sun.sun_path));
+  constexpr size_t offset = 1;
+  const size_t len = std::min(sizeof(sun.sun_path) - offset, name.size());
+  std::strncpy(&sun.sun_path[offset], name.c_str(), len);
+
+  // Note: instead of using sizeof(sun) we compute the addrlen from
+  // the string length of the abstract socket name. If we use
+  // sizeof(sun), lsof shows all the trailing NUL characters.
+  return Sockaddr(
+      reinterpret_cast<struct sockaddr*>(&sun),
+      sizeof(sun.sun_family) + offset + len + 1);
+};
+
+Sockaddr::Sockaddr(const struct sockaddr* addr, socklen_t addrlen) {
+  TP_ARG_CHECK(addr != nullptr);
+  TP_ARG_CHECK_LE(addrlen, sizeof(addr_));
+  std::memset(&addr_, 0, sizeof(addr_));
+  std::memcpy(&addr_, addr, addrlen);
+  addrlen_ = addrlen;
+}
+
+std::string Sockaddr::str() const {
+  const struct sockaddr_un* sun{
+      reinterpret_cast<const struct sockaddr_un*>(&addr_)};
+  constexpr size_t offset = 1;
+  const size_t len = addrlen_ - sizeof(sun->sun_family) - offset - 1;
+  return std::string(&sun->sun_path[offset], len);
+}
+
+} // namespace shm
+} // namespace transport
+} // namespace tensorpipe

--- a/tensorpipe/transport/shm/sockaddr.h
+++ b/tensorpipe/transport/shm/sockaddr.h
@@ -10,35 +10,27 @@
 
 #include <sys/socket.h>
 
+#include <chrono>
 #include <cstring>
-#include <string>
+#include <memory>
 
+#include <tensorpipe/common/defs.h>
+#include <tensorpipe/common/error.h>
+#include <tensorpipe/common/error_macros.h>
+#include <tensorpipe/common/optional.h>
 #include <tensorpipe/common/socket.h>
+#include <tensorpipe/transport/error.h>
 
 namespace tensorpipe {
 namespace transport {
-namespace uv {
+namespace shm {
 
 class Sockaddr final : public tensorpipe::Sockaddr {
  public:
-  static Sockaddr createInetSockAddr(const std::string& name);
-
-  Sockaddr(const struct sockaddr* addr, socklen_t addrlen) {
-    TP_ARG_CHECK(addr != nullptr);
-    TP_ARG_CHECK_LE(addrlen, sizeof(addr_));
-    // Ensure the sockaddr_storage is zeroed, because we don't always
-    // write to all fields in the `sockaddr_[in|in6]` structures.
-    std::memset(&addr_, 0, sizeof(addr_));
-    std::memcpy(&addr_, addr, addrlen);
-    addrlen_ = addrlen;
-  }
+  static Sockaddr createAbstractUnixAddr(const std::string& name);
 
   inline const struct sockaddr* addr() const override {
     return reinterpret_cast<const struct sockaddr*>(&addr_);
-  }
-
-  inline struct sockaddr* addr() {
-    return reinterpret_cast<struct sockaddr*>(&addr_);
   }
 
   inline socklen_t addrlen() const override {
@@ -48,10 +40,12 @@ class Sockaddr final : public tensorpipe::Sockaddr {
   std::string str() const;
 
  private:
+  explicit Sockaddr(const struct sockaddr* addr, socklen_t addrlen);
+
   struct sockaddr_storage addr_;
   socklen_t addrlen_;
 };
 
-} // namespace uv
+} // namespace shm
 } // namespace transport
 } // namespace tensorpipe

--- a/tensorpipe/util/ringbuffer/consumer.h
+++ b/tensorpipe/util/ringbuffer/consumer.h
@@ -19,15 +19,21 @@ namespace ringbuffer {
 ///
 /// Provides methods to read data from a ringbuffer.
 ///
-class Consumer : public RingBufferWrapper {
+class Consumer {
  public:
-  // Use base class constructor.
-  using RingBufferWrapper::RingBufferWrapper;
+  Consumer() = delete;
+
+  Consumer(RingBuffer& rb) : header_{rb.getHeader()}, data_{rb.getData()} {
+    TP_THROW_IF_NULLPTR(data_);
+  }
 
   Consumer(const Consumer&) = delete;
   Consumer(Consumer&&) = delete;
 
-  virtual ~Consumer() noexcept {
+  Consumer& operator=(const Consumer&) = delete;
+  Consumer& operator=(Consumer&&) = delete;
+
+  ~Consumer() noexcept {
     TP_THROW_ASSERT_IF(inTx());
   }
 
@@ -192,7 +198,10 @@ class Consumer : public RingBufferWrapper {
     return size;
   }
 
- protected:
+ private:
+  RingBufferHeader& header_;
+  const uint8_t* const data_;
+  unsigned tx_size_ = 0;
   bool inTx_{false};
 };
 

--- a/tensorpipe/util/ringbuffer/consumer.h
+++ b/tensorpipe/util/ringbuffer/consumer.h
@@ -51,7 +51,7 @@ class Consumer {
     if (unlikely(inTx())) {
       return -EBUSY;
     }
-    if (header_.in_read_tx.test_and_set(std::memory_order_acquire)) {
+    if (header_.beginReadTransaction()) {
       return -EAGAIN;
     }
     inTx_ = true;
@@ -66,7 +66,7 @@ class Consumer {
     header_.incTail(tx_size_);
     tx_size_ = 0;
     inTx_ = false;
-    header_.in_read_tx.clear(std::memory_order_release);
+    header_.endReadTransaction();
     return 0;
   }
 
@@ -78,7 +78,7 @@ class Consumer {
     // <in_read_tx> flags that we are in a transaction,
     // so enforce no stores pass it.
     inTx_ = false;
-    header_.in_read_tx.clear(std::memory_order_release);
+    header_.endReadTransaction();
     return 0;
   }
 

--- a/tensorpipe/util/ringbuffer/producer.h
+++ b/tensorpipe/util/ringbuffer/producer.h
@@ -51,7 +51,7 @@ class Producer {
     if (unlikely(inTx())) {
       return -EBUSY;
     }
-    if (header_.in_write_tx.test_and_set(std::memory_order_acquire)) {
+    if (header_.beginWriteTransaction()) {
       return -EAGAIN;
     }
     inTx_ = true;
@@ -68,7 +68,7 @@ class Producer {
     // <in_write_tx> flags that we are in a transaction,
     // so enforce no stores pass it.
     inTx_ = false;
-    header_.in_write_tx.clear(std::memory_order_release);
+    header_.endWriteTransaction();
     return 0;
   }
 
@@ -80,7 +80,7 @@ class Producer {
     // <in_write_tx> flags that we are in a transaction,
     // so enforce no stores pass it.
     inTx_ = false;
-    header_.in_write_tx.clear(std::memory_order_release);
+    header_.endWriteTransaction();
     return 0;
   }
 

--- a/tensorpipe/util/ringbuffer/producer.h
+++ b/tensorpipe/util/ringbuffer/producer.h
@@ -19,15 +19,21 @@ namespace ringbuffer {
 ///
 /// Provides methods to write data into a ringbuffer.
 ///
-class Producer : public RingBufferWrapper {
+class Producer {
  public:
-  // Use base class constructor.
-  using RingBufferWrapper::RingBufferWrapper;
+  Producer() = delete;
+
+  Producer(RingBuffer& rb) : header_{rb.getHeader()}, data_{rb.getData()} {
+    TP_THROW_IF_NULLPTR(data_);
+  }
 
   Producer(const Producer&) = delete;
   Producer(Producer&&) = delete;
 
-  virtual ~Producer() noexcept {
+  Producer& operator=(const Producer&) = delete;
+  Producer& operator=(Producer&&) = delete;
+
+  ~Producer() noexcept {
     TP_THROW_ASSERT_IF(inTx());
   }
 
@@ -196,7 +202,10 @@ class Producer : public RingBufferWrapper {
     return size;
   }
 
- protected:
+ private:
+  RingBufferHeader& header_;
+  uint8_t* const data_;
+  unsigned tx_size_ = 0;
   bool inTx_{false};
 };
 

--- a/tensorpipe/util/ringbuffer/ringbuffer.h
+++ b/tensorpipe/util/ringbuffer/ringbuffer.h
@@ -133,13 +133,10 @@ class RingBufferHeader {
 ///
 class RingBuffer final {
  public:
-  RingBuffer(const RingBuffer&) = delete;
-  RingBuffer(RingBuffer&&) = delete;
+  RingBuffer() = default;
 
-  RingBuffer(
-      std::shared_ptr<RingBufferHeader> header,
-      std::shared_ptr<uint8_t> data)
-      : header_{std::move(header)}, data_{std::move(data)} {
+  RingBuffer(RingBufferHeader* header, uint8_t* data)
+      : header_(header), data_(data) {
     TP_THROW_IF_NULLPTR(header_) << "Header cannot be nullptr";
     TP_THROW_IF_NULLPTR(data_) << "Data cannot be nullptr";
   }
@@ -153,51 +150,16 @@ class RingBuffer final {
   }
 
   const uint8_t* getData() const {
-    return data_.get();
+    return data_;
   }
 
   uint8_t* getData() {
-    return data_.get();
+    return data_;
   }
 
  protected:
-  std::shared_ptr<RingBufferHeader> header_;
-
-  // Note: this is a std::shared_ptr<uint8_t[]> semantically.
-  // A shared_ptr with array type is supported in C++17 and higher.
-  std::shared_ptr<uint8_t> data_;
-};
-
-///
-/// Ringbuffer wrapper
-///
-class RingBufferWrapper {
- public:
-  RingBufferWrapper(const RingBufferWrapper&) = delete;
-
-  RingBufferWrapper(std::shared_ptr<RingBuffer> rb)
-      : rb_{rb}, header_{rb->getHeader()}, data_{rb->getData()} {
-    TP_THROW_IF_NULLPTR(rb);
-    TP_THROW_IF_NULLPTR(data_);
-  }
-
-  auto& getHeader() {
-    return header_;
-  }
-
-  const auto& getHeader() const {
-    return header_;
-  }
-
-  auto getRingBuffer() {
-    return rb_;
-  }
-
- protected:
-  std::shared_ptr<RingBuffer> rb_;
-  RingBufferHeader& header_;
-  uint8_t* const data_;
-  unsigned tx_size_ = 0;
+  RingBufferHeader* header_ = nullptr;
+  uint8_t* data_ = nullptr;
 };
 
 } // namespace ringbuffer

--- a/tensorpipe/util/ringbuffer/shm.cc
+++ b/tensorpipe/util/ringbuffer/shm.cc
@@ -37,14 +37,14 @@ std::tuple<util::shm::Segment, util::shm::Segment, RingBuffer> create(
 }
 
 std::tuple<util::shm::Segment, util::shm::Segment, RingBuffer> load(
-    int header_fd,
-    int data_fd,
+    Fd header_fd,
+    Fd data_fd,
     optional<util::shm::PageType> data_page_type,
     bool perm_write) {
   util::shm::Segment header_segment;
   RingBufferHeader* header;
   std::tie(header_segment, header) = util::shm::Segment::load<RingBufferHeader>(
-      header_fd, perm_write, util::shm::PageType::Default);
+      std::move(header_fd), perm_write, util::shm::PageType::Default);
   constexpr auto kHeaderSize = sizeof(RingBufferHeader);
   if (unlikely(kHeaderSize != header_segment.getSize())) {
     TP_THROW_SYSTEM(EPERM) << "Header segment of unexpected size";
@@ -52,8 +52,8 @@ std::tuple<util::shm::Segment, util::shm::Segment, RingBuffer> load(
 
   util::shm::Segment data_segment;
   uint8_t* data;
-  std::tie(data_segment, data) =
-      util::shm::Segment::load<uint8_t[]>(data_fd, perm_write, data_page_type);
+  std::tie(data_segment, data) = util::shm::Segment::load<uint8_t[]>(
+      std::move(data_fd), perm_write, data_page_type);
   if (unlikely(header->kDataPoolByteSize != data_segment.getSize())) {
     TP_THROW_SYSTEM(EPERM) << "Data segment of unexpected size";
   }

--- a/tensorpipe/util/ringbuffer/shm.cc
+++ b/tensorpipe/util/ringbuffer/shm.cc
@@ -13,57 +13,55 @@ namespace util {
 namespace ringbuffer {
 namespace shm {
 
-std::tuple<int, int, std::shared_ptr<RingBuffer>> create(
+std::tuple<util::shm::Segment, util::shm::Segment, RingBuffer> create(
     size_t min_rb_byte_size,
-    optional<tensorpipe::util::shm::PageType> data_page_type,
+    optional<util::shm::PageType> data_page_type,
     bool perm_write) {
-  std::shared_ptr<RingBufferHeader> header;
-  std::shared_ptr<tensorpipe::util::shm::Segment> header_segment;
-  std::tie(header, header_segment) =
-      tensorpipe::util::shm::Segment::create<RingBufferHeader>(
-          perm_write,
-          tensorpipe::util::shm::PageType::Default,
-          min_rb_byte_size);
+  util::shm::Segment header_segment;
+  RingBufferHeader* header;
+  std::tie(header_segment, header) =
+      util::shm::Segment::create<RingBufferHeader>(
+          perm_write, util::shm::PageType::Default, min_rb_byte_size);
 
-  std::shared_ptr<uint8_t> data;
-  std::shared_ptr<tensorpipe::util::shm::Segment> data_segment;
-  std::tie(data, data_segment) =
-      tensorpipe::util::shm::Segment::create<uint8_t[]>(
-          header->kDataPoolByteSize, perm_write, data_page_type);
+  util::shm::Segment data_segment;
+  uint8_t* data;
+  std::tie(data_segment, data) = util::shm::Segment::create<uint8_t[]>(
+      header->kDataPoolByteSize, perm_write, data_page_type);
 
   // Note: cannot use implicit construction from initializer list on GCC 5.5:
   // "converting to XYZ from initializer list would use explicit constructor".
   return std::make_tuple(
-      header_segment->getFd(),
-      data_segment->getFd(),
-      std::make_shared<RingBuffer>(std::move(header), std::move(data)));
+      std::move(header_segment),
+      std::move(data_segment),
+      RingBuffer(header, data));
 }
 
-std::shared_ptr<RingBuffer> load(
+std::tuple<util::shm::Segment, util::shm::Segment, RingBuffer> load(
     int header_fd,
     int data_fd,
-    optional<tensorpipe::util::shm::PageType> data_page_type,
+    optional<util::shm::PageType> data_page_type,
     bool perm_write) {
-  std::shared_ptr<RingBufferHeader> header;
-  std::shared_ptr<tensorpipe::util::shm::Segment> header_segment;
-  std::tie(header, header_segment) =
-      tensorpipe::util::shm::Segment::load<RingBufferHeader>(
-          header_fd, perm_write, tensorpipe::util::shm::PageType::Default);
+  util::shm::Segment header_segment;
+  RingBufferHeader* header;
+  std::tie(header_segment, header) = util::shm::Segment::load<RingBufferHeader>(
+      header_fd, perm_write, util::shm::PageType::Default);
   constexpr auto kHeaderSize = sizeof(RingBufferHeader);
-  if (unlikely(kHeaderSize != header_segment->getSize())) {
+  if (unlikely(kHeaderSize != header_segment.getSize())) {
     TP_THROW_SYSTEM(EPERM) << "Header segment of unexpected size";
   }
 
-  std::shared_ptr<uint8_t> data;
-  std::shared_ptr<tensorpipe::util::shm::Segment> data_segment;
-  std::tie(data, data_segment) =
-      tensorpipe::util::shm::Segment::load<uint8_t[]>(
-          data_fd, perm_write, data_page_type);
-  if (unlikely(header->kDataPoolByteSize != data_segment->getSize())) {
+  util::shm::Segment data_segment;
+  uint8_t* data;
+  std::tie(data_segment, data) =
+      util::shm::Segment::load<uint8_t[]>(data_fd, perm_write, data_page_type);
+  if (unlikely(header->kDataPoolByteSize != data_segment.getSize())) {
     TP_THROW_SYSTEM(EPERM) << "Data segment of unexpected size";
   }
 
-  return std::make_shared<RingBuffer>(std::move(header), std::move(data));
+  return std::make_tuple(
+      std::move(header_segment),
+      std::move(data_segment),
+      RingBuffer(header, data));
 }
 
 } // namespace shm

--- a/tensorpipe/util/ringbuffer/shm.h
+++ b/tensorpipe/util/ringbuffer/shm.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <tensorpipe/common/fd.h>
 #include <tensorpipe/util/ringbuffer/ringbuffer.h>
 #include <tensorpipe/util/shm/segment.h>
 
@@ -35,8 +36,8 @@ std::tuple<util::shm::Segment, util::shm::Segment, RingBuffer> create(
     bool perm_write = true);
 
 std::tuple<util::shm::Segment, util::shm::Segment, RingBuffer> load(
-    int header_fd,
-    int data_fd,
+    Fd header_fd,
+    Fd data_fd,
     optional<util::shm::PageType> data_page_type = nullopt,
     bool perm_write = true);
 

--- a/tensorpipe/util/ringbuffer/shm.h
+++ b/tensorpipe/util/ringbuffer/shm.h
@@ -18,7 +18,7 @@ namespace shm {
 
 /// Creates ringbuffer on shared memory.
 ///
-/// RingBuffer's data can have any <tensorpipe::util::shm::PageType>
+/// RingBuffer's data can have any <util::shm::PageType>
 /// (e.g. 4KB or a HugeTLB Page of 2MB or 1GB). If  <data_page_type> is not
 /// provided, then choose the largest page that would result in
 /// close to full occupancy.
@@ -29,15 +29,15 @@ namespace shm {
 /// <min_rb_byte_size> is the minimum size of the data section
 /// of a RingBuffer (or each CPU's RingBuffer).
 ///
-std::tuple<int, int, std::shared_ptr<RingBuffer>> create(
+std::tuple<util::shm::Segment, util::shm::Segment, RingBuffer> create(
     size_t min_rb_byte_size,
-    optional<tensorpipe::util::shm::PageType> data_page_type = nullopt,
+    optional<util::shm::PageType> data_page_type = nullopt,
     bool perm_write = true);
 
-std::shared_ptr<RingBuffer> load(
+std::tuple<util::shm::Segment, util::shm::Segment, RingBuffer> load(
     int header_fd,
     int data_fd,
-    optional<tensorpipe::util::shm::PageType> data_page_type = nullopt,
+    optional<util::shm::PageType> data_page_type = nullopt,
     bool perm_write = true);
 
 } // namespace shm


### PR DESCRIPTION
Summary:
Disclaimer: I thought this would give us some (maybe small) perf gain, but it doesn't seem like that. Probably because x86 has a strong memory consistency model, and thus all atomics are very strict all the time. We might still see perf gains on other platform (think ARM), but we're not targeting them yet, so this is not really relevant. Regardless of the absence of perf gains, I still think this diff makes the code cleaner, as it specifies exactly the requirements we need.

We used atomics for the head/tail of the ringbuffers, which in their default behavior use a sequentially consistent memory model, which is the strongest possible one: all sequentially consistent accesses on any memory in the system are ordered in a single global total order. I expected this would cause some overhead (in the code, or in the processor). We don't need such a strong property though: we only need some ordering guarantees around the order of accesses within the ringbuffer, where we control all users. So we can express all the properties we need using the "weaker" acquire/release memory order.

See here for an explanation of memory orders: https://en.cppreference.com/w/cpp/atomic/memory_order

Reviewed By: beauby

Differential Revision: D23573343

