### PR TITLE
Handle scopes in IPv6 addresses in UV transport

### DIFF
--- a/tensorpipe/test/transport/uv/context_test.cc
+++ b/tensorpipe/test/transport/uv/context_test.cc
@@ -35,8 +35,15 @@ TEST_P(UVTransportContextTest, LookupHostnameAddress) {
 }
 #endif
 
-// Linux-only because OSX uses "lo0" for the loopback interface
+// Interface name conventions change based on platform. Linux uses "lo", OSX
+// uses lo0, Windows uses integers.
 #ifdef __linux__
+#define LOOPBACK_INTERFACE "lo"
+#elif __APPLE__
+#define LOOPBACK_INTERFACE "lo0"
+#endif
+
+#ifdef LOOPBACK_INTERFACE
 TEST_P(UVTransportContextTest, LookupInterfaceAddress) {
   auto context = std::dynamic_pointer_cast<transport::uv::Context>(
       GetParam()->getContext());
@@ -44,7 +51,7 @@ TEST_P(UVTransportContextTest, LookupInterfaceAddress) {
 
   Error error;
   std::string addr;
-  std::tie(error, addr) = context->lookupAddrForIface("lo");
+  std::tie(error, addr) = context->lookupAddrForIface(LOOPBACK_INTERFACE);
   EXPECT_FALSE(error) << error.what();
   EXPECT_NE(addr, "");
 }

--- a/tensorpipe/test/transport/uv/context_test.cc
+++ b/tensorpipe/test/transport/uv/context_test.cc
@@ -20,8 +20,9 @@ UVTransportTestHelper helper;
 
 using namespace tensorpipe;
 
-// Disabled because on CircleCI the macOS machines cannot resolve their hostname
-TEST_P(UVTransportContextTest, DISABLED_LookupHostnameAddress) {
+// Linux-only because OSX machines on CircleCI cannot resolve their hostname
+#ifdef __linux__
+TEST_P(UVTransportContextTest, LookupHostnameAddress) {
   auto context = std::dynamic_pointer_cast<transport::uv::Context>(
       GetParam()->getContext());
   ASSERT_TRUE(context);
@@ -32,9 +33,11 @@ TEST_P(UVTransportContextTest, DISABLED_LookupHostnameAddress) {
   EXPECT_FALSE(error) << error.what();
   EXPECT_NE(addr, "");
 }
+#endif
 
-// Disabled because "lo" isn't a universal convention for the loopback interface
-TEST_P(UVTransportContextTest, DISABLED_LookupInterfaceAddress) {
+// Linux-only because OSX uses "lo0" for the loopback interface
+#ifdef __linux__
+TEST_P(UVTransportContextTest, LookupInterfaceAddress) {
   auto context = std::dynamic_pointer_cast<transport::uv::Context>(
       GetParam()->getContext());
   ASSERT_TRUE(context);
@@ -45,5 +48,6 @@ TEST_P(UVTransportContextTest, DISABLED_LookupInterfaceAddress) {
   EXPECT_FALSE(error) << error.what();
   EXPECT_NE(addr, "");
 }
+#endif
 
 INSTANTIATE_TEST_CASE_P(Uv, UVTransportContextTest, ::testing::Values(&helper));

--- a/tensorpipe/test/transport/uv/sockaddr_test.cc
+++ b/tensorpipe/test/transport/uv/sockaddr_test.cc
@@ -75,6 +75,14 @@ TEST(Sockaddr, Inet6BadPort) {
       uv::Sockaddr::createInetSockAddr("]::1["), std::invalid_argument);
 }
 
+// Interface name conventions change based on platform. Linux uses "lo", OSX
+// uses lo0, Windows uses integers.
+#ifdef __linux__
+#define LOOPBACK_INTERFACE "lo"
+#elif __APPLE__
+#define LOOPBACK_INTERFACE "lo0"
+#endif
+
 TEST(Sockaddr, Inet6) {
   {
     auto sa = uv::Sockaddr::createInetSockAddr("[::1]:5");
@@ -97,15 +105,12 @@ TEST(Sockaddr, Inet6) {
     ASSERT_EQ(sa.str(), "[::1]:0");
   }
 
-// Interface name conventions change based on platform. The tests use "lo" for
-// the loopback interface, which is Linux-specific. OSX uses lo0, Windows uses
-// integers.
-#ifdef __linux__
+#ifdef LOOPBACK_INTERFACE
   {
-    auto sa = uv::Sockaddr::createInetSockAddr("::1%lo");
+    auto sa = uv::Sockaddr::createInetSockAddr("::1%" LOOPBACK_INTERFACE);
     ASSERT_EQ(family(sa), AF_INET6);
     ASSERT_EQ(port(sa), 0);
-    ASSERT_EQ(sa.str(), "[::1%lo]:0");
+    ASSERT_EQ(sa.str(), "[::1%" LOOPBACK_INTERFACE "]:0");
   }
 
   {
@@ -115,9 +120,10 @@ TEST(Sockaddr, Inet6) {
     sa.sin6_port = ntohs(42);
     sa.sin6_flowinfo = 0;
     sa.sin6_addr.s6_addr[15] = 1;
+    // Implicitly assuming that the loopback interface is the first one.
     sa.sin6_scope_id = 1;
     uv::Sockaddr tpSa(reinterpret_cast<sockaddr*>(&sa), sizeof(sa));
-    ASSERT_EQ(tpSa.str(), "[::1%lo]:42");
+    ASSERT_EQ(tpSa.str(), "[::1%" LOOPBACK_INTERFACE "]:42");
   }
 #endif
 }


### PR DESCRIPTION
Contrary to IPv4, IPv6 could give the same link-local address to multiple interfaces. Moreover, while IPv4 uses link-local addresses only when it cannot find a global address, IPv6 always gives a link-local address to each interface. Thus link-local addresses need to be qualified with a sin6_scope_id field in the sockaddr_in6 struct, which in a textual representation becomes a `%<iface_name>` at the end of the IP address.

One issue we have is that the default way of auto-detecting the address in libuv (resolving the hostname and returning the first viable address) may find a link-local address. But then this is converted to string and back, and there we don't support the interface qualifier and thus lose it. When binding to a link-local address without an interface qualifier we get a EINVAL.

We could debate whether we should even support link-local addresses (and I think we will), but Gloo supports them (perhaps by accident, since Gloo doesn't convert to string but uses the sockaddr_in6 struct directly). We are aiming to mimic Gloo's behavior so, for now, let's support the interface qualifier in our string conversions.

The string-to-sockaddr one is easy because libuv has a function that can do it (and that function belongs to a family of functions, so for consistency I'll use them everywhere). The sockaddr-to-string conversion isn't automatically dealt with by libuv (on purpose it seems: https://github.com/libuv/libuv/issues/582) so I'm doing it manually.

I'm also adding tests for this which however can only run on Linux. We had other tests covering similar logic that were disabled, but I'm re-enabling them (also on Linux only) so that we can get at least some signal.

Fixes #224.