### PR TITLE
Fix CMake build when SHM disabled.

### DIFF
--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -11,6 +11,8 @@ add_library(tensorpipe
   channel/registry.cc
   common/address.cc
   common/error.cc
+  common/fd.cc
+  common/socket.cc
   common/system.cc
   core/context.cc
   core/error.cc
@@ -95,8 +97,6 @@ target_link_libraries(tensorpipe PRIVATE uv::uv)
 
 if(TP_ENABLE_SHM)
   target_sources(tensorpipe PRIVATE
-    common/fd.cc
-    common/socket.cc
     transport/shm/context.cc
     transport/shm/connection.cc
     transport/shm/listener.cc


### PR DESCRIPTION
Now that `Socket`/`Fd` have been promoted to `common/`, their implementation should be compiled regardless of whether TensorPipe is compiled with the SHM transport, otherwise some linkers will complain about `virtual ~Fd()` being an undefined symbol (cf. https://app.circleci.com/pipelines/github/pytorch/pytorch/216673/workflows/8221802b-16fd-42b2-b801-c105ab39ace1/jobs/7624520).
In order for the implementation of `Socket` to build on OSX (which does not offer the `SOCK_NONBLOCK` flag for `socket()`), we have to manually set the socket to non-blocking via `fnctl`.