### PR TITLE
Fix cuda_ipc channel for off set buffers.

### DIFF
--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -61,6 +61,7 @@ target_sources(tensorpipe PRIVATE
 
 if(TP_USE_CUDA)
   find_package(CUDA REQUIRED)
+  # CMake's find_CUDA does not expose a variable for the CUDA driver library.
   target_link_libraries(tensorpipe PUBLIC ${CUDA_LIBRARIES} cuda)
   target_include_directories(tensorpipe PUBLIC ${CUDA_INCLUDE_DIRS})
   set(TENSORPIPE_SUPPORTS_CUDA 1)

--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -61,7 +61,7 @@ target_sources(tensorpipe PRIVATE
 
 if(TP_USE_CUDA)
   find_package(CUDA REQUIRED)
-  target_link_libraries(tensorpipe PUBLIC ${CUDA_LIBRARIES})
+  target_link_libraries(tensorpipe PUBLIC ${CUDA_LIBRARIES} cuda)
   target_include_directories(tensorpipe PUBLIC ${CUDA_INCLUDE_DIRS})
   set(TENSORPIPE_SUPPORTS_CUDA 1)
 

--- a/tensorpipe/channel/cuda_ipc/channel.cc
+++ b/tensorpipe/channel/cuda_ipc/channel.cc
@@ -80,7 +80,6 @@ class SendOperation {
     cudaIpcMemHandle_t handle;
     TP_CUDA_CHECK(cudaIpcGetMemHandle(&handle, const_cast<void*>(ptr_)));
     CUdeviceptr basePtr;
-
     CUresult error = cuMemGetAddressRange(
         &basePtr, nullptr, reinterpret_cast<CUdeviceptr>(ptr_));
     if (error != CUDA_SUCCESS) {

--- a/tensorpipe/channel/cuda_ipc/channel.cc
+++ b/tensorpipe/channel/cuda_ipc/channel.cc
@@ -80,19 +80,8 @@ class SendOperation {
     cudaIpcMemHandle_t handle;
     TP_CUDA_CHECK(cudaIpcGetMemHandle(&handle, const_cast<void*>(ptr_)));
     CUdeviceptr basePtr;
-    CUresult error = cuMemGetAddressRange(
-        &basePtr, nullptr, reinterpret_cast<CUdeviceptr>(ptr_));
-    if (error != CUDA_SUCCESS) {
-      CUresult res;
-      const char* errorName;
-      const char* errorStr;
-      res = cuGetErrorName(error, &errorName);
-      TP_THROW_ASSERT_IF(res != CUDA_SUCCESS);
-      res = cuGetErrorString(error, &errorStr);
-      TP_THROW_ASSERT_IF(res != CUDA_SUCCESS);
-
-      TP_THROW_ASSERT() << "CUDA error (" << errorName << "): " << errorStr;
-    }
+    TP_CUDA_DRIVER_CHECK(cuMemGetAddressRange(
+        &basePtr, nullptr, reinterpret_cast<CUdeviceptr>(ptr_)));
     size_t offset = reinterpret_cast<const uint8_t*>(ptr_) -
         reinterpret_cast<uint8_t*>(basePtr);
     return Descriptor{

--- a/tensorpipe/common/cuda.h
+++ b/tensorpipe/common/cuda.h
@@ -10,6 +10,7 @@
 
 #include <memory>
 
+#include <cuda.h>
 #include <cuda_runtime.h>
 
 #include <tensorpipe/common/defs.h>
@@ -23,8 +24,23 @@
         << cudaGetErrorString(error) << ")";                            \
   } while (false)
 
-namespace tensorpipe {
+#define TP_CUDA_DRIVER_CHECK(a)                                           \
+  do {                                                                    \
+    CUresult error = (a);                                                 \
+    if (error != CUDA_SUCCESS) {                                          \
+      CUresult res;                                                       \
+      const char* errorName;                                              \
+      const char* errorStr;                                               \
+      res = cuGetErrorName(error, &errorName);                            \
+      TP_THROW_ASSERT_IF(res != CUDA_SUCCESS);                            \
+      res = cuGetErrorString(error, &errorStr);                           \
+      TP_THROW_ASSERT_IF(res != CUDA_SUCCESS);                            \
+      TP_THROW_ASSERT() << __TP_EXPAND_OPD(a) << " " << errorName << " (" \
+                        << errorStr << ")";                               \
+    }                                                                     \
+  } while (false)
 
+namespace tensorpipe {
 class CudaError final : public BaseError {
  public:
   explicit CudaError(cudaError_t error) : error_(error) {}


### PR DESCRIPTION
In the cuda_ipc channel, we use CUDA's IPC tools to export a buffer's address from one process to the other.
The `cudaIpcGetMemHandle()` function returns a handle to the _base address of the allocation_ of the given pointer, so we need to get the offset of the buffer from the base address and send that over to the other process.
That is only possible using the CUDA driver API, which means we have to link against it as well.