### PR TITLE
Add CudaDeviceGuard to reset current device to original one

### DIFF
--- a/tensorpipe/common/cuda_loop.cc
+++ b/tensorpipe/common/cuda_loop.cc
@@ -98,7 +98,7 @@ void CudaLoop::addCallback(
 
   auto cudaCallback =
       std::make_unique<CudaCallback>(*this, std::move(callback));
-  TP_CUDA_CHECK(cudaSetDevice(device));
+  CudaDeviceGuard guard(device);
   TP_CUDA_CHECK(cudaStreamAddCallback(
       stream, runCudaCallback, cudaCallback.release(), 0));
 }


### PR DESCRIPTION
Introduce a CudaDeviceGuard class, that changes the current device for
the current thread, and resets it to the original device upon
destruction. This is to avoid modifying the global state behind the
user's back.