### PR TITLE
Fix GCC 7 freaking out on a field initializer

### DIFF
--- a/tensorpipe/common/memory.h
+++ b/tensorpipe/common/memory.h
@@ -45,7 +45,7 @@ class MmappedPtr {
 
  private:
   struct Deleter {
-    size_t length = 0;
+    size_t length;
 
     void operator()(void* ptr) {
       int ret = ::munmap(ptr, length);


### PR DESCRIPTION
Not sure why, but GCC 7 complains if we initialize length to zero. We don't really need to do that (length will only be read when the pointer is non-null, and in that case it's explicitly set) so this fixes the issue.