### PR TITLE
Make Channel API accept buffer structs rather than raw pointers. (#212)

### DIFF
--- a/tensorpipe/channel/basic/channel.cc
+++ b/tensorpipe/channel/basic/channel.cc
@@ -33,16 +33,11 @@ class Channel::Impl : public std::enable_shared_from_this<Channel::Impl> {
   void init();
 
   void send(
-      const void* ptr,
-      size_t length,
+      CpuBuffer buffer,
       TDescriptorCallback descriptorCallback,
       TSendCallback callback);
 
-  void recv(
-      TDescriptor descriptor,
-      void* ptr,
-      size_t length,
-      TRecvCallback callback);
+  void recv(TDescriptor descriptor, CpuBuffer buffer, TRecvCallback callback);
 
   // Tell the channel what its identifier is.
   void setId(std::string id);
@@ -53,16 +48,14 @@ class Channel::Impl : public std::enable_shared_from_this<Channel::Impl> {
   OnDemandLoop loop_;
 
   void sendFromLoop_(
-      const void* ptr,
-      size_t length,
+      CpuBuffer buffer,
       TDescriptorCallback descriptorCallback,
       TSendCallback callback);
 
   // Receive memory region from peer.
   void recvFromLoop_(
       TDescriptor descriptor,
-      void* ptr,
-      size_t length,
+      CpuBuffer buffer,
       TRecvCallback callback);
 
   void setIdFromLoop_(std::string id);
@@ -126,32 +119,27 @@ Channel::Impl::Impl(
       id_(std::move(id)) {}
 
 void Channel::send(
-    const void* ptr,
-    size_t length,
+    CpuBuffer buffer,
     TDescriptorCallback descriptorCallback,
     TSendCallback callback) {
-  impl_->send(ptr, length, std::move(descriptorCallback), std::move(callback));
+  impl_->send(buffer, std::move(descriptorCallback), std::move(callback));
 }
 
 void Channel::Impl::send(
-    const void* ptr,
-    size_t length,
+    CpuBuffer buffer,
     TDescriptorCallback descriptorCallback,
     TSendCallback callback) {
   loop_.deferToLoop([this,
-                     ptr,
-                     length,
+                     buffer,
                      descriptorCallback{std::move(descriptorCallback)},
                      callback{std::move(callback)}]() mutable {
-    sendFromLoop_(
-        ptr, length, std::move(descriptorCallback), std::move(callback));
+    sendFromLoop_(buffer, std::move(descriptorCallback), std::move(callback));
   });
 }
 
 // Send memory region to peer.
 void Channel::Impl::sendFromLoop_(
-    const void* ptr,
-    size_t length,
+    CpuBuffer buffer,
     TDescriptorCallback descriptorCallback,
     TSendCallback callback) {
   TP_DCHECK(loop_.inLoop());
@@ -191,8 +179,8 @@ void Channel::Impl::sendFromLoop_(
   TP_VLOG(6) << "Channel " << id_ << " is writing payload (#" << sequenceNumber
              << ")";
   connection_->write(
-      ptr,
-      length,
+      buffer.ptr,
+      buffer.length,
       eagerCallbackWrapper_(
           [sequenceNumber, callback{std::move(callback)}](Impl& impl) {
             TP_VLOG(6) << "Channel " << impl.id_ << " done writing payload (#"
@@ -206,30 +194,26 @@ void Channel::Impl::sendFromLoop_(
 // Receive memory region from peer.
 void Channel::recv(
     TDescriptor descriptor,
-    void* ptr,
-    size_t length,
+    CpuBuffer buffer,
     TRecvCallback callback) {
-  impl_->recv(std::move(descriptor), ptr, length, std::move(callback));
+  impl_->recv(std::move(descriptor), buffer, std::move(callback));
 }
 
 void Channel::Impl::recv(
     TDescriptor descriptor,
-    void* ptr,
-    size_t length,
+    CpuBuffer buffer,
     TRecvCallback callback) {
   loop_.deferToLoop([this,
                      descriptor{std::move(descriptor)},
-                     ptr,
-                     length,
+                     buffer,
                      callback{std::move(callback)}]() mutable {
-    recvFromLoop_(std::move(descriptor), ptr, length, std::move(callback));
+    recvFromLoop_(std::move(descriptor), buffer, std::move(callback));
   });
 }
 
 void Channel::Impl::recvFromLoop_(
     TDescriptor descriptor,
-    void* ptr,
-    size_t length,
+    CpuBuffer buffer,
     TRecvCallback callback) {
   TP_DCHECK(loop_.inLoop());
 
@@ -257,8 +241,8 @@ void Channel::Impl::recvFromLoop_(
   TP_VLOG(6) << "Channel " << id_ << " is reading payload (#" << sequenceNumber
              << ")";
   connection_->read(
-      ptr,
-      length,
+      buffer.ptr,
+      buffer.length,
       eagerCallbackWrapper_(
           [sequenceNumber, callback{std::move(callback)}](
               Impl& impl, const void* /* unused */, size_t /* unused */) {

--- a/tensorpipe/channel/basic/channel.h
+++ b/tensorpipe/channel/basic/channel.h
@@ -11,13 +11,13 @@
 #include <memory>
 
 #include <tensorpipe/channel/basic/context.h>
-#include <tensorpipe/channel/channel.h>
+#include <tensorpipe/channel/cpu_context.h>
 
 namespace tensorpipe {
 namespace channel {
 namespace basic {
 
-class Channel : public channel::Channel {
+class Channel : public channel::CpuChannel {
   // Use the passkey idiom to allow make_shared to call what should be a private
   // constructor. See https://abseil.io/tips/134 for more information.
   struct ConstructorToken {};
@@ -31,17 +31,13 @@ class Channel : public channel::Channel {
 
   // Send memory region to peer.
   void send(
-      const void* ptr,
-      size_t length,
+      CpuBuffer buffer,
       TDescriptorCallback descriptorCallback,
       TSendCallback callback) override;
 
   // Receive memory region from peer.
-  void recv(
-      TDescriptor descriptor,
-      void* ptr,
-      size_t length,
-      TRecvCallback callback) override;
+  void recv(TDescriptor descriptor, CpuBuffer buffer, TRecvCallback callback)
+      override;
 
   // Tell the channel what its identifier is.
   void setId(std::string id) override;

--- a/tensorpipe/channel/basic/context.cc
+++ b/tensorpipe/channel/basic/context.cc
@@ -41,7 +41,7 @@ class Context::Impl : public Context::PrivateIface,
 
   const std::string& domainDescriptor() const;
 
-  std::shared_ptr<channel::Channel> createChannel(
+  std::shared_ptr<channel::CpuChannel> createChannel(
       std::shared_ptr<transport::Connection>,
       Endpoint);
 
@@ -88,13 +88,13 @@ const std::string& Context::Impl::domainDescriptor() const {
   return domainDescriptor_;
 }
 
-std::shared_ptr<channel::Channel> Context::createChannel(
+std::shared_ptr<channel::CpuChannel> Context::createChannel(
     std::shared_ptr<transport::Connection> connection,
     Endpoint endpoint) {
   return impl_->createChannel(std::move(connection), endpoint);
 }
 
-std::shared_ptr<channel::Channel> Context::Impl::createChannel(
+std::shared_ptr<channel::CpuChannel> Context::Impl::createChannel(
     std::shared_ptr<transport::Connection> connection,
     Endpoint /* unused */) {
   std::string channelId = id_ + ".c" + std::to_string(channelCounter_++);

--- a/tensorpipe/channel/basic/context.h
+++ b/tensorpipe/channel/basic/context.h
@@ -11,20 +11,20 @@
 #include <memory>
 #include <string>
 
-#include <tensorpipe/channel/context.h>
+#include <tensorpipe/channel/cpu_context.h>
 #include <tensorpipe/common/callback.h>
 
 namespace tensorpipe {
 namespace channel {
 namespace basic {
 
-class Context : public channel::Context {
+class Context : public channel::CpuContext {
  public:
   Context();
 
   const std::string& domainDescriptor() const override;
 
-  std::shared_ptr<Channel> createChannel(
+  std::shared_ptr<CpuChannel> createChannel(
       std::shared_ptr<transport::Connection>,
       Endpoint) override;
 

--- a/tensorpipe/channel/channel.h
+++ b/tensorpipe/channel/channel.h
@@ -53,20 +53,19 @@ using TSendCallback = std::function<void(const Error&)>;
 using TRecvCallback = std::function<void(const Error&)>;
 
 // Abstract base class for channel classes.
+template <typename TBuffer>
 class Channel {
  public:
   // Send memory region to peer.
   virtual void send(
-      const void* ptr,
-      size_t length,
+      TBuffer buffer,
       TDescriptorCallback descriptorCallback,
       TSendCallback callback) = 0;
 
   // Receive memory region from peer.
   virtual void recv(
       TDescriptor descriptor,
-      void* ptr,
-      size_t length,
+      TBuffer buffer,
       TRecvCallback callback) = 0;
 
   // Tell the channel what its identifier is.

--- a/tensorpipe/channel/cma/channel.cc
+++ b/tensorpipe/channel/cma/channel.cc
@@ -55,16 +55,11 @@ class Channel::Impl : public std::enable_shared_from_this<Channel::Impl> {
   void init();
 
   void send(
-      const void* ptr,
-      size_t length,
+      CpuBuffer buffer,
       TDescriptorCallback descriptorCallback,
       TSendCallback callback);
 
-  void recv(
-      TDescriptor descriptor,
-      void* ptr,
-      size_t length,
-      TRecvCallback callback);
+  void recv(TDescriptor descriptor, CpuBuffer buffer, TRecvCallback callback);
 
   // Tell the channel what its identifier is.
   void setId(std::string id);
@@ -78,16 +73,14 @@ class Channel::Impl : public std::enable_shared_from_this<Channel::Impl> {
 
   // Send memory region to peer.
   void sendFromLoop_(
-      const void* ptr,
-      size_t length,
+      CpuBuffer buffer,
       TDescriptorCallback descriptorCallback,
       TSendCallback callback);
 
   // Receive memory region from peer.
   void recvFromLoop_(
       TDescriptor descriptor,
-      void* ptr,
-      size_t length,
+      CpuBuffer buffer,
       TRecvCallback callback);
 
   void setIdFromLoop_(std::string id);
@@ -158,31 +151,26 @@ void Channel::Impl::initFromLoop_() {
 }
 
 void Channel::send(
-    const void* ptr,
-    size_t length,
+    CpuBuffer buffer,
     TDescriptorCallback descriptorCallback,
     TSendCallback callback) {
-  impl_->send(ptr, length, std::move(descriptorCallback), std::move(callback));
+  impl_->send(buffer, std::move(descriptorCallback), std::move(callback));
 }
 
 void Channel::Impl::send(
-    const void* ptr,
-    size_t length,
+    CpuBuffer buffer,
     TDescriptorCallback descriptorCallback,
     TSendCallback callback) {
   loop_.deferToLoop([this,
-                     ptr,
-                     length,
+                     buffer,
                      descriptorCallback{std::move(descriptorCallback)},
                      callback{std::move(callback)}]() mutable {
-    sendFromLoop_(
-        ptr, length, std::move(descriptorCallback), std::move(callback));
+    sendFromLoop_(buffer, std::move(descriptorCallback), std::move(callback));
   });
 }
 
 void Channel::Impl::sendFromLoop_(
-    const void* ptr,
-    size_t length,
+    CpuBuffer buffer,
     TDescriptorCallback descriptorCallback,
     TSendCallback callback) {
   TP_DCHECK(loop_.inLoop());
@@ -236,7 +224,7 @@ void Channel::Impl::sendFromLoop_(
   NopHolder<Descriptor> nopHolder;
   Descriptor& nopDescriptor = nopHolder.getObject();
   nopDescriptor.pid = getpid();
-  nopDescriptor.ptr = reinterpret_cast<uint64_t>(ptr);
+  nopDescriptor.ptr = reinterpret_cast<uint64_t>(buffer.ptr);
 
   descriptorCallback(Error::kSuccess, saveDescriptor(nopHolder));
 }
@@ -244,30 +232,26 @@ void Channel::Impl::sendFromLoop_(
 // Receive memory region from peer.
 void Channel::recv(
     TDescriptor descriptor,
-    void* ptr,
-    size_t length,
+    CpuBuffer buffer,
     TRecvCallback callback) {
-  impl_->recv(std::move(descriptor), ptr, length, std::move(callback));
+  impl_->recv(std::move(descriptor), buffer, std::move(callback));
 }
 
 void Channel::Impl::recv(
     TDescriptor descriptor,
-    void* ptr,
-    size_t length,
+    CpuBuffer buffer,
     TRecvCallback callback) {
   loop_.deferToLoop([this,
                      descriptor{std::move(descriptor)},
-                     ptr,
-                     length,
+                     buffer,
                      callback{std::move(callback)}]() mutable {
-    recvFromLoop_(std::move(descriptor), ptr, length, std::move(callback));
+    recvFromLoop_(std::move(descriptor), buffer, std::move(callback));
   });
 }
 
 void Channel::Impl::recvFromLoop_(
     TDescriptor descriptor,
-    void* ptr,
-    size_t length,
+    CpuBuffer buffer,
     TRecvCallback callback) {
   TP_DCHECK(loop_.inLoop());
 
@@ -301,8 +285,8 @@ void Channel::Impl::recvFromLoop_(
   context_->requestCopy(
       remotePid,
       remotePtr,
-      ptr,
-      length,
+      buffer.ptr,
+      buffer.length,
       eagerCallbackWrapper_([sequenceNumber,
                              callback{std::move(callback)}](Impl& impl) {
         TP_VLOG(6) << "Channel " << impl.id_ << " done copying payload (#"

--- a/tensorpipe/channel/cma/channel.h
+++ b/tensorpipe/channel/cma/channel.h
@@ -10,14 +10,14 @@
 
 #include <memory>
 
-#include <tensorpipe/channel/channel.h>
 #include <tensorpipe/channel/cma/context.h>
+#include <tensorpipe/channel/cpu_context.h>
 
 namespace tensorpipe {
 namespace channel {
 namespace cma {
 
-class Channel : public channel::Channel {
+class Channel : public channel::CpuChannel {
   // Use the passkey idiom to allow make_shared to call what should be a private
   // constructor. See https://abseil.io/tips/134 for more information.
   struct ConstructorToken {};
@@ -31,17 +31,13 @@ class Channel : public channel::Channel {
 
   // Send memory region to peer.
   void send(
-      const void* ptr,
-      size_t length,
+      CpuBuffer buffer,
       TDescriptorCallback descriptorCallback,
       TSendCallback callback) override;
 
   // Receive memory region from peer.
-  void recv(
-      TDescriptor descriptor,
-      void* ptr,
-      size_t length,
-      TRecvCallback callback) override;
+  void recv(TDescriptor descriptor, CpuBuffer buffer, TRecvCallback callback)
+      override;
 
   // Tell the channel what its identifier is.
   void setId(std::string id) override;

--- a/tensorpipe/channel/cma/context.cc
+++ b/tensorpipe/channel/cma/context.cc
@@ -73,7 +73,7 @@ class Context::Impl : public Context::PrivateIface,
 
   const std::string& domainDescriptor() const;
 
-  std::shared_ptr<channel::Channel> createChannel(
+  std::shared_ptr<channel::CpuChannel> createChannel(
       std::shared_ptr<transport::Connection>,
       Endpoint);
 
@@ -193,13 +193,13 @@ const std::string& Context::Impl::domainDescriptor() const {
   return domainDescriptor_;
 }
 
-std::shared_ptr<channel::Channel> Context::createChannel(
+std::shared_ptr<channel::CpuChannel> Context::createChannel(
     std::shared_ptr<transport::Connection> connection,
     Endpoint endpoint) {
   return impl_->createChannel(std::move(connection), endpoint);
 }
 
-std::shared_ptr<channel::Channel> Context::Impl::createChannel(
+std::shared_ptr<channel::CpuChannel> Context::Impl::createChannel(
     std::shared_ptr<transport::Connection> connection,
     Endpoint /* unused */) {
   TP_THROW_ASSERT_IF(joined_);

--- a/tensorpipe/channel/cma/context.h
+++ b/tensorpipe/channel/cma/context.h
@@ -12,7 +12,7 @@
 #include <memory>
 #include <string>
 
-#include <tensorpipe/channel/context.h>
+#include <tensorpipe/channel/cpu_context.h>
 #include <tensorpipe/common/callback.h>
 #include <tensorpipe/common/error.h>
 
@@ -20,13 +20,13 @@ namespace tensorpipe {
 namespace channel {
 namespace cma {
 
-class Context : public channel::Context {
+class Context : public channel::CpuContext {
  public:
   Context();
 
   const std::string& domainDescriptor() const override;
 
-  std::shared_ptr<Channel> createChannel(
+  std::shared_ptr<CpuChannel> createChannel(
       std::shared_ptr<transport::Connection>,
       Endpoint) override;
 

--- a/tensorpipe/channel/context.h
+++ b/tensorpipe/channel/context.h
@@ -25,6 +25,7 @@ namespace channel {
 // context. All registered instances are assumed to be eligible
 // channels for all pairs.
 //
+template <typename TBuffer>
 class Context {
  public:
   // Return string to describe the domain for this channel.
@@ -42,7 +43,7 @@ class Context {
   // initialized yet, take care to queue these operations to execute
   // as soon as initialization has completed.
   //
-  virtual std::shared_ptr<Channel> createChannel(
+  virtual std::shared_ptr<Channel<TBuffer>> createChannel(
       std::shared_ptr<transport::Connection>,
       Endpoint) = 0;
 

--- a/tensorpipe/channel/cpu_context.h
+++ b/tensorpipe/channel/cpu_context.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <tensorpipe/channel/channel.h>
+#include <tensorpipe/channel/context.h>
+#include <tensorpipe/common/cpu_buffer.h>
+
+namespace tensorpipe {
+namespace channel {
+
+using CpuChannel = Channel<CpuBuffer>;
+using CpuContext = Context<CpuBuffer>;
+
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/cuda_context.h
+++ b/tensorpipe/channel/cuda_context.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <tensorpipe/channel/channel.h>
+#include <tensorpipe/channel/context.h>
+#include <tensorpipe/common/cuda_buffer.h>
+
+namespace tensorpipe {
+namespace channel {
+
+using CudaChannel = Channel<CudaBuffer>;
+using CudaContext = Context<CudaBuffer>;
+
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/cuda_ipc/channel.cc
+++ b/tensorpipe/channel/cuda_ipc/channel.cc
@@ -197,18 +197,11 @@ class Channel::Impl : public std::enable_shared_from_this<Channel::Impl> {
   void init();
 
   void send(
-      const void* ptr,
-      size_t length,
+      CudaBuffer buffer,
       TDescriptorCallback descriptorCallback,
-      TSendCallback callback,
-      cudaStream_t stream);
+      TSendCallback callback);
 
-  void recv(
-      TDescriptor descriptor,
-      void* ptr,
-      size_t length,
-      TRecvCallback callback,
-      cudaStream_t stream);
+  void recv(TDescriptor descriptor, CudaBuffer buffer, TRecvCallback callback);
 
   // Tell the channel what its identifier is.
   void setId(std::string id);
@@ -222,19 +215,15 @@ class Channel::Impl : public std::enable_shared_from_this<Channel::Impl> {
 
   // Send memory region to peer.
   void sendFromLoop_(
-      const void* ptr,
-      size_t length,
+      CudaBuffer buffer,
       TDescriptorCallback descriptorCallback,
-      TSendCallback callback,
-      cudaStream_t stream);
+      TSendCallback callback);
 
   // Receive memory region from peer.
   void recvFromLoop_(
       TDescriptor descriptor,
-      void* ptr,
-      size_t length,
-      TRecvCallback callback,
-      cudaStream_t stream);
+      CudaBuffer buffer,
+      TRecvCallback callback);
 
   void readPackets_();
   void onReply_(const Reply& nopReply);
@@ -312,55 +301,28 @@ void Channel::Impl::initFromLoop_() {
 }
 
 void Channel::send(
-    const void* ptr,
-    size_t length,
+    CudaBuffer buffer,
     TDescriptorCallback descriptorCallback,
     TSendCallback callback) {
-  send(
-      ptr,
-      length,
-      std::move(descriptorCallback),
-      std::move(callback),
-      cudaStreamDefault);
-}
-
-void Channel::send(
-    const void* ptr,
-    size_t length,
-    TDescriptorCallback descriptorCallback,
-    TSendCallback callback,
-    cudaStream_t stream) {
-  impl_->send(
-      ptr, length, std::move(descriptorCallback), std::move(callback), stream);
+  impl_->send(buffer, std::move(descriptorCallback), std::move(callback));
 }
 
 void Channel::Impl::send(
-    const void* ptr,
-    size_t length,
+    CudaBuffer buffer,
     TDescriptorCallback descriptorCallback,
-    TSendCallback callback,
-    cudaStream_t stream) {
+    TSendCallback callback) {
   loop_.deferToLoop([this,
-                     ptr,
-                     length,
-                     stream,
+                     buffer,
                      descriptorCallback{std::move(descriptorCallback)},
                      callback{std::move(callback)}]() mutable {
-    sendFromLoop_(
-        ptr,
-        length,
-        std::move(descriptorCallback),
-        std::move(callback),
-        stream);
+    sendFromLoop_(buffer, std::move(descriptorCallback), std::move(callback));
   });
 }
 
 void Channel::Impl::sendFromLoop_(
-    const void* ptr,
-    size_t length,
+    CudaBuffer buffer,
     TDescriptorCallback descriptorCallback,
-    TSendCallback callback,
-    cudaStream_t stream) {
+    TSendCallback callback) {
   TP_DCHECK(loop_.inLoop());
 
   const uint64_t sequenceNumber = nextTensorBeingSent_++;
@@ -388,14 +350,14 @@ void Channel::Impl::sendFromLoop_(
                << sequenceNumber << ")";
   };
 
-  if (error_ || length == 0) {
+  if (error_ || buffer.length == 0) {
     descriptorCallback(error_, std::string());
     callback(error_);
     return;
   }
 
   sendOperations_.emplace_back(
-      sequenceNumber, std::move(callback), ptr, stream);
+      sequenceNumber, std::move(callback), buffer.ptr, buffer.stream);
   auto& op = sendOperations_.back();
 
   NopHolder<Descriptor> nopHolder;
@@ -406,49 +368,27 @@ void Channel::Impl::sendFromLoop_(
 // Receive memory region from peer.
 void Channel::recv(
     TDescriptor descriptor,
-    void* ptr,
-    size_t length,
+    CudaBuffer buffer,
     TRecvCallback callback) {
-  recv(
-      std::move(descriptor),
-      ptr,
-      length,
-      std::move(callback),
-      cudaStreamDefault);
-}
-
-void Channel::recv(
-    TDescriptor descriptor,
-    void* ptr,
-    size_t length,
-    TRecvCallback callback,
-    cudaStream_t stream) {
-  impl_->recv(std::move(descriptor), ptr, length, std::move(callback), stream);
+  impl_->recv(std::move(descriptor), buffer, std::move(callback));
 }
 
 void Channel::Impl::recv(
     TDescriptor descriptor,
-    void* ptr,
-    size_t length,
-    TRecvCallback callback,
-    cudaStream_t stream) {
+    CudaBuffer buffer,
+    TRecvCallback callback) {
   loop_.deferToLoop([this,
                      descriptor{std::move(descriptor)},
-                     ptr,
-                     length,
-                     stream,
+                     buffer,
                      callback{std::move(callback)}]() mutable {
-    recvFromLoop_(
-        std::move(descriptor), ptr, length, std::move(callback), stream);
+    recvFromLoop_(std::move(descriptor), buffer, std::move(callback));
   });
 }
 
 void Channel::Impl::recvFromLoop_(
     TDescriptor descriptor,
-    void* ptr,
-    size_t length,
-    TRecvCallback callback,
-    cudaStream_t stream) {
+    CudaBuffer buffer,
+    TRecvCallback callback) {
   TP_DCHECK(loop_.inLoop());
 
   const uint64_t sequenceNumber = nextTensorBeingReceived_++;
@@ -463,12 +403,13 @@ void Channel::Impl::recvFromLoop_(
                << sequenceNumber << ")";
   };
 
-  if (error_ || length == 0) {
+  if (error_ || buffer.length == 0) {
     callback(error_);
     return;
   }
 
-  recvOperations_.emplace_back(sequenceNumber, ptr, stream, length);
+  recvOperations_.emplace_back(
+      sequenceNumber, buffer.ptr, buffer.stream, buffer.length);
   auto& op = recvOperations_.back();
 
   NopHolder<Descriptor> nopHolder;

--- a/tensorpipe/channel/cuda_ipc/channel.h
+++ b/tensorpipe/channel/cuda_ipc/channel.h
@@ -12,14 +12,14 @@
 
 #include <cuda_runtime.h>
 
-#include <tensorpipe/channel/channel.h>
+#include <tensorpipe/channel/cuda_context.h>
 #include <tensorpipe/channel/cuda_ipc/context.h>
 
 namespace tensorpipe {
 namespace channel {
 namespace cuda_ipc {
 
-class Channel : public channel::Channel {
+class Channel : public channel::CudaChannel {
   // Use the passkey idiom to allow make_shared to call what should be a private
   // constructor. See https://abseil.io/tips/134 for more information.
   struct ConstructorToken {};
@@ -33,31 +33,13 @@ class Channel : public channel::Channel {
 
   // Send memory region to peer.
   void send(
-      const void* ptr,
-      size_t length,
+      CudaBuffer buffer,
       TDescriptorCallback descriptorCallback,
       TSendCallback callback) override;
 
-  void send(
-      const void* ptr,
-      size_t length,
-      TDescriptorCallback descriptorCallback,
-      TSendCallback callback,
-      cudaStream_t stream);
-
   // Receive memory region from peer.
-  void recv(
-      TDescriptor descriptor,
-      void* ptr,
-      size_t length,
-      TRecvCallback callback) override;
-
-  void recv(
-      TDescriptor descriptor,
-      void* ptr,
-      size_t length,
-      TRecvCallback callback,
-      cudaStream_t stream);
+  void recv(TDescriptor descriptor, CudaBuffer buffer, TRecvCallback callback)
+      override;
 
   // Tell the channel what its identifier is.
   void setId(std::string id) override;

--- a/tensorpipe/channel/cuda_ipc/context.cc
+++ b/tensorpipe/channel/cuda_ipc/context.cc
@@ -41,12 +41,6 @@ std::string generateDomainDescriptor() {
   return oss.str();
 }
 
-std::shared_ptr<Context> makeCudaIpcChannel() {
-  return std::make_shared<Context>();
-}
-
-TP_REGISTER_CREATOR(TensorpipeChannelRegistry, cuda_ipc, makeCudaIpcChannel);
-
 } // namespace
 
 class Context::Impl : public Context::PrivateIface,
@@ -56,7 +50,7 @@ class Context::Impl : public Context::PrivateIface,
 
   const std::string& domainDescriptor() const;
 
-  std::shared_ptr<channel::Channel> createChannel(
+  std::shared_ptr<channel::CudaChannel> createChannel(
       std::shared_ptr<transport::Connection>,
       Endpoint);
 
@@ -137,13 +131,13 @@ const std::string& Context::Impl::domainDescriptor() const {
   return domainDescriptor_;
 }
 
-std::shared_ptr<channel::Channel> Context::createChannel(
+std::shared_ptr<channel::CudaChannel> Context::createChannel(
     std::shared_ptr<transport::Connection> connection,
     Endpoint endpoint) {
   return impl_->createChannel(std::move(connection), endpoint);
 }
 
-std::shared_ptr<channel::Channel> Context::Impl::createChannel(
+std::shared_ptr<channel::CudaChannel> Context::Impl::createChannel(
     std::shared_ptr<transport::Connection> connection,
     Endpoint /* unused */) {
   TP_THROW_ASSERT_IF(joined_);

--- a/tensorpipe/channel/cuda_ipc/context.h
+++ b/tensorpipe/channel/cuda_ipc/context.h
@@ -12,7 +12,7 @@
 #include <memory>
 #include <string>
 
-#include <tensorpipe/channel/context.h>
+#include <tensorpipe/channel/cuda_context.h>
 #include <tensorpipe/common/callback.h>
 #include <tensorpipe/common/error.h>
 
@@ -20,13 +20,13 @@ namespace tensorpipe {
 namespace channel {
 namespace cuda_ipc {
 
-class Context : public channel::Context {
+class Context : public channel::CudaContext {
  public:
   Context();
 
   const std::string& domainDescriptor() const override;
 
-  std::shared_ptr<Channel> createChannel(
+  std::shared_ptr<CudaChannel> createChannel(
       std::shared_ptr<transport::Connection>,
       Endpoint) override;
 

--- a/tensorpipe/channel/mpt/channel.cc
+++ b/tensorpipe/channel/mpt/channel.cc
@@ -60,16 +60,11 @@ class Channel::Impl : public std::enable_shared_from_this<Channel::Impl> {
   void init();
 
   void send(
-      const void* ptr,
-      size_t length,
+      CpuBuffer buffer,
       TDescriptorCallback descriptorCallback,
       TSendCallback callback);
 
-  void recv(
-      TDescriptor descriptor,
-      void* ptr,
-      size_t length,
-      TRecvCallback callback);
+  void recv(TDescriptor descriptor, CpuBuffer buffer, TRecvCallback callback);
 
   // Tell the channel what its identifier is.
   void setId(std::string id);
@@ -87,15 +82,13 @@ class Channel::Impl : public std::enable_shared_from_this<Channel::Impl> {
   void initFromLoop_();
 
   void sendFromLoop_(
-      const void* ptr,
-      size_t length,
+      CpuBuffer buffer,
       TDescriptorCallback descriptorCallback,
       TSendCallback callback);
 
   void recvFromLoop_(
       TDescriptor descriptor,
-      void* ptr,
-      size_t length,
+      CpuBuffer buffer,
       TRecvCallback callback);
 
   void setIdFromLoop_(std::string id);
@@ -259,31 +252,26 @@ void Channel::Impl::initFromLoop_() {
 }
 
 void Channel::send(
-    const void* ptr,
-    size_t length,
+    CpuBuffer buffer,
     TDescriptorCallback descriptorCallback,
     TSendCallback callback) {
-  impl_->send(ptr, length, std::move(descriptorCallback), std::move(callback));
+  impl_->send(buffer, std::move(descriptorCallback), std::move(callback));
 }
 
 void Channel::Impl::send(
-    const void* ptr,
-    size_t length,
+    CpuBuffer buffer,
     TDescriptorCallback descriptorCallback,
     TSendCallback callback) {
   loop_.deferToLoop([this,
-                     ptr,
-                     length,
+                     buffer,
                      descriptorCallback{std::move(descriptorCallback)},
                      callback{std::move(callback)}]() mutable {
-    sendFromLoop_(
-        ptr, length, std::move(descriptorCallback), std::move(callback));
+    sendFromLoop_(buffer, std::move(descriptorCallback), std::move(callback));
   });
 }
 
 void Channel::Impl::sendFromLoop_(
-    const void* ptr,
-    size_t length,
+    CpuBuffer buffer,
     TDescriptorCallback descriptorCallback,
     TSendCallback callback) {
   TP_DCHECK(loop_.inLoop());
@@ -323,8 +311,8 @@ void Channel::Impl::sendFromLoop_(
   sendOperations_.emplace_back();
   SendOperation& op = sendOperations_.back();
   op.sequenceNumber = sequenceNumber;
-  op.ptr = ptr;
-  op.length = length;
+  op.ptr = buffer.ptr;
+  op.length = buffer.length;
   op.callback = std::move(callback);
 
   if (state_ == ESTABLISHED) {
@@ -336,30 +324,26 @@ void Channel::Impl::sendFromLoop_(
 
 void Channel::recv(
     TDescriptor descriptor,
-    void* ptr,
-    size_t length,
+    CpuBuffer buffer,
     TRecvCallback callback) {
-  impl_->recv(std::move(descriptor), ptr, length, std::move(callback));
+  impl_->recv(std::move(descriptor), buffer, std::move(callback));
 }
 
 void Channel::Impl::recv(
     TDescriptor descriptor,
-    void* ptr,
-    size_t length,
+    CpuBuffer buffer,
     TRecvCallback callback) {
   loop_.deferToLoop([this,
                      descriptor{std::move(descriptor)},
-                     ptr,
-                     length,
+                     buffer,
                      callback{std::move(callback)}]() mutable {
-    recvFromLoop_(std::move(descriptor), ptr, length, std::move(callback));
+    recvFromLoop_(std::move(descriptor), buffer, std::move(callback));
   });
 }
 
 void Channel::Impl::recvFromLoop_(
     TDescriptor descriptor,
-    void* ptr,
-    size_t length,
+    CpuBuffer buffer,
     TRecvCallback callback) {
   TP_DCHECK(loop_.inLoop());
 
@@ -387,8 +371,8 @@ void Channel::Impl::recvFromLoop_(
   recvOperations_.emplace_back();
   RecvOperation& op = recvOperations_.back();
   op.sequenceNumber = sequenceNumber;
-  op.ptr = ptr;
-  op.length = length;
+  op.ptr = buffer.ptr;
+  op.length = buffer.length;
   op.callback = std::move(callback);
 
   if (state_ == ESTABLISHED) {

--- a/tensorpipe/channel/mpt/channel.h
+++ b/tensorpipe/channel/mpt/channel.h
@@ -11,14 +11,14 @@
 #include <deque>
 #include <list>
 
-#include <tensorpipe/channel/channel.h>
+#include <tensorpipe/channel/cpu_context.h>
 #include <tensorpipe/channel/mpt/context.h>
 
 namespace tensorpipe {
 namespace channel {
 namespace mpt {
 
-class Channel : public channel::Channel {
+class Channel : public channel::CpuChannel {
   // Use the passkey idiom to allow make_shared to call what should be a private
   // constructor. See https://abseil.io/tips/134 for more information.
   struct ConstructorToken {};
@@ -34,17 +34,13 @@ class Channel : public channel::Channel {
 
   // Send memory region to peer.
   void send(
-      const void* ptr,
-      size_t length,
+      CpuBuffer buffer,
       TDescriptorCallback descriptorCallback,
       TSendCallback callback) override;
 
   // Receive memory region from peer.
-  void recv(
-      TDescriptor descriptor,
-      void* ptr,
-      size_t length,
-      TRecvCallback callback) override;
+  void recv(TDescriptor descriptor, CpuBuffer buffer, TRecvCallback callback)
+      override;
 
   // Tell the channel what its identifier is.
   void setId(std::string id) override;

--- a/tensorpipe/channel/mpt/context.cc
+++ b/tensorpipe/channel/mpt/context.cc
@@ -13,7 +13,6 @@
 #include <unordered_map>
 #include <unordered_set>
 
-#include <tensorpipe/channel/channel.h>
 #include <tensorpipe/channel/error.h>
 #include <tensorpipe/channel/helpers.h>
 #include <tensorpipe/channel/mpt/channel.h>
@@ -52,7 +51,7 @@ class Context::Impl : public Context::PrivateIface,
 
   const std::string& domainDescriptor() const;
 
-  std::shared_ptr<channel::Channel> createChannel(
+  std::shared_ptr<channel::CpuChannel> createChannel(
       std::shared_ptr<transport::Connection>,
       Endpoint);
 
@@ -196,13 +195,13 @@ const std::string& Context::Impl::domainDescriptor() const {
   return domainDescriptor_;
 }
 
-std::shared_ptr<channel::Channel> Context::createChannel(
+std::shared_ptr<channel::CpuChannel> Context::createChannel(
     std::shared_ptr<transport::Connection> connection,
     Endpoint endpoint) {
   return impl_->createChannel(std::move(connection), endpoint);
 }
 
-std::shared_ptr<channel::Channel> Context::Impl::createChannel(
+std::shared_ptr<channel::CpuChannel> Context::Impl::createChannel(
     std::shared_ptr<transport::Connection> connection,
     Endpoint endpoint) {
   std::string channelId = id_ + ".c" + std::to_string(channelCounter_++);

--- a/tensorpipe/channel/mpt/context.h
+++ b/tensorpipe/channel/mpt/context.h
@@ -12,7 +12,7 @@
 #include <string>
 #include <vector>
 
-#include <tensorpipe/channel/context.h>
+#include <tensorpipe/channel/cpu_context.h>
 #include <tensorpipe/common/callback.h>
 #include <tensorpipe/transport/context.h>
 
@@ -20,7 +20,7 @@ namespace tensorpipe {
 namespace channel {
 namespace mpt {
 
-class Context : public channel::Context {
+class Context : public channel::CpuContext {
  public:
   Context(
       std::vector<std::shared_ptr<transport::Context>>,
@@ -28,7 +28,7 @@ class Context : public channel::Context {
 
   const std::string& domainDescriptor() const override;
 
-  std::shared_ptr<Channel> createChannel(
+  std::shared_ptr<CpuChannel> createChannel(
       std::shared_ptr<transport::Connection>,
       Endpoint) override;
 

--- a/tensorpipe/channel/registry.h
+++ b/tensorpipe/channel/registry.h
@@ -8,9 +8,9 @@
 
 #pragma once
 
-#include <tensorpipe/channel/context.h>
+#include <tensorpipe/channel/cpu_context.h>
 #include <tensorpipe/util/registry/registry.h>
 
 TP_DECLARE_SHARED_REGISTRY(
     TensorpipeChannelRegistry,
-    tensorpipe::channel::Context);
+    tensorpipe::channel::CpuContext);

--- a/tensorpipe/channel/xth/channel.cc
+++ b/tensorpipe/channel/xth/channel.cc
@@ -42,16 +42,11 @@ class Channel::Impl : public std::enable_shared_from_this<Channel::Impl> {
   void init();
 
   void send(
-      const void* ptr,
-      size_t length,
+      CpuBuffer buffer,
       TDescriptorCallback descriptorCallback,
       TSendCallback callback);
 
-  void recv(
-      TDescriptor descriptor,
-      void* ptr,
-      size_t length,
-      TRecvCallback callback);
+  void recv(TDescriptor descriptor, CpuBuffer buffer, TRecvCallback callback);
 
   // Tell the channel what its identifier is.
   void setId(std::string id);
@@ -65,16 +60,14 @@ class Channel::Impl : public std::enable_shared_from_this<Channel::Impl> {
 
   // Send memory region to peer.
   void sendFromLoop_(
-      const void* ptr,
-      size_t length,
+      CpuBuffer buffer,
       TDescriptorCallback descriptorCallback,
       TSendCallback callback);
 
   // Receive memory region from peer.
   void recvFromLoop_(
       TDescriptor descriptor,
-      void* ptr,
-      size_t length,
+      CpuBuffer buffer,
       TRecvCallback callback);
 
   void setIdFromLoop_(std::string id);
@@ -145,31 +138,26 @@ void Channel::Impl::initFromLoop_() {
 }
 
 void Channel::send(
-    const void* ptr,
-    size_t length,
+    CpuBuffer buffer,
     TDescriptorCallback descriptorCallback,
     TSendCallback callback) {
-  impl_->send(ptr, length, std::move(descriptorCallback), std::move(callback));
+  impl_->send(buffer, std::move(descriptorCallback), std::move(callback));
 }
 
 void Channel::Impl::send(
-    const void* ptr,
-    size_t length,
+    CpuBuffer buffer,
     TDescriptorCallback descriptorCallback,
     TSendCallback callback) {
   loop_.deferToLoop([this,
-                     ptr,
-                     length,
+                     buffer,
                      descriptorCallback{std::move(descriptorCallback)},
                      callback{std::move(callback)}]() mutable {
-    sendFromLoop_(
-        ptr, length, std::move(descriptorCallback), std::move(callback));
+    sendFromLoop_(buffer, std::move(descriptorCallback), std::move(callback));
   });
 }
 
 void Channel::Impl::sendFromLoop_(
-    const void* ptr,
-    size_t length,
+    CpuBuffer buffer,
     TDescriptorCallback descriptorCallback,
     TSendCallback callback) {
   TP_DCHECK(loop_.inLoop());
@@ -221,7 +209,7 @@ void Channel::Impl::sendFromLoop_(
 
   NopHolder<Descriptor> nopHolder;
   Descriptor& nopDescriptor = nopHolder.getObject();
-  nopDescriptor.ptr = reinterpret_cast<std::uintptr_t>(ptr);
+  nopDescriptor.ptr = reinterpret_cast<std::uintptr_t>(buffer.ptr);
 
   descriptorCallback(Error::kSuccess, saveDescriptor(nopHolder));
 }
@@ -229,30 +217,26 @@ void Channel::Impl::sendFromLoop_(
 // Receive memory region from peer.
 void Channel::recv(
     TDescriptor descriptor,
-    void* ptr,
-    size_t length,
+    CpuBuffer buffer,
     TRecvCallback callback) {
-  impl_->recv(std::move(descriptor), ptr, length, std::move(callback));
+  impl_->recv(std::move(descriptor), buffer, std::move(callback));
 }
 
 void Channel::Impl::recv(
     TDescriptor descriptor,
-    void* ptr,
-    size_t length,
+    CpuBuffer buffer,
     TRecvCallback callback) {
   loop_.deferToLoop([this,
                      descriptor{std::move(descriptor)},
-                     ptr,
-                     length,
+                     buffer,
                      callback{std::move(callback)}]() mutable {
-    recvFromLoop_(std::move(descriptor), ptr, length, std::move(callback));
+    recvFromLoop_(std::move(descriptor), buffer, std::move(callback));
   });
 }
 
 void Channel::Impl::recvFromLoop_(
     TDescriptor descriptor,
-    void* ptr,
-    size_t length,
+    CpuBuffer buffer,
     TRecvCallback callback) {
   TP_DCHECK(loop_.inLoop());
 
@@ -282,8 +266,8 @@ void Channel::Impl::recvFromLoop_(
              << ")";
   context_->requestCopy(
       remotePtr,
-      ptr,
-      length,
+      buffer.ptr,
+      buffer.length,
       eagerCallbackWrapper_([sequenceNumber,
                              callback{std::move(callback)}](Impl& impl) {
         TP_VLOG(6) << "Channel " << impl.id_ << " done copying payload (#"

--- a/tensorpipe/channel/xth/channel.h
+++ b/tensorpipe/channel/xth/channel.h
@@ -10,14 +10,14 @@
 
 #include <memory>
 
-#include <tensorpipe/channel/channel.h>
+#include <tensorpipe/channel/cpu_context.h>
 #include <tensorpipe/channel/xth/context.h>
 
 namespace tensorpipe {
 namespace channel {
 namespace xth {
 
-class Channel : public channel::Channel {
+class Channel : public channel::CpuChannel {
   // Use the passkey idiom to allow make_shared to call what should be a private
   // constructor. See https://abseil.io/tips/134 for more information.
   struct ConstructorToken {};
@@ -31,17 +31,13 @@ class Channel : public channel::Channel {
 
   // Send memory region to peer.
   void send(
-      const void* ptr,
-      size_t length,
+      CpuBuffer buffer,
       TDescriptorCallback descriptorCallback,
       TSendCallback callback) override;
 
   // Receive memory region from peer.
-  void recv(
-      TDescriptor descriptor,
-      void* ptr,
-      size_t length,
-      TRecvCallback callback) override;
+  void recv(TDescriptor descriptor, CpuBuffer buffer, TRecvCallback callback)
+      override;
 
   // Tell the channel what its identifier is.
   void setId(std::string id) override;

--- a/tensorpipe/channel/xth/context.cc
+++ b/tensorpipe/channel/xth/context.cc
@@ -58,7 +58,7 @@ class Context::Impl : public Context::PrivateIface,
 
   const std::string& domainDescriptor() const;
 
-  std::shared_ptr<channel::Channel> createChannel(
+  std::shared_ptr<channel::CpuChannel> createChannel(
       std::shared_ptr<transport::Connection>,
       Endpoint);
 
@@ -176,13 +176,13 @@ const std::string& Context::Impl::domainDescriptor() const {
   return domainDescriptor_;
 }
 
-std::shared_ptr<channel::Channel> Context::createChannel(
+std::shared_ptr<channel::CpuChannel> Context::createChannel(
     std::shared_ptr<transport::Connection> connection,
     Endpoint endpoint) {
   return impl_->createChannel(std::move(connection), endpoint);
 }
 
-std::shared_ptr<channel::Channel> Context::Impl::createChannel(
+std::shared_ptr<channel::CpuChannel> Context::Impl::createChannel(
     std::shared_ptr<transport::Connection> connection,
     Endpoint /* unused */) {
   TP_THROW_ASSERT_IF(joined_);

--- a/tensorpipe/channel/xth/context.h
+++ b/tensorpipe/channel/xth/context.h
@@ -12,7 +12,7 @@
 #include <memory>
 #include <string>
 
-#include <tensorpipe/channel/context.h>
+#include <tensorpipe/channel/cpu_context.h>
 #include <tensorpipe/common/callback.h>
 #include <tensorpipe/common/error.h>
 
@@ -20,13 +20,13 @@ namespace tensorpipe {
 namespace channel {
 namespace xth {
 
-class Context : public channel::Context {
+class Context : public channel::CpuContext {
  public:
   Context();
 
   const std::string& domainDescriptor() const override;
 
-  std::shared_ptr<Channel> createChannel(
+  std::shared_ptr<CpuChannel> createChannel(
       std::shared_ptr<transport::Connection>,
       Endpoint) override;
 

--- a/tensorpipe/common/cpu_buffer.h
+++ b/tensorpipe/common/cpu_buffer.h
@@ -6,8 +6,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <tensorpipe/channel/registry.h>
+#pragma once
 
-TP_DEFINE_SHARED_REGISTRY(
-    TensorpipeChannelRegistry,
-    tensorpipe::channel::CpuContext);
+#include <cstddef>
+
+namespace tensorpipe {
+
+struct CpuBuffer {
+  void* ptr{nullptr};
+  size_t length{0};
+};
+
+} // namespace tensorpipe

--- a/tensorpipe/common/cuda_buffer.h
+++ b/tensorpipe/common/cuda_buffer.h
@@ -6,8 +6,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <tensorpipe/channel/registry.h>
+#pragma once
 
-TP_DEFINE_SHARED_REGISTRY(
-    TensorpipeChannelRegistry,
-    tensorpipe::channel::CpuContext);
+#include <cstddef>
+
+#include <cuda_runtime.h>
+
+namespace tensorpipe {
+
+struct CudaBuffer {
+  void* ptr{nullptr};
+  size_t length{0};
+  cudaStream_t stream{cudaStreamDefault};
+};
+
+} // namespace tensorpipe

--- a/tensorpipe/core/buffer.h
+++ b/tensorpipe/core/buffer.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <tensorpipe/config.h>
+
+#include <tensorpipe/common/cpu_buffer.h>
+#if TENSORPIPE_SUPPORTS_CUDA
+#include <tensorpipe/common/cuda_buffer.h>
+#endif // TENSORPIPE_SUPPORTS_CUDA
+
+namespace tensorpipe {
+
+enum class DeviceType {
+  kCpu,
+#if TENSORPIPE_SUPPORTS_CUDA
+  kCuda,
+#endif // TENSORPIPE_SUPPORTS_CUDA
+};
+
+struct Buffer {
+  Buffer() {}
+
+  /* implicit */ Buffer(CpuBuffer buffer)
+      : type(DeviceType::kCpu), cpu(buffer) {}
+
+  Buffer& operator=(CpuBuffer& buffer) {
+    type = DeviceType::kCpu;
+    cpu = buffer;
+
+    return *this;
+  }
+
+#if TENSORPIPE_SUPPORTS_CUDA
+  /* implicit */ Buffer(CudaBuffer buffer)
+      : type(DeviceType::kCuda), cuda(buffer) {}
+
+  Buffer& operator=(CudaBuffer& buffer) {
+    type = DeviceType::kCuda;
+    cuda = buffer;
+
+    return *this;
+  }
+
+#endif // TENSORPIPE_SUPPORTS_CUDA
+
+  DeviceType type;
+  union {
+    CpuBuffer cpu;
+#if TENSORPIPE_SUPPORTS_CUDA
+    CudaBuffer cuda;
+#endif // TENSORPIPE_SUPPORTS_CUDA
+  };
+};
+
+} // namespace tensorpipe

--- a/tensorpipe/core/context.cc
+++ b/tensorpipe/core/context.cc
@@ -51,7 +51,10 @@ class Context::Impl : public Context::PrivateIface,
       std::string,
       std::shared_ptr<transport::Context>);
 
-  void registerChannel(int64_t, std::string, std::shared_ptr<channel::Context>);
+  void registerChannel(
+      int64_t,
+      std::string,
+      std::shared_ptr<channel::CpuContext>);
 
   std::shared_ptr<Listener> listen(const std::vector<std::string>&);
 
@@ -60,7 +63,7 @@ class Context::Impl : public Context::PrivateIface,
   ClosingEmitter& getClosingEmitter() override;
 
   std::shared_ptr<transport::Context> getTransport(const std::string&) override;
-  std::shared_ptr<channel::Context> getChannel(const std::string&) override;
+  std::shared_ptr<channel::CpuContext> getChannel(const std::string&) override;
 
   using PrivateIface::TOrderedTransports;
 
@@ -102,7 +105,8 @@ class Context::Impl : public Context::PrivateIface,
 
   std::unordered_map<std::string, std::shared_ptr<transport::Context>>
       transports_;
-  std::unordered_map<std::string, std::shared_ptr<channel::Context>> channels_;
+  std::unordered_map<std::string, std::shared_ptr<channel::CpuContext>>
+      channels_;
 
   TOrderedTransports transportsByPriority_;
   TOrderedChannels channelsByPriority_;
@@ -150,14 +154,14 @@ void Context::Impl::registerTransport(
 void Context::registerChannel(
     int64_t priority,
     std::string channel,
-    std::shared_ptr<channel::Context> context) {
+    std::shared_ptr<channel::CpuContext> context) {
   impl_->registerChannel(priority, std::move(channel), std::move(context));
 }
 
 void Context::Impl::registerChannel(
     int64_t priority,
     std::string channel,
-    std::shared_ptr<channel::Context> context) {
+    std::shared_ptr<channel::CpuContext> context) {
   TP_THROW_ASSERT_IF(channel.empty());
   TP_THROW_ASSERT_IF(channels_.find(channel) != channels_.end())
       << "channel " << channel << " already registered";
@@ -227,7 +231,7 @@ std::shared_ptr<transport::Context> Context::Impl::getTransport(
   return iter->second;
 }
 
-std::shared_ptr<channel::Context> Context::Impl::getChannel(
+std::shared_ptr<channel::CpuContext> Context::Impl::getChannel(
     const std::string& channel) {
   auto iter = channels_.find(channel);
   if (iter == channels_.end()) {

--- a/tensorpipe/core/context.h
+++ b/tensorpipe/core/context.h
@@ -14,8 +14,9 @@
 #include <tuple>
 #include <vector>
 
-#include <tensorpipe/channel/context.h>
+#include <tensorpipe/channel/cpu_context.h>
 #include <tensorpipe/common/callback.h>
+#include <tensorpipe/core/buffer.h>
 #include <tensorpipe/transport/context.h>
 
 namespace tensorpipe {
@@ -58,7 +59,10 @@ class Context final {
       std::string,
       std::shared_ptr<transport::Context>);
 
-  void registerChannel(int64_t, std::string, std::shared_ptr<channel::Context>);
+  void registerChannel(
+      int64_t,
+      std::string,
+      std::shared_ptr<channel::CpuContext>);
 
   std::shared_ptr<Listener> listen(const std::vector<std::string>&);
 
@@ -84,7 +88,7 @@ class Context final {
     virtual std::shared_ptr<transport::Context> getTransport(
         const std::string&) = 0;
 
-    virtual std::shared_ptr<channel::Context> getChannel(
+    virtual std::shared_ptr<channel::CpuContext> getChannel(
         const std::string&) = 0;
 
     using TOrderedTransports = std::map<
@@ -95,7 +99,7 @@ class Context final {
 
     using TOrderedChannels = std::map<
         int64_t,
-        std::tuple<std::string, std::shared_ptr<channel::Context>>>;
+        std::tuple<std::string, std::shared_ptr<channel::CpuContext>>>;
 
     virtual const TOrderedChannels& getOrderedChannels() = 0;
 

--- a/tensorpipe/core/message.h
+++ b/tensorpipe/core/message.h
@@ -13,6 +13,8 @@
 #include <string>
 #include <vector>
 
+#include <tensorpipe/core/buffer.h>
+
 namespace tensorpipe {
 
 // Messages consist of a primary buffer and zero or more separate
@@ -49,10 +51,9 @@ class Message final {
   std::vector<Payload> payloads;
 
   struct Tensor {
-    void* data{nullptr};
-    size_t length{0};
+    tensorpipe::Buffer buffer;
 
-    // Users may include arbitrary metadata in the following fields.
+    // Users may include arbitrary metadata in the following field.
     // This may contain allocation hints for the receiver, for example.
     std::string metadata;
   };

--- a/tensorpipe/core/nop_types.h
+++ b/tensorpipe/core/nop_types.h
@@ -16,6 +16,8 @@
 #include <nop/structure.h>
 #include <nop/types/variant.h>
 
+#include <tensorpipe/core/buffer.h>
+
 namespace tensorpipe {
 
 struct SpontaneousConnection {
@@ -62,8 +64,6 @@ struct BrochureAnswer {
       registrationId,
       channelSelection);
 };
-
-enum class DeviceType { DEVICE_TYPE_UNSPECIFIED, DEVICE_TYPE_CPU };
 
 struct MessageDescriptor {
   struct PayloadDescriptor {

--- a/tensorpipe/python/tensorpipe.cc
+++ b/tensorpipe/python/tensorpipe.cc
@@ -115,8 +115,8 @@ tensorpipe::Message prepareToWrite(std::shared_ptr<OutgoingMessage> pyMessage) {
   tpMessage.tensors.reserve(pyMessage->tensors.size());
   for (const auto& pyTensor : pyMessage->tensors) {
     tensorpipe::Message::Tensor tpTensor{
-        pyTensor->buffer.ptr(),
-        pyTensor->buffer.length(),
+        tensorpipe::CpuBuffer{pyTensor->buffer.ptr(),
+                              pyTensor->buffer.length()},
         {reinterpret_cast<char*>(pyTensor->metadata.ptr()),
          pyTensor->metadata.length()}};
     tpMessage.tensors.push_back(std::move(tpTensor));
@@ -187,9 +187,9 @@ std::shared_ptr<IncomingMessage> prepareToAllocate(
   std::vector<std::shared_ptr<IncomingTensor>> pyTensors;
   pyTensors.reserve(tpMessage.tensors.size());
   for (const auto& tpTensor : tpMessage.tensors) {
-    TP_DCHECK(tpTensor.data == nullptr);
-    pyTensors.push_back(
-        std::make_shared<IncomingTensor>(tpTensor.length, tpTensor.metadata));
+    TP_DCHECK(tpTensor.buffer.cpu.ptr == nullptr);
+    pyTensors.push_back(std::make_shared<IncomingTensor>(
+        tpTensor.buffer.cpu.length, tpTensor.metadata));
   }
   auto pyMessage = std::make_shared<IncomingMessage>(
       tpMessage.metadata, std::move(pyPayloads), std::move(pyTensors));
@@ -208,8 +208,8 @@ tensorpipe::Message prepareToRead(std::shared_ptr<IncomingMessage> pyMessage) {
   tpMessage.tensors.reserve(pyMessage->tensors.size());
   for (const auto& pyTensor : pyMessage->tensors) {
     TP_THROW_ASSERT_IF(!pyTensor->buffer.has_value()) << "No buffer";
-    tensorpipe::Message::Tensor tpTensor{pyTensor->buffer.value().ptr(),
-                                         pyTensor->buffer.value().length()};
+    tensorpipe::Message::Tensor tpTensor{tensorpipe::CpuBuffer{
+        pyTensor->buffer.value().ptr(), pyTensor->buffer.value().length()}};
     tpMessage.tensors.push_back(std::move(tpTensor));
   }
   return tpMessage;
@@ -224,7 +224,7 @@ using transport_class_ =
 
 template <typename T>
 using channel_class_ =
-    py::class_<T, tensorpipe::channel::Context, std::shared_ptr<T>>;
+    py::class_<T, tensorpipe::channel::CpuContext, std::shared_ptr<T>>;
 
 } // namespace
 
@@ -438,7 +438,7 @@ PYBIND11_MODULE(pytensorpipe, module) {
       py::arg("name"),
       py::arg("transport"));
 
-  shared_ptr_class_<tensorpipe::channel::Context> abstractChannel(
+  shared_ptr_class_<tensorpipe::channel::CpuContext> abstractChannel(
       module, "AbstractChannel");
 
   channel_class_<tensorpipe::channel::basic::Context> basicChannel(

--- a/tensorpipe/tensorpipe.h
+++ b/tensorpipe/tensorpipe.h
@@ -12,6 +12,7 @@
 
 // High-level API
 
+#include <tensorpipe/core/buffer.h>
 #include <tensorpipe/core/context.h>
 #include <tensorpipe/core/error.h>
 #include <tensorpipe/core/listener.h>
@@ -32,7 +33,11 @@
 
 // Channels
 
-#include <tensorpipe/channel/context.h>
+#include <tensorpipe/channel/cpu_context.h>
+#if TENSORPIPE_SUPPORTS_CUDA
+#include <tensorpipe/channel/cuda_context.h>
+#endif // TENSORPIPE_SUPPORTS_CUDA
+
 #include <tensorpipe/channel/error.h>
 
 #include <tensorpipe/channel/basic/context.h>

--- a/tensorpipe/test/channel/basic/basic_test.cc
+++ b/tensorpipe/test/channel/basic/basic_test.cc
@@ -17,7 +17,7 @@ class BasicChannelTestHelper : public ChannelTestHelper {
     return "basic";
   }
 
-  std::shared_ptr<tensorpipe::channel::Context> makeContext(
+  std::shared_ptr<tensorpipe::channel::CpuContext> makeContext(
       std::string id) override {
     auto context = std::make_shared<tensorpipe::channel::basic::Context>();
     context->setId(std::move(id));

--- a/tensorpipe/test/channel/channel_test.cc
+++ b/tensorpipe/test/channel/channel_test.cc
@@ -16,8 +16,8 @@ using namespace tensorpipe;
 using namespace tensorpipe::channel;
 
 TEST_P(ChannelTest, DomainDescriptor) {
-  std::shared_ptr<Context> context1 = GetParam()->makeContext("ctx1");
-  std::shared_ptr<Context> context2 = GetParam()->makeContext("ctx2");
+  std::shared_ptr<CpuContext> context1 = GetParam()->makeContext("ctx1");
+  std::shared_ptr<CpuContext> context2 = GetParam()->makeContext("ctx2");
   EXPECT_FALSE(context1->domainDescriptor().empty());
   EXPECT_FALSE(context2->domainDescriptor().empty());
   EXPECT_EQ(context1->domainDescriptor(), context2->domainDescriptor());
@@ -28,7 +28,7 @@ TEST_P(ChannelTest, ClientToServer) {
 
   testConnection(
       [&](std::shared_ptr<transport::Connection> conn) {
-        std::shared_ptr<Context> ctx = GetParam()->makeContext("server");
+        std::shared_ptr<CpuContext> ctx = GetParam()->makeContext("server");
         auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
 
         // Initialize with sequential values.
@@ -39,7 +39,7 @@ TEST_P(ChannelTest, ClientToServer) {
         std::future<std::tuple<Error, TDescriptor>> descriptorFuture;
         std::future<Error> sendFuture;
         std::tie(descriptorFuture, sendFuture) =
-            sendWithFuture(channel, data.data(), data.size());
+            sendWithFuture(channel, CpuBuffer{data.data(), data.size()});
         Error descriptorError;
         TDescriptor descriptor;
         std::tie(descriptorError, descriptor) = descriptorFuture.get();
@@ -54,15 +54,15 @@ TEST_P(ChannelTest, ClientToServer) {
         ctx->join();
       },
       [&](std::shared_ptr<transport::Connection> conn) {
-        std::shared_ptr<Context> ctx = GetParam()->makeContext("client");
+        std::shared_ptr<CpuContext> ctx = GetParam()->makeContext("client");
         auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
 
         std::vector<uint8_t> data(dataSize);
 
         // Perform recv and wait for completion.
         auto descriptor = peers_->recv(PeerGroup::kClient);
-        std::future<Error> recvFuture =
-            recvWithFuture(channel, descriptor, data.data(), data.size());
+        std::future<Error> recvFuture = recvWithFuture(
+            channel, descriptor, CpuBuffer{data.data(), data.size()});
         Error recvError = recvFuture.get();
         EXPECT_FALSE(recvError) << recvError.what();
 
@@ -83,15 +83,15 @@ TEST_P(ChannelTest, ServerToClient) {
 
   testConnection(
       [&](std::shared_ptr<transport::Connection> conn) {
-        std::shared_ptr<Context> ctx = GetParam()->makeContext("server");
+        std::shared_ptr<CpuContext> ctx = GetParam()->makeContext("server");
         auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
 
         std::vector<uint8_t> data(dataSize);
 
         // Perform recv and wait for completion.
         auto descriptor = peers_->recv(PeerGroup::kServer);
-        std::future<Error> recvFuture =
-            recvWithFuture(channel, descriptor, data.data(), data.size());
+        std::future<Error> recvFuture = recvWithFuture(
+            channel, descriptor, CpuBuffer{data.data(), data.size()});
         Error recvError = recvFuture.get();
         EXPECT_FALSE(recvError) << recvError.what();
 
@@ -106,7 +106,7 @@ TEST_P(ChannelTest, ServerToClient) {
         ctx->join();
       },
       [&](std::shared_ptr<transport::Connection> conn) {
-        std::shared_ptr<Context> ctx = GetParam()->makeContext("client");
+        std::shared_ptr<CpuContext> ctx = GetParam()->makeContext("client");
         auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
 
         // Initialize with sequential values.
@@ -117,7 +117,7 @@ TEST_P(ChannelTest, ServerToClient) {
         std::future<std::tuple<Error, TDescriptor>> descriptorFuture;
         std::future<Error> sendFuture;
         std::tie(descriptorFuture, sendFuture) =
-            sendWithFuture(channel, data.data(), data.size());
+            sendWithFuture(channel, CpuBuffer{data.data(), data.size()});
         Error descriptorError;
         TDescriptor descriptor;
         std::tie(descriptorError, descriptor) = descriptorFuture.get();
@@ -139,7 +139,7 @@ TEST_P(ChannelTest, SendMultipleTensors) {
 
   testConnection(
       [&](std::shared_ptr<transport::Connection> conn) {
-        std::shared_ptr<Context> ctx = GetParam()->makeContext("server");
+        std::shared_ptr<CpuContext> ctx = GetParam()->makeContext("server");
         auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
 
         // Initialize with sequential values.
@@ -154,7 +154,7 @@ TEST_P(ChannelTest, SendMultipleTensors) {
           std::future<std::tuple<Error, TDescriptor>> descriptorFuture;
           std::future<Error> sendFuture;
           std::tie(descriptorFuture, sendFuture) =
-              sendWithFuture(channel, data.data(), data.size());
+              sendWithFuture(channel, CpuBuffer{data.data(), data.size()});
           Error descriptorError;
           TDescriptor descriptor;
           std::tie(descriptorError, descriptor) = descriptorFuture.get();
@@ -173,7 +173,7 @@ TEST_P(ChannelTest, SendMultipleTensors) {
         ctx->join();
       },
       [&](std::shared_ptr<transport::Connection> conn) {
-        std::shared_ptr<Context> ctx = GetParam()->makeContext("client");
+        std::shared_ptr<CpuContext> ctx = GetParam()->makeContext("client");
         auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
 
         std::vector<std::vector<uint8_t>> dataVec(
@@ -186,7 +186,7 @@ TEST_P(ChannelTest, SendMultipleTensors) {
         for (int i = 0; i < numTensors; i++) {
           auto descriptor = peers_->recv(PeerGroup::kClient);
           std::future<Error> recvFuture = recvWithFuture(
-              channel, descriptor, dataVec[i].data(), dataVec[i].size());
+              channel, descriptor, CpuBuffer{dataVec[i].data(), dataSize});
           recvFutures.push_back(std::move(recvFuture));
         }
         for (auto& recvFuture : recvFutures) {
@@ -213,7 +213,7 @@ TEST_P(ChannelTest, SendTensorsBothWays) {
 
   testConnection(
       [&](std::shared_ptr<transport::Connection> conn) {
-        std::shared_ptr<Context> ctx = GetParam()->makeContext("server");
+        std::shared_ptr<CpuContext> ctx = GetParam()->makeContext("server");
         auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
 
         // Initialize sendBuffer with sequential values.
@@ -229,8 +229,8 @@ TEST_P(ChannelTest, SendTensorsBothWays) {
         // Perform send.
         {
           std::future<std::tuple<Error, TDescriptor>> descriptorFuture;
-          std::tie(descriptorFuture, sendFuture) =
-              sendWithFuture(channel, sendData.data(), sendData.size());
+          std::tie(descriptorFuture, sendFuture) = sendWithFuture(
+              channel, CpuBuffer{sendData.data(), sendData.size()});
           Error descriptorError;
           TDescriptor descriptor;
           std::tie(descriptorError, descriptor) = descriptorFuture.get();
@@ -242,7 +242,7 @@ TEST_P(ChannelTest, SendTensorsBothWays) {
         {
           auto descriptor = peers_->recv(PeerGroup::kServer);
           recvFuture = recvWithFuture(
-              channel, descriptor, recvData.data(), recvData.size());
+              channel, descriptor, CpuBuffer{recvData.data(), recvData.size()});
         }
 
         // Wait for completion of both.
@@ -262,7 +262,7 @@ TEST_P(ChannelTest, SendTensorsBothWays) {
         ctx->join();
       },
       [&](std::shared_ptr<transport::Connection> conn) {
-        std::shared_ptr<Context> ctx = GetParam()->makeContext("client");
+        std::shared_ptr<CpuContext> ctx = GetParam()->makeContext("client");
         auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
 
         // Initialize sendBuffer with sequential values.
@@ -278,8 +278,8 @@ TEST_P(ChannelTest, SendTensorsBothWays) {
         // Perform send.
         {
           std::future<std::tuple<Error, TDescriptor>> descriptorFuture;
-          std::tie(descriptorFuture, sendFuture) =
-              sendWithFuture(channel, sendData.data(), sendData.size());
+          std::tie(descriptorFuture, sendFuture) = sendWithFuture(
+              channel, CpuBuffer{sendData.data(), sendData.size()});
           Error descriptorError;
           TDescriptor descriptor;
           std::tie(descriptorError, descriptor) = descriptorFuture.get();
@@ -291,7 +291,7 @@ TEST_P(ChannelTest, SendTensorsBothWays) {
         {
           auto descriptor = peers_->recv(PeerGroup::kClient);
           recvFuture = recvWithFuture(
-              channel, descriptor, recvData.data(), recvData.size());
+              channel, descriptor, CpuBuffer{recvData.data(), recvData.size()});
         }
 
         // Wait for completion of both.
@@ -317,14 +317,14 @@ TEST_P(ChannelTest, NullPointer) {
 
   testConnection(
       [&](std::shared_ptr<transport::Connection> conn) {
-        std::shared_ptr<Context> ctx = GetParam()->makeContext("server");
+        std::shared_ptr<CpuContext> ctx = GetParam()->makeContext("server");
         auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
 
         // Perform send and wait for completion.
         std::future<std::tuple<Error, TDescriptor>> descriptorFuture;
         std::future<Error> sendFuture;
         std::tie(descriptorFuture, sendFuture) =
-            sendWithFuture(channel, nullptr, 0);
+            sendWithFuture(channel, CpuBuffer{nullptr, 0});
         Error descriptorError;
         TDescriptor descriptor;
         std::tie(descriptorError, descriptor) = descriptorFuture.get();
@@ -339,13 +339,13 @@ TEST_P(ChannelTest, NullPointer) {
         ctx->join();
       },
       [&](std::shared_ptr<transport::Connection> conn) {
-        std::shared_ptr<Context> ctx = GetParam()->makeContext("client");
+        std::shared_ptr<CpuContext> ctx = GetParam()->makeContext("client");
         auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
 
         // Perform recv and wait for completion.
         auto descriptor = peers_->recv(PeerGroup::kClient);
         std::future<Error> recvFuture =
-            recvWithFuture(channel, descriptor, nullptr, 0);
+            recvWithFuture(channel, descriptor, CpuBuffer{nullptr, 0});
         Error recvError = recvFuture.get();
         EXPECT_FALSE(recvError) << recvError.what();
 
@@ -361,7 +361,7 @@ TEST_P(ChannelTest, EmptyTensor) {
 
   testConnection(
       [&](std::shared_ptr<transport::Connection> conn) {
-        std::shared_ptr<Context> ctx = GetParam()->makeContext("server");
+        std::shared_ptr<CpuContext> ctx = GetParam()->makeContext("server");
         auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
 
         // Allocate a non-empty vector so that its .data() pointer is non-null.
@@ -371,7 +371,7 @@ TEST_P(ChannelTest, EmptyTensor) {
         std::future<std::tuple<Error, TDescriptor>> descriptorFuture;
         std::future<Error> sendFuture;
         std::tie(descriptorFuture, sendFuture) =
-            sendWithFuture(channel, data.data(), 0);
+            sendWithFuture(channel, CpuBuffer{data.data(), 0});
         Error descriptorError;
         TDescriptor descriptor;
         std::tie(descriptorError, descriptor) = descriptorFuture.get();
@@ -386,7 +386,7 @@ TEST_P(ChannelTest, EmptyTensor) {
         ctx->join();
       },
       [&](std::shared_ptr<transport::Connection> conn) {
-        std::shared_ptr<Context> ctx = GetParam()->makeContext("client");
+        std::shared_ptr<CpuContext> ctx = GetParam()->makeContext("client");
         auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
 
         // Allocate a non-empty vector so that its .data() pointer is non-null.
@@ -395,7 +395,7 @@ TEST_P(ChannelTest, EmptyTensor) {
         // Perform recv and wait for completion.
         auto descriptor = peers_->recv(PeerGroup::kClient);
         std::future<Error> recvFuture =
-            recvWithFuture(channel, descriptor, data.data(), 0);
+            recvWithFuture(channel, descriptor, CpuBuffer{data.data(), 0});
         Error recvError = recvFuture.get();
         EXPECT_FALSE(recvError) << recvError.what();
 
@@ -411,12 +411,12 @@ TEST_P(ChannelTest, contextIsNotJoined) {
 
   testConnection(
       [&](std::shared_ptr<transport::Connection> conn) {
-        std::shared_ptr<Context> context = GetParam()->makeContext("server");
+        std::shared_ptr<CpuContext> context = GetParam()->makeContext("server");
         peers_->send(PeerGroup::kClient, kReady);
         context->createChannel(std::move(conn), Endpoint::kListen);
       },
       [&](std::shared_ptr<transport::Connection> conn) {
-        std::shared_ptr<Context> context = GetParam()->makeContext("client");
+        std::shared_ptr<CpuContext> context = GetParam()->makeContext("client");
         EXPECT_EQ(kReady, peers_->recv(PeerGroup::kClient));
         context->createChannel(std::move(conn), Endpoint::kConnect);
       });
@@ -441,13 +441,13 @@ TEST_P(ChannelTest, CallbacksAreDeferred) {
 
   testConnection(
       [&](std::shared_ptr<transport::Connection> conn) {
-        std::shared_ptr<Context> ctx = GetParam()->makeContext("server");
+        std::shared_ptr<CpuContext> ctx = GetParam()->makeContext("server");
         auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
 
         // Initialize with sequential values.
         std::vector<uint8_t> data(dataSize);
         std::iota(data.begin(), data.end(), 0);
-        auto buffer = helper_->makeBuffer(dataSize);
+        auto buffer = helper_->makeBuffer(data.size());
         buffer->wrap(data.data());
 
         // Perform send and wait for completion.
@@ -456,8 +456,7 @@ TEST_P(ChannelTest, CallbacksAreDeferred) {
         std::mutex mutex;
         std::unique_lock<std::mutex> callerLock(mutex);
         channel->send(
-            buffer->data(),
-            buffer->size(),
+            CpuBuffer{data.data(), data.size()},
             [&descriptorPromise](const Error& error, TDescriptor descriptor) {
               descriptorPromise.set_value(
                   std::make_tuple(error, std::move(descriptor)));
@@ -482,14 +481,12 @@ TEST_P(ChannelTest, CallbacksAreDeferred) {
         ctx->join();
       },
       [&](std::shared_ptr<transport::Connection> conn) {
-        std::shared_ptr<Context> ctx = GetParam()->makeContext("client");
+        std::shared_ptr<CpuContext> ctx = GetParam()->makeContext("client");
         auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
 
         // Initialize with zeroes.
         std::vector<uint8_t> data(dataSize);
         std::fill(data.begin(), data.end(), 0);
-        auto buffer = helper_->makeBuffer(dataSize);
-        buffer->wrap(data.data());
 
         // Perform recv and wait for completion.
         std::promise<Error> recvPromise;
@@ -498,12 +495,9 @@ TEST_P(ChannelTest, CallbacksAreDeferred) {
         auto descriptor = peers_->recv(PeerGroup::kClient);
         channel->recv(
             descriptor,
-            buffer->data(),
-            buffer->size(),
-            [&recvPromise, &mutex, &buffer, ptr{data.data()}](
-                const Error& error) {
+            CpuBuffer{data.data(), data.size()},
+            [&recvPromise, &mutex](const Error& error) {
               std::unique_lock<std::mutex> calleeLock(mutex);
-              buffer->unwrap(ptr);
               recvPromise.set_value(error);
             });
         callerLock.unlock();

--- a/tensorpipe/test/channel/channel_test.h
+++ b/tensorpipe/test/channel/channel_test.h
@@ -15,7 +15,7 @@
 
 #include <gtest/gtest.h>
 
-#include <tensorpipe/channel/context.h>
+#include <tensorpipe/channel/cpu_context.h>
 #include <tensorpipe/test/peer_group.h>
 #include <tensorpipe/transport/uv/context.h>
 
@@ -62,7 +62,7 @@ class ChannelTestHelper {
   // hierarchies are separated.
   virtual std::string channelName() = 0;
 
-  virtual std::shared_ptr<tensorpipe::channel::Context> makeContext(
+  virtual std::shared_ptr<tensorpipe::channel::CpuContext> makeContext(
       std::string id) = 0;
 
   virtual std::shared_ptr<PeerGroup> makePeerGroup() {
@@ -127,48 +127,38 @@ class ChannelTest : public ::testing::TestWithParam<ChannelTestHelper*> {
           std::tuple<tensorpipe::Error, tensorpipe::channel::TDescriptor>>,
       std::future<tensorpipe::Error>>
   sendWithFuture(
-      std::shared_ptr<tensorpipe::channel::Channel> channel,
-      const void* ptr,
-      size_t length) {
+      std::shared_ptr<tensorpipe::channel::CpuChannel> channel,
+      const tensorpipe::CpuBuffer& buffer) {
     auto descriptorPromise = std::make_shared<
         std::promise<std::tuple<tensorpipe::Error, std::string>>>();
     auto promise = std::make_shared<std::promise<tensorpipe::Error>>();
     auto descriptorFuture = descriptorPromise->get_future();
     auto future = promise->get_future();
-    auto buffer = helper_->makeBuffer(length);
-    buffer->wrap(ptr);
 
     channel->send(
-        buffer->data(),
-        buffer->size(),
+        buffer,
         [descriptorPromise{std::move(descriptorPromise)}](
             const tensorpipe::Error& error, std::string descriptor) {
           descriptorPromise->set_value(
               std::make_tuple(error, std::move(descriptor)));
         },
-        [promise{std::move(promise)}, buffer](const tensorpipe::Error& error) {
+        [promise{std::move(promise)}](const tensorpipe::Error& error) {
           promise->set_value(error);
         });
     return {std::move(descriptorFuture), std::move(future)};
   }
 
   [[nodiscard]] std::future<tensorpipe::Error> recvWithFuture(
-      std::shared_ptr<tensorpipe::channel::Channel> channel,
+      std::shared_ptr<tensorpipe::channel::CpuChannel> channel,
       tensorpipe::channel::TDescriptor descriptor,
-      void* ptr,
-      size_t length) {
+      const tensorpipe::CpuBuffer& buffer) {
     auto promise = std::make_shared<std::promise<tensorpipe::Error>>();
     auto future = promise->get_future();
-    auto buffer = helper_->makeBuffer(length);
-    buffer->wrap(ptr);
 
     channel->recv(
         std::move(descriptor),
-        buffer->data(),
-        buffer->size(),
-        [promise{std::move(promise)}, buffer, ptr](
-            const tensorpipe::Error& error) {
-          buffer->unwrap(ptr);
+        buffer,
+        [promise{std::move(promise)}](const tensorpipe::Error& error) {
           promise->set_value(error);
         });
     return future;

--- a/tensorpipe/test/channel/cma/cma_test.cc
+++ b/tensorpipe/test/channel/cma/cma_test.cc
@@ -17,7 +17,7 @@ class CmaChannelTestHelper : public ChannelTestHelper {
     return "cma";
   }
 
-  std::shared_ptr<tensorpipe::channel::Context> makeContext(
+  std::shared_ptr<tensorpipe::channel::CpuContext> makeContext(
       std::string id) override {
     auto context = std::make_shared<tensorpipe::channel::cma::Context>();
     context->setId(std::move(id));

--- a/tensorpipe/test/channel/cuda_ipc/cuda_ipc_test.cc
+++ b/tensorpipe/test/channel/cuda_ipc/cuda_ipc_test.cc
@@ -59,29 +59,30 @@ class CudaWrapper : public DataWrapper {
   size_t size_;
 };
 
-class CudaChannelTestHelper : public ChannelTestHelper {
- public:
-  std::string channelName() override {
-    return "cuda_ipc";
-  }
+// class CudaChannelTestHelper : public ChannelTestHelper {
+//  public:
+//   std::string channelName() override {
+//     return "cuda_ipc";
+//   }
 
-  std::shared_ptr<tensorpipe::channel::Context> makeContext(
-      std::string id) override {
-    auto context = std::make_shared<tensorpipe::channel::cuda_ipc::Context>();
-    context->setId(std::move(id));
-    return context;
-  }
+//   std::shared_ptr<tensorpipe::channel::Context> makeContext(
+//       std::string id) override {
+//     auto context =
+//     std::make_shared<tensorpipe::channel::cuda_ipc::Context>();
+//     context->setId(std::move(id));
+//     return context;
+//   }
 
-  std::shared_ptr<PeerGroup> makePeerGroup() override {
-    return std::make_shared<ProcessPeerGroup>();
-  }
+//   std::shared_ptr<PeerGroup> makePeerGroup() override {
+//     return std::make_shared<ProcessPeerGroup>();
+//   }
 
-  std::shared_ptr<DataWrapper> makeBuffer(size_t len) override {
-    return std::make_shared<CudaWrapper>(len);
-  }
-};
+//   std::shared_ptr<DataWrapper> makeBuffer(size_t len) override {
+//     return std::make_shared<CudaWrapper>(len);
+//   }
+// };
 
-CudaChannelTestHelper helper;
+// CudaChannelTestHelper helper;
 
 class CudaIpcChannelTest : public ChannelTest {};
 
@@ -95,110 +96,113 @@ using namespace tensorpipe::channel;
       << __TP_EXPAND_OPD(a) << " " << cudaGetErrorName(cudaPeekAtLastError()) \
       << " (" << cudaGetErrorString(cudaPeekAtLastError()) << ")"
 
-TEST_P(CudaIpcChannelTest, ReceiverWaitsForStartEvent) {
-  constexpr int kSize = 1024;
+// TEST_P(CudaIpcChannelTest, ReceiverWaitsForStartEvent) {
+//   constexpr int kSize = 1024;
 
-  testConnection(
-      [&](std::shared_ptr<transport::Connection> conn) {
-        std::shared_ptr<Context> ctx = GetParam()->makeContext("server");
-        auto channel = std::static_pointer_cast<cuda_ipc::Channel>(
-            ctx->createChannel(std::move(conn), Endpoint::kListen));
+//   testConnection(
+//       [&](std::shared_ptr<transport::Connection> conn) {
+//         std::shared_ptr<Context> ctx = GetParam()->makeContext("server");
+//         auto channel = std::static_pointer_cast<cuda_ipc::Channel>(
+//             ctx->createChannel(std::move(conn), Endpoint::kListen));
 
-        TP_CUDA_CHECK(cudaSetDevice(0));
-        cudaStream_t sendStream;
-        TP_CUDA_CHECK(cudaStreamCreate(&sendStream));
-        void* ptr;
-        TP_CUDA_CHECK(cudaMalloc(&ptr, kSize));
+//         TP_CUDA_CHECK(cudaSetDevice(0));
+//         cudaStream_t sendStream;
+//         TP_CUDA_CHECK(cudaStreamCreate(&sendStream));
+//         void* ptr;
+//         TP_CUDA_CHECK(cudaMalloc(&ptr, kSize));
 
-        // Delay sendStream with computations on buffer.
-        slowKernel(ptr, kSize, sendStream);
+//         // Delay sendStream with computations on buffer.
+//         slowKernel(ptr, kSize, sendStream);
 
-        // Set buffer to target value.
-        TP_CUDA_CHECK(cudaMemsetAsync(ptr, 0x42, kSize, sendStream));
+//         // Set buffer to target value.
+//         TP_CUDA_CHECK(cudaMemsetAsync(ptr, 0x42, kSize, sendStream));
 
-        // Perform send and wait for completion.
-        auto descriptorPromise = std::make_shared<
-            std::promise<std::tuple<tensorpipe::Error, std::string>>>();
-        auto sendPromise = std::make_shared<std::promise<tensorpipe::Error>>();
-        auto descriptorFuture = descriptorPromise->get_future();
-        auto sendFuture = sendPromise->get_future();
+//         // Perform send and wait for completion.
+//         auto descriptorPromise = std::make_shared<
+//             std::promise<std::tuple<tensorpipe::Error, std::string>>>();
+//         auto sendPromise =
+//         std::make_shared<std::promise<tensorpipe::Error>>(); auto
+//         descriptorFuture = descriptorPromise->get_future(); auto sendFuture =
+//         sendPromise->get_future();
 
-        channel->send(
-            ptr,
-            kSize,
-            [descriptorPromise{std::move(descriptorPromise)}](
-                const tensorpipe::Error& error, std::string descriptor) {
-              descriptorPromise->set_value(
-                  std::make_tuple(error, std::move(descriptor)));
-            },
-            [sendPromise{std::move(sendPromise)}](
-                const tensorpipe::Error& error) {
-              sendPromise->set_value(error);
-            },
-            sendStream);
+//         channel->send(
+//             ptr,
+//             kSize,
+//             [descriptorPromise{std::move(descriptorPromise)}](
+//                 const tensorpipe::Error& error, std::string descriptor) {
+//               descriptorPromise->set_value(
+//                   std::make_tuple(error, std::move(descriptor)));
+//             },
+//             [sendPromise{std::move(sendPromise)}](
+//                 const tensorpipe::Error& error) {
+//               sendPromise->set_value(error);
+//             },
+//             sendStream);
 
-        Error descriptorError;
-        TDescriptor descriptor;
-        std::tie(descriptorError, descriptor) = descriptorFuture.get();
+//         Error descriptorError;
+//         TDescriptor descriptor;
+//         std::tie(descriptorError, descriptor) = descriptorFuture.get();
 
-        EXPECT_FALSE(descriptorError) << descriptorError.what();
-        peers_->send(PeerGroup::kClient, descriptor);
-        Error sendError = sendFuture.get();
-        EXPECT_FALSE(sendError) << sendError.what();
-        TP_CUDA_CHECK(cudaFree(ptr));
+//         EXPECT_FALSE(descriptorError) << descriptorError.what();
+//         peers_->send(PeerGroup::kClient, descriptor);
+//         Error sendError = sendFuture.get();
+//         EXPECT_FALSE(sendError) << sendError.what();
+//         TP_CUDA_CHECK(cudaFree(ptr));
 
-        peers_->done(PeerGroup::kServer);
-        peers_->join(PeerGroup::kServer);
+//         peers_->done(PeerGroup::kServer);
+//         peers_->join(PeerGroup::kServer);
 
-        ctx->join();
-      },
-      [&](std::shared_ptr<transport::Connection> conn) {
-        std::shared_ptr<Context> ctx = GetParam()->makeContext("client");
-        auto channel = std::static_pointer_cast<cuda_ipc::Channel>(
-            ctx->createChannel(std::move(conn), Endpoint::kConnect));
+//         ctx->join();
+//       },
+//       [&](std::shared_ptr<transport::Connection> conn) {
+//         std::shared_ptr<Context> ctx = GetParam()->makeContext("client");
+//         auto channel = std::static_pointer_cast<cuda_ipc::Channel>(
+//             ctx->createChannel(std::move(conn), Endpoint::kConnect));
 
-        TP_CUDA_CHECK(cudaSetDevice(0));
-        cudaStream_t recvStream;
-        TP_CUDA_CHECK(cudaStreamCreate(&recvStream));
-        void* ptr;
-        TP_CUDA_CHECK(cudaMalloc(&ptr, kSize));
+//         TP_CUDA_CHECK(cudaSetDevice(0));
+//         cudaStream_t recvStream;
+//         TP_CUDA_CHECK(cudaStreamCreate(&recvStream));
+//         void* ptr;
+//         TP_CUDA_CHECK(cudaMalloc(&ptr, kSize));
 
-        auto descriptor = peers_->recv(PeerGroup::kClient);
+//         auto descriptor = peers_->recv(PeerGroup::kClient);
 
-        // Perform recv and wait for completion.
-        auto recvPromise = std::make_shared<std::promise<tensorpipe::Error>>();
-        auto recvFuture = recvPromise->get_future();
+//         // Perform recv and wait for completion.
+//         auto recvPromise =
+//         std::make_shared<std::promise<tensorpipe::Error>>(); auto recvFuture
+//         = recvPromise->get_future();
 
-        channel->recv(
-            std::move(descriptor),
-            ptr,
-            kSize,
-            [recvPromise{std::move(recvPromise)}](
-                const tensorpipe::Error& error) {
-              recvPromise->set_value(error);
-            },
-            recvStream);
+//         channel->recv(
+//             std::move(descriptor),
+//             ptr,
+//             kSize,
+//             [recvPromise{std::move(recvPromise)}](
+//                 const tensorpipe::Error& error) {
+//               recvPromise->set_value(error);
+//             },
+//             recvStream);
 
-        Error recvError = recvFuture.get();
-        EXPECT_FALSE(recvError) << recvError.what();
+//         Error recvError = recvFuture.get();
+//         EXPECT_FALSE(recvError) << recvError.what();
 
-        std::array<uint8_t, kSize> data;
-        TP_CUDA_CHECK(cudaMemcpy(data.data(), ptr, kSize, cudaMemcpyDefault));
-        // Validate contents of vector.
-        for (auto i = 0; i < kSize; i++) {
-          EXPECT_EQ(data[i], 0x42);
-        }
-        TP_CUDA_CHECK(cudaFree(ptr));
+//         std::array<uint8_t, kSize> data;
+//         TP_CUDA_CHECK(cudaMemcpy(data.data(), ptr, kSize,
+//         cudaMemcpyDefault));
+//         // Validate contents of vector.
+//         for (auto i = 0; i < kSize; i++) {
+//           EXPECT_EQ(data[i], 0x42);
+//         }
+//         TP_CUDA_CHECK(cudaFree(ptr));
 
-        peers_->done(PeerGroup::kClient);
-        peers_->join(PeerGroup::kClient);
+//         peers_->done(PeerGroup::kClient);
+//         peers_->join(PeerGroup::kClient);
 
-        ctx->join();
-      });
-}
+//         ctx->join();
+//       });
+// }
 
-INSTANTIATE_TEST_CASE_P(CudaIpc, ChannelTest, ::testing::Values(&helper));
-INSTANTIATE_TEST_CASE_P(
-    CudaIpc,
-    CudaIpcChannelTest,
-    ::testing::Values(&helper));
+// INSTANTIATE_TEST_CASE_P(CudaIpc, ChannelTest, ::testing::Values(&helper));
+// INSTANTIATE_TEST_CASE_P(
+//     CudaIpc,
+//     CudaIpcChannelTest,
+//     ::testing::Values(&helper));

--- a/tensorpipe/test/channel/mpt/mpt_test.cc
+++ b/tensorpipe/test/channel/mpt/mpt_test.cc
@@ -17,7 +17,7 @@ class MptChannelTestHelper : public ChannelTestHelper {
     return "mpt";
   }
 
-  std::shared_ptr<tensorpipe::channel::Context> makeContext(
+  std::shared_ptr<tensorpipe::channel::CpuContext> makeContext(
       std::string id) override {
     std::vector<std::shared_ptr<tensorpipe::transport::Context>> contexts = {
         std::make_shared<tensorpipe::transport::uv::Context>(),

--- a/tensorpipe/test/channel/xth/xth_test.cc
+++ b/tensorpipe/test/channel/xth/xth_test.cc
@@ -17,7 +17,7 @@ class XthChannelTestHelper : public ChannelTestHelper {
     return "xth";
   }
 
-  std::shared_ptr<tensorpipe::channel::Context> makeContext(
+  std::shared_ptr<tensorpipe::channel::CpuContext> makeContext(
       std::string id) override {
     auto context = std::make_shared<tensorpipe::channel::xth::Context>();
     context->setId(std::move(id));

--- a/tensorpipe/test/core/context_test.cc
+++ b/tensorpipe/test/core/context_test.cc
@@ -78,10 +78,10 @@ namespace {
   }
   for (size_t idx = 0; idx < m1.tensors.size(); idx++) {
     EXPECT_TRUE(buffersAreEqual(
-        m1.tensors[idx].data,
-        m1.tensors[idx].length,
-        m2.tensors[idx].data,
-        m2.tensors[idx].length));
+        m1.tensors[idx].buffer.cpu.ptr,
+        m1.tensors[idx].buffer.cpu.length,
+        m2.tensors[idx].buffer.cpu.ptr,
+        m2.tensors[idx].buffer.cpu.length));
   }
   return ::testing::AssertionSuccess();
 }
@@ -99,10 +99,9 @@ Message makeMessage(int numPayloads, int numTensors) {
     message.payloads.push_back(std::move(payload));
   }
   for (int i = 0; i < numTensors; i++) {
-    Message::Tensor tensor;
-    tensor.data =
-        reinterpret_cast<void*>(const_cast<char*>(kTensorData.data()));
-    tensor.length = kTensorData.length();
+    Message::Tensor tensor{CpuBuffer{
+        reinterpret_cast<void*>(const_cast<char*>(kTensorData.data())),
+        kTensorData.length()}};
     message.tensors.push_back(std::move(tensor));
   }
   return message;
@@ -191,8 +190,8 @@ TEST(Context, ClientPingSerial) {
     buffers.push_back(std::move(payloadData));
   }
   for (auto& tensor : message.tensors) {
-    auto tensorData = std::make_unique<uint8_t[]>(tensor.length);
-    tensor.data = tensorData.get();
+    auto tensorData = std::make_unique<uint8_t[]>(tensor.buffer.cpu.length);
+    tensor.buffer.cpu.ptr = tensorData.get();
     buffers.push_back(std::move(tensorData));
   }
 
@@ -260,8 +259,8 @@ TEST(Context, ClientPingInline) {
         buffers.push_back(std::move(payloadData));
       }
       for (auto& tensor : message.tensors) {
-        auto tensorData = std::make_unique<uint8_t[]>(tensor.length);
-        tensor.data = tensorData.get();
+        auto tensorData = std::make_unique<uint8_t[]>(tensor.buffer.cpu.length);
+        tensor.buffer.cpu.ptr = tensorData.get();
         buffers.push_back(std::move(tensorData));
       }
       serverPipe->read(
@@ -360,8 +359,9 @@ TEST(Context, ServerPingPongTwice) {
                 buffers.push_back(std::move(payloadData));
               }
               for (auto& tensor : message.tensors) {
-                auto tensorData = std::make_unique<uint8_t[]>(tensor.length);
-                tensor.data = tensorData.get();
+                auto tensorData =
+                    std::make_unique<uint8_t[]>(tensor.buffer.cpu.length);
+                tensor.buffer.cpu.ptr = tensorData.get();
                 buffers.push_back(std::move(tensorData));
               }
               serverPipe->read(
@@ -404,8 +404,8 @@ TEST(Context, ServerPingPongTwice) {
         buffers.push_back(std::move(payloadData));
       }
       for (auto& tensor : message.tensors) {
-        auto tensorData = std::make_unique<uint8_t[]>(tensor.length);
-        tensor.data = tensorData.get();
+        auto tensorData = std::make_unique<uint8_t[]>(tensor.buffer.cpu.length);
+        tensor.buffer.cpu.ptr = tensorData.get();
         buffers.push_back(std::move(tensorData));
       }
       clientPipe->read(
@@ -458,8 +458,8 @@ static void pipeRead(
       buffers.push_back(std::move(payloadData));
     }
     for (auto& tensor : message.tensors) {
-      auto tensorData = std::make_unique<uint8_t[]>(tensor.length);
-      tensor.data = tensorData.get();
+      auto tensorData = std::make_unique<uint8_t[]>(tensor.buffer.cpu.length);
+      tensor.buffer.cpu.ptr = tensorData.get();
       buffers.push_back(std::move(tensorData));
     }
     pipe->read(


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/tensorpipe/pull/212

+ Introduce buffer.h defining the buffer struct(s). The `CpuBuffer`
struct is always defined, while the `CudaBuffer` struct is defined
only when `TENSORPIPE_SUPPORTS_CUDA` is true.
+ Update all channels to take a `CpuBuffer` or `CudaBuffer` for
`send`/`recv` rather than a raw pointer and a length.
+ Make the base `Channel`/`Context` classes templated on `TBuffer`,
effectively creating two channel hierarchies (one for CPU channels,
one for CUDA channels).
+ Update the Pipe and the generic channel tests to use the new API. So
far, generic channel tests are CPU only, and tests for the CUDA IPC
channel are (temporarily) disabled. A subsequent PR will take care of
refactoring tests so that generic tests work for CUDA channels. An
other PR will add support for CUDA tensors in the Pipe.

Differential Revision: D23598033

Test Plan: Imported from OSS

Reviewed By: lw

Pulled By: beauby

