### PR TITLE
Lazy loading of libcuda.so.

### DIFF
--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -61,8 +61,7 @@ target_sources(tensorpipe PRIVATE
 
 if(TP_USE_CUDA)
   find_package(CUDA REQUIRED)
-  # CMake's find_CUDA does not expose a variable for the CUDA driver library.
-  target_link_libraries(tensorpipe PUBLIC ${CUDA_LIBRARIES} cuda)
+  target_link_libraries(tensorpipe PUBLIC ${CUDA_LIBRARIES})
   target_include_directories(tensorpipe PUBLIC ${CUDA_INCLUDE_DIRS})
   set(TENSORPIPE_SUPPORTS_CUDA 1)
 

--- a/tensorpipe/channel/cuda_ipc/context.h
+++ b/tensorpipe/channel/cuda_ipc/context.h
@@ -21,6 +21,8 @@ class Context : public channel::CudaContext {
  public:
   Context();
 
+  bool isViable() const override;
+
   const std::string& domainDescriptor() const override;
 
   std::shared_ptr<CudaChannel> createChannel(

--- a/tensorpipe/channel/cuda_ipc/context_impl.h
+++ b/tensorpipe/channel/cuda_ipc/context_impl.h
@@ -10,6 +10,7 @@
 
 #include <tensorpipe/channel/cuda_ipc/context.h>
 #include <tensorpipe/common/callback.h>
+#include <tensorpipe/common/cuda_lib.h>
 
 namespace tensorpipe {
 namespace channel {
@@ -20,6 +21,8 @@ class Context::PrivateIface {
   virtual ClosingEmitter& getClosingEmitter() = 0;
 
   virtual ~PrivateIface() = default;
+
+  virtual CudaLib& getCudaLib() = 0;
 };
 
 } // namespace cuda_ipc

--- a/tensorpipe/common/cuda.h
+++ b/tensorpipe/common/cuda.h
@@ -10,7 +10,6 @@
 
 #include <memory>
 
-#include <cuda.h>
 #include <cuda_runtime.h>
 
 #include <tensorpipe/common/defs.h>
@@ -22,22 +21,6 @@
     TP_THROW_ASSERT_IF(cudaSuccess != error)                            \
         << __TP_EXPAND_OPD(a) << " " << cudaGetErrorName(error) << " (" \
         << cudaGetErrorString(error) << ")";                            \
-  } while (false)
-
-#define TP_CUDA_DRIVER_CHECK(a)                                           \
-  do {                                                                    \
-    CUresult error = (a);                                                 \
-    if (error != CUDA_SUCCESS) {                                          \
-      CUresult res;                                                       \
-      const char* errorName;                                              \
-      const char* errorStr;                                               \
-      res = cuGetErrorName(error, &errorName);                            \
-      TP_THROW_ASSERT_IF(res != CUDA_SUCCESS);                            \
-      res = cuGetErrorString(error, &errorStr);                           \
-      TP_THROW_ASSERT_IF(res != CUDA_SUCCESS);                            \
-      TP_THROW_ASSERT() << __TP_EXPAND_OPD(a) << " " << errorName << " (" \
-                        << errorStr << ")";                               \
-    }                                                                     \
   } while (false)
 
 namespace tensorpipe {

--- a/tensorpipe/common/cuda_lib.h
+++ b/tensorpipe/common/cuda_lib.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <cuda.h>
+
+#include <tensorpipe/common/defs.h>
+#include <tensorpipe/common/dl.h>
+
+#define TP_CUDA_DRIVER_CHECK(cuda_lib, a)                                 \
+  do {                                                                    \
+    CUresult error = (a);                                                 \
+    if (error != CUDA_SUCCESS) {                                          \
+      CUresult res;                                                       \
+      const char* errorName;                                              \
+      const char* errorStr;                                               \
+      res = cuda_lib.getErrorName(error, &errorName);                     \
+      TP_THROW_ASSERT_IF(res != CUDA_SUCCESS);                            \
+      res = cuda_lib.getErrorString(error, &errorStr);                    \
+      TP_THROW_ASSERT_IF(res != CUDA_SUCCESS);                            \
+      TP_THROW_ASSERT() << __TP_EXPAND_OPD(a) << " " << errorName << " (" \
+                        << errorStr << ")";                               \
+    }                                                                     \
+  } while (false)
+
+namespace tensorpipe {
+
+// Master list of all symbols we care about from libcuda.
+
+#define TP_FORALL_CUDA_SYMBOLS(_)                               \
+  _(getErrorName, cuGetErrorName, (CUresult, const char**))     \
+  _(getErrorString, cuGetErrorString, (CUresult, const char**)) \
+  _(memGetAddressRange_v2,                                      \
+    cuMemGetAddressRange_v2,                                    \
+    (CUdeviceptr*, size_t*, CUdeviceptr))
+
+// Wrapper for libcuda.
+
+class CudaLib {
+ private:
+  explicit CudaLib(DynamicLibraryHandle dlhandle)
+      : dlhandle_(std::move(dlhandle)) {}
+
+  DynamicLibraryHandle dlhandle_;
+
+#define TP_DECLARE_FIELD(method_name, function_name, args_types) \
+  CUresult(*function_name##_ptr_) args_types = nullptr;
+  TP_FORALL_CUDA_SYMBOLS(TP_DECLARE_FIELD)
+#undef TP_DECLARE_FIELD
+
+ public:
+  CudaLib() = default;
+
+  static std::tuple<Error, CudaLib> create() {
+    Error error;
+    DynamicLibraryHandle dlhandle;
+    // To keep things "neat" and contained, we open in "local" mode (as
+    // opposed to global) so that the cuda symbols can only be resolved
+    // through this handle and are not exposed (a.k.a., "leaked") to other
+    // shared objects.
+    std::tie(error, dlhandle) =
+        createDynamicLibraryHandle("libcuda.so", RTLD_LOCAL | RTLD_LAZY);
+    if (error) {
+      return std::make_tuple(std::move(error), CudaLib());
+    }
+    CudaLib lib(std::move(dlhandle));
+#define TP_LOAD_SYMBOL(method_name, function_name, args_types)        \
+  {                                                                   \
+    void* ptr;                                                        \
+    std::tie(error, ptr) = loadSymbol(lib.dlhandle_, #function_name); \
+    if (error) {                                                      \
+      return std::make_tuple(std::move(error), CudaLib());            \
+    }                                                                 \
+    TP_THROW_ASSERT_IF(ptr == nullptr);                               \
+    lib.function_name##_ptr_ =                                        \
+        reinterpret_cast<decltype(function_name##_ptr_)>(ptr);        \
+  }
+    TP_FORALL_CUDA_SYMBOLS(TP_LOAD_SYMBOL)
+#undef TP_LOAD_SYMBOL
+    return std::make_tuple(Error::kSuccess, std::move(lib));
+  }
+
+#define TP_FORWARD_CALL(method_name, function_name, args_types)  \
+  template <typename... Args>                                    \
+  auto method_name(Args&&... args) const {                       \
+    return (*function_name##_ptr_)(std::forward<Args>(args)...); \
+  }
+  TP_FORALL_CUDA_SYMBOLS(TP_FORWARD_CALL)
+#undef TP_FORWARD_CALL
+
+  CUresult memGetAddressRange(
+      CUdeviceptr* pbase,
+      size_t* psize,
+      CUdeviceptr dptr) {
+    // NOTE: We are forwarding to cuMemGetAddressRange_v2() directly, because
+    // the name cuMemGetAddressRange is #defined to its _v2 variant in cuda.h.
+    // Calling the actual cuMemGetAddressRange() function here would lead to a
+    // CUDA_ERROR_INVALID_CONTEXT.
+    return memGetAddressRange_v2(pbase, psize, dptr);
+  }
+};
+
+#undef TP_FORALL_CUDA_SYMBOLS
+
+} // namespace tensorpipe


### PR DESCRIPTION
Linking against `libcuda.so` is problematic for PyTorch, since a CUDA-enabled build of PyTorch is expected to run on machines without GPUs (on which `libcuda.so`is usually not available, while `libcudart.so` gets packaged as a dependency of PyTorch).

This PR attempts to `dlopen(libcuda.so)` from within the `tensorpipe::channel::cuda_ipc::Context::Impl()` constructor, pretty much the same way the ibv transport does. If successful, the required symbols (mainly `cuMemGetAddressRange()`[1]) are exposed on a `CudaLib` object, available through the `Context::Impl::getCudaLib()` method. If `dlopen()` fails, the context is marked as non-viable.

[1] The actual symbol is `cuMemGetAddressRange_v2`, which is what `cuMemGetAddressRange` actually gets `#define`d to in `cuda.h`, while the latter corresponds to an older version, which leads to a `CUDA_ERROR_INVALID_CONTEXT`. This took a while to figure out.