### PR TITLE
Set device before calling cudaStreamWaitEvent() in CUDA IPC channel.

### DIFF
--- a/tensorpipe/channel/cuda_ipc/channel.cc
+++ b/tensorpipe/channel/cuda_ipc/channel.cc
@@ -85,7 +85,7 @@ class SendOperation {
 
   void process(const cudaIpcEventHandle_t& stopEvHandle) {
     CudaEvent stopEv(stopEvHandle);
-    stopEv.wait(stream_);
+    stopEv.wait(stream_, cudaDeviceForPointer(ptr_));
   }
 
  private:
@@ -117,7 +117,7 @@ struct RecvOperation {
       const cudaIpcEventHandle_t& startEvHandle,
       const cudaIpcMemHandle_t& remoteHandle) {
     CudaEvent startEv(startEvHandle);
-    startEv.wait(stream_);
+    startEv.wait(stream_, cudaDeviceForPointer(ptr_));
 
     void* remotePtr;
     TP_CUDA_CHECK(cudaIpcOpenMemHandle(

--- a/tensorpipe/common/cuda.h
+++ b/tensorpipe/common/cuda.h
@@ -36,7 +36,8 @@ class CudaEvent {
     TP_CUDA_CHECK(cudaEventRecord(ev_, stream));
   }
 
-  void wait(cudaStream_t stream) {
+  void wait(cudaStream_t stream, int device) {
+    TP_CUDA_CHECK(cudaSetDevice(device));
     TP_CUDA_CHECK(cudaStreamWaitEvent(stream, ev_, 0));
   }
 

--- a/tensorpipe/test/CMakeLists.txt
+++ b/tensorpipe/test/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 add_executable(tensorpipe_test
   test.cc
+  test_environment.cc
   transport/context_test.cc
   transport/connection_test.cc
   transport/uv/uv_test.cc

--- a/tensorpipe/test/channel/channel_test_cuda.cc
+++ b/tensorpipe/test/channel/channel_test_cuda.cc
@@ -10,6 +10,7 @@
 
 #include <tensorpipe/channel/cuda_context.h>
 #include <tensorpipe/test/channel/channel_test.h>
+#include <tensorpipe/test/test_environment.h>
 #include <tensorpipe/test/channel/kernel.cuh>
 
 using namespace tensorpipe;
@@ -120,3 +121,118 @@ class ReceiverWaitsForStartEventTest
 };
 
 CHANNEL_TEST(CudaChannelTestSuite, ReceiverWaitsForStartEvent);
+
+class SendAcrossDevicesTest : public ClientServerChannelTestCase<CudaBuffer> {
+  static constexpr size_t kSize = 1024;
+
+ public:
+  void run(ChannelTestHelper<CudaBuffer>* helper) override {
+    if (TestEnvironment::numCudaDevices() < 2) {
+      GTEST_SKIP() << "Skipping test requiring >=2 CUDA devices.";
+      return;
+    }
+
+    ClientServerChannelTestCase<CudaBuffer>::run(helper);
+  }
+
+ private:
+  void server(std::shared_ptr<transport::Connection> conn) override {
+    std::shared_ptr<CudaContext> ctx = this->helper_->makeContext("server");
+    auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
+
+    // Send happens from device #0.
+    EXPECT_EQ(cudaSuccess, cudaSetDevice(0));
+    cudaStream_t sendStream;
+    EXPECT_EQ(cudaSuccess, cudaStreamCreate(&sendStream));
+    void* ptr;
+    EXPECT_EQ(cudaSuccess, cudaMalloc(&ptr, kSize));
+
+    // Set buffer to target value.
+    EXPECT_EQ(cudaSuccess, cudaMemsetAsync(ptr, 0x42, kSize, sendStream));
+
+    // Perform send and wait for completion.
+    auto descriptorPromise = std::make_shared<
+        std::promise<std::tuple<tensorpipe::Error, std::string>>>();
+    auto sendPromise = std::make_shared<std::promise<tensorpipe::Error>>();
+    auto descriptorFuture = descriptorPromise->get_future();
+    auto sendFuture = sendPromise->get_future();
+
+    channel->send(
+        CudaBuffer{
+            .ptr = ptr,
+            .length = kSize,
+            .stream = sendStream,
+        },
+        [descriptorPromise{std::move(descriptorPromise)}](
+            const tensorpipe::Error& error, std::string descriptor) {
+          descriptorPromise->set_value(
+              std::make_tuple(error, std::move(descriptor)));
+        },
+        [sendPromise{std::move(sendPromise)}](const tensorpipe::Error& error) {
+          sendPromise->set_value(error);
+        });
+
+    Error descriptorError;
+    TDescriptor descriptor;
+    std::tie(descriptorError, descriptor) = descriptorFuture.get();
+
+    EXPECT_FALSE(descriptorError) << descriptorError.what();
+    this->peers_->send(PeerGroup::kClient, descriptor);
+    Error sendError = sendFuture.get();
+    EXPECT_FALSE(sendError) << sendError.what();
+    EXPECT_EQ(cudaSuccess, cudaFree(ptr));
+
+    this->peers_->done(PeerGroup::kServer);
+    this->peers_->join(PeerGroup::kServer);
+
+    ctx->join();
+  }
+
+  void client(std::shared_ptr<transport::Connection> conn) override {
+    std::shared_ptr<CudaContext> ctx = this->helper_->makeContext("client");
+    auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
+
+    // Recv happens on device #1.
+    EXPECT_EQ(cudaSuccess, cudaSetDevice(1));
+    cudaStream_t recvStream;
+    EXPECT_EQ(cudaSuccess, cudaStreamCreate(&recvStream));
+    void* ptr;
+    EXPECT_EQ(cudaSuccess, cudaMalloc(&ptr, kSize));
+
+    auto descriptor = this->peers_->recv(PeerGroup::kClient);
+
+    // Perform recv and wait for completion.
+    auto recvPromise = std::make_shared<std::promise<tensorpipe::Error>>();
+    auto recvFuture = recvPromise->get_future();
+
+    channel->recv(
+        std::move(descriptor),
+        CudaBuffer{
+            .ptr = ptr,
+            .length = kSize,
+            .stream = recvStream,
+        },
+        [recvPromise{std::move(recvPromise)}](const tensorpipe::Error& error) {
+          recvPromise->set_value(error);
+        });
+
+    Error recvError = recvFuture.get();
+    EXPECT_FALSE(recvError) << recvError.what();
+
+    std::array<uint8_t, kSize> data;
+    EXPECT_EQ(
+        cudaSuccess, cudaMemcpy(data.data(), ptr, kSize, cudaMemcpyDefault));
+    // Validate contents of vector.
+    for (auto i = 0; i < kSize; i++) {
+      EXPECT_EQ(data[i], 0x42);
+    }
+    EXPECT_EQ(cudaSuccess, cudaFree(ptr));
+
+    this->peers_->done(PeerGroup::kClient);
+    this->peers_->join(PeerGroup::kClient);
+
+    ctx->join();
+  }
+};
+
+CHANNEL_TEST(CudaChannelTestSuite, SendAcrossDevices);

--- a/tensorpipe/test/test_environment.cc
+++ b/tensorpipe/test/test_environment.cc
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/test/test_environment.h>
+
+#include <tensorpipe/config.h>
+
+#if TENSORPIPE_SUPPORTS_CUDA
+#include <cuda_runtime.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <tensorpipe/common/cuda.h>
+#include <tensorpipe/common/defs.h>
+#include <unistd.h>
+#endif // TENSORPIPE_SUPPORTS_CUDA
+
+int TestEnvironment::numCudaDevices() {
+  static int count = -1;
+  if (count == -1) {
+#if TENSORPIPE_SUPPORTS_CUDA
+    pid_t pid = fork();
+    TP_THROW_SYSTEM_IF(pid < 0, errno) << "Failed to fork";
+    if (pid == 0) {
+      int res;
+      TP_CUDA_CHECK(cudaGetDeviceCount(&res));
+      std::exit(res);
+    } else {
+      int status;
+      TP_THROW_SYSTEM_IF(waitpid(pid, &status, 0) < 0, errno)
+          << "Failed to wait for child process";
+      TP_THROW_ASSERT_IF(!WIFEXITED(status));
+      count = WEXITSTATUS(status);
+    }
+#else // TENSORPIPE_SUPPORTS_CUDA
+    count = 0;
+#endif // TENSORPIPE_SUPPORTS_CUDA
+  }
+
+  return count;
+}

--- a/tensorpipe/test/test_environment.h
+++ b/tensorpipe/test/test_environment.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#if TENSORPIPE_SUPPORTS_CUDA
+#include <tensorpipe/common/cuda.h>
+#endif // TENSORPIPE_SUPPORTS_CUDA
+
+class TestEnvironment {
+ public:
+  static int numCudaDevices();
+};


### PR DESCRIPTION
Summary: A call to cudaStreamWaitEvent() should happen on the device the stream is defined on, according to CUDA docs.

Differential Revision: D24859542

