### PR TITLE
Add a GPUDirect channel (InfiniBand for CUDA)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
           name: Test
           command: |
             cd build
-            ./tensorpipe/test/tensorpipe_test
+            ./tensorpipe/test/tensorpipe_test --gtest_filter=-*CudaGdr*
       - run:
           name: Install
           command: |

--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -93,6 +93,12 @@ if(TP_USE_CUDA)
       channel/cuda_ipc/context_impl.cc)
     set(TENSORPIPE_HAS_CUDA_IPC_CHANNEL 1)
   endif()
+
+  target_sources(tensorpipe PRIVATE
+    common/ibv.cc
+    channel/cuda_gdr/channel.cc
+    channel/cuda_gdr/context.cc)
+  set(TENSORPIPE_HAS_CUDA_GDR_CHANNEL 1)
 endif()
 
 ## Transports

--- a/tensorpipe/channel/cuda_gdr/channel.cc
+++ b/tensorpipe/channel/cuda_gdr/channel.cc
@@ -1,0 +1,882 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/channel/cuda_gdr/channel.h>
+
+#include <algorithm>
+#include <list>
+
+#include <nop/serializer.h>
+#include <nop/structure.h>
+
+#include <tensorpipe/channel/cuda_gdr/context_impl.h>
+#include <tensorpipe/channel/error.h>
+#include <tensorpipe/channel/helpers.h>
+#include <tensorpipe/common/callback.h>
+#include <tensorpipe/common/cuda.h>
+#include <tensorpipe/common/defs.h>
+#include <tensorpipe/common/error.h>
+#include <tensorpipe/common/error_macros.h>
+#include <tensorpipe/common/ibv.h>
+#include <tensorpipe/transport/connection.h>
+
+namespace tensorpipe {
+namespace channel {
+namespace cuda_gdr {
+
+namespace {
+
+// Replicate the IbvLib::gid struct so we can serialize it with libnop.
+struct NopIbvGid {
+  uint64_t subnetPrefix;
+  uint64_t interfaceId;
+  NOP_STRUCTURE(NopIbvGid, subnetPrefix, interfaceId);
+
+  void fromIbvGid(const IbvLib::gid& globalIdentifier) {
+    subnetPrefix = globalIdentifier.global.subnet_prefix;
+    interfaceId = globalIdentifier.global.interface_id;
+  }
+
+  IbvLib::gid toIbvGid() const {
+    IbvLib::gid globalIdentifier;
+    globalIdentifier.global.subnet_prefix = subnetPrefix;
+    globalIdentifier.global.interface_id = interfaceId;
+    return globalIdentifier;
+  }
+};
+
+// Replicate the IbvSetupInformation struct so we can serialize it with libnop.
+struct NopIbvSetupInformation {
+  // This pointless constructor is needed to work around a bug in GCC 5.5 (and
+  // possibly other versions). It appears to be needed in the nop types that
+  // are used inside std::vectors.
+  NopIbvSetupInformation() {}
+
+  uint32_t localIdentifier;
+  NopIbvGid globalIdentifier;
+  uint32_t queuePairNumber;
+  IbvLib::mtu maximumTransmissionUnit;
+  NOP_STRUCTURE(
+      NopIbvSetupInformation,
+      localIdentifier,
+      globalIdentifier,
+      queuePairNumber,
+      maximumTransmissionUnit);
+
+  void fromIbvSetupInformation(const IbvSetupInformation& setupInfo) {
+    localIdentifier = setupInfo.localIdentifier;
+    globalIdentifier.fromIbvGid(setupInfo.globalIdentifier);
+    queuePairNumber = setupInfo.queuePairNumber;
+    maximumTransmissionUnit = setupInfo.maximumTransmissionUnit;
+  }
+
+  IbvSetupInformation toIbvSetupInformation() const {
+    IbvSetupInformation setupInfo;
+    setupInfo.localIdentifier = localIdentifier;
+    setupInfo.globalIdentifier = globalIdentifier.toIbvGid();
+    setupInfo.queuePairNumber = queuePairNumber;
+    setupInfo.maximumTransmissionUnit = maximumTransmissionUnit;
+    return setupInfo;
+  }
+};
+
+struct SendOperation {
+  // Provide a constructor so we can create the CudaEvent in-place.
+  SendOperation(
+      size_t sequenceNumber,
+      CudaBuffer buffer,
+      TRecvCallback callback,
+      size_t localGpuIdx,
+      size_t localNicIdx)
+      : sequenceNumber(sequenceNumber),
+        buffer(buffer),
+        callback(std::move(callback)),
+        event(localGpuIdx),
+        localNicIdx(localNicIdx) {}
+
+  size_t sequenceNumber;
+  CudaBuffer buffer;
+  TSendCallback callback;
+  CudaEvent event;
+  size_t localNicIdx;
+  size_t remoteNicIdx;
+};
+
+struct RecvOperation {
+  // Provide a constructor so we can create the CudaEvent in-place.
+  RecvOperation(
+      size_t sequenceNumber,
+      CudaBuffer buffer,
+      TSendCallback callback,
+      size_t deviceIdx,
+      size_t localNicIdx,
+      size_t remoteNicIdx)
+      : sequenceNumber(sequenceNumber),
+        buffer(buffer),
+        callback(std::move(callback)),
+        event(deviceIdx),
+        localNicIdx(localNicIdx),
+        remoteNicIdx(remoteNicIdx) {}
+
+  size_t sequenceNumber;
+  CudaBuffer buffer;
+  TSendCallback callback;
+  CudaEvent event;
+  size_t localNicIdx;
+  size_t remoteNicIdx;
+};
+
+// First "round" of handshake.
+struct HandshakeNumNics {
+  size_t numNics;
+  NOP_STRUCTURE(HandshakeNumNics, numNics);
+};
+
+// Second "round" of handshake.
+struct HandshakeSetupInfo {
+  std::vector<std::vector<NopIbvSetupInformation>> setupInfo;
+  NOP_STRUCTURE(HandshakeSetupInfo, setupInfo);
+};
+
+// From sender to receiver (through pipe).
+struct Descriptor {
+  size_t originNicIdx;
+  NOP_STRUCTURE(Descriptor, originNicIdx);
+};
+
+// From receiver to sender (through channel's connection).
+struct ReadyToReceive {
+  size_t destinationNicIdx;
+  NOP_STRUCTURE(ReadyToReceive, destinationNicIdx);
+};
+
+} // namespace
+
+class Channel::Impl : public std::enable_shared_from_this<Channel::Impl> {
+ public:
+  Impl(
+      std::shared_ptr<Context::Impl> context,
+      std::shared_ptr<transport::Connection> connection,
+      std::string id);
+
+  // Called by the channel's constructor.
+  void init();
+
+  void send(
+      CudaBuffer buffer,
+      TDescriptorCallback descriptorCallback,
+      TSendCallback callback);
+
+  void recv(TDescriptor descriptor, CudaBuffer buffer, TRecvCallback callback);
+
+  // Tell the channel what its identifier is.
+  void setId(std::string id);
+
+  void close();
+
+ private:
+  void initFromLoop();
+
+  // Send memory region to peer.
+  void sendFromLoop(
+      CudaBuffer buffer,
+      TDescriptorCallback descriptorCallback,
+      TSendCallback callback);
+
+  // Receive memory region from peer.
+  void recvFromLoop(
+      TDescriptor descriptor,
+      CudaBuffer buffer,
+      TRecvCallback callback);
+
+  void closeFromLoop();
+
+  void setError(Error error);
+
+  void setIdFromLoop(std::string id);
+
+  // Helper function to process transport error.
+  // Shared between read and write callback entry points.
+  void handleError();
+
+  std::shared_ptr<Context::Impl> context_;
+  std::shared_ptr<transport::Connection> connection_;
+  Error error_{Error::kSuccess};
+
+  ClosingReceiver closingReceiver_;
+
+  // Increasing identifier for send operations.
+  uint64_t nextTensorBeingSent_{0};
+
+  // Increasing identifier for recv operations.
+  uint64_t nextTensorBeingReceived_{0};
+
+  // An identifier for the channel, composed of the identifier for the context,
+  // combined with an increasing sequence number. It will only be used for
+  // logging and debugging purposes.
+  std::string id_;
+
+  enum State {
+    INITIALIZING = 1,
+    WAITING_FOR_HANDSHAKE_NUM_NICS,
+    WAITING_FOR_HANDSHAKE_SETUP_INFO,
+    ESTABLISHED,
+  };
+  State state_{INITIALIZING};
+
+  void onReadHandshakeNumNics(const HandshakeNumNics& nopHandshakeNumNics);
+  void onReadHandshakeSetupInfo(
+      const HandshakeSetupInfo& nopHandshakeSetupInfo);
+
+  std::vector<size_t> localGpuToNic_;
+  size_t numLocalNics_;
+  size_t numRemoteNics_;
+
+  std::vector<std::vector<IbvQueuePair>> queuePairs_;
+
+  std::list<SendOperation> sendOps_;
+  std::list<RecvOperation> recvOps_;
+
+  uint32_t numSendsInFlight_{0};
+  uint32_t numRecvsInFlight_{0};
+
+  void processSendOperationFromLoop(SendOperation& op);
+  void onReadReadyToReceive(
+      SendOperation& op,
+      const ReadyToReceive& readyToReceive);
+  void onSendEventReady(SendOperation& op);
+  void onIbvSendDone(SendOperation& op);
+  void eraseOp(const SendOperation& op);
+
+  void processRecvOperationFromLoop(RecvOperation& op);
+  void onRecvEventReady(RecvOperation& op);
+  void onIbvRecvDone(RecvOperation& op);
+  void eraseOp(const RecvOperation& op);
+
+  void tryCleanup();
+  void cleanup();
+
+  LazyCallbackWrapper<Impl> lazyCallbackWrapper_{*this, *this->context_};
+  EagerCallbackWrapper<Impl> eagerCallbackWrapper_{*this, *this->context_};
+
+  // For some odd reason it seems we need to use a qualified name here...
+  template <typename T>
+  friend class tensorpipe::LazyCallbackWrapper;
+  template <typename T>
+  friend class tensorpipe::EagerCallbackWrapper;
+};
+
+Channel::Channel(
+    ConstructorToken /* unused */,
+    std::shared_ptr<Context::Impl> context,
+    std::shared_ptr<transport::Connection> connection,
+    std::string id)
+    : impl_(std::make_shared<Impl>(
+          std::move(context),
+          std::move(connection),
+          std::move(id))) {
+  impl_->init();
+}
+
+Channel::Impl::Impl(
+    std::shared_ptr<Context::Impl> context,
+    std::shared_ptr<transport::Connection> connection,
+    std::string id)
+    : context_(std::move(context)),
+      connection_(std::move(connection)),
+      closingReceiver_(context_, context_->getClosingEmitter()),
+      id_(std::move(id)) {}
+
+void Channel::Impl::init() {
+  context_->deferToLoop(
+      [impl{this->shared_from_this()}]() { impl->initFromLoop(); });
+}
+
+void Channel::Impl::initFromLoop() {
+  TP_DCHECK(context_->inLoop());
+  TP_DCHECK_EQ(state_, INITIALIZING);
+  TP_DCHECK(!error_);
+
+  closingReceiver_.activate(*this);
+
+  localGpuToNic_ = context_->getGpuToNicMapping();
+  numLocalNics_ =
+      *std::max_element(localGpuToNic_.begin(), localGpuToNic_.end()) + 1;
+
+  auto nopHolderOut = std::make_shared<NopHolder<HandshakeNumNics>>();
+  HandshakeNumNics& nopHandshakeNumNics = nopHolderOut->getObject();
+  nopHandshakeNumNics.numNics = numLocalNics_;
+  TP_VLOG(6) << "Channel " << id_
+             << " is writing nop object (handshake num NICs)";
+  connection_->write(
+      *nopHolderOut, lazyCallbackWrapper_([nopHolderOut](Impl& impl) {
+        TP_VLOG(6) << "Channel " << impl.id_
+                   << " done writing nop object (handshake num NICs)";
+      }));
+
+  auto nopHolderIn = std::make_shared<NopHolder<HandshakeNumNics>>();
+  TP_VLOG(6) << "Channel " << id_
+             << " is reading nop object (handshake num NICs)";
+  connection_->read(
+      *nopHolderIn, lazyCallbackWrapper_([nopHolderIn](Impl& impl) {
+        TP_VLOG(6) << "Channel " << impl.id_
+                   << " done reading nop object (handshake num NICs)";
+        impl.onReadHandshakeNumNics(nopHolderIn->getObject());
+      }));
+
+  state_ = WAITING_FOR_HANDSHAKE_NUM_NICS;
+}
+
+void Channel::Impl::onReadHandshakeNumNics(
+    const HandshakeNumNics& nopHandshakeNumNics) {
+  TP_DCHECK(context_->inLoop());
+  TP_DCHECK_EQ(state_, WAITING_FOR_HANDSHAKE_NUM_NICS);
+  TP_DCHECK(!error_);
+
+  numRemoteNics_ = nopHandshakeNumNics.numNics;
+
+  std::vector<std::vector<NopIbvSetupInformation>> allSetupInfo;
+
+  queuePairs_.resize(numLocalNics_);
+  allSetupInfo.resize(numLocalNics_);
+  for (size_t localNicIdx = 0; localNicIdx < numLocalNics_; localNicIdx++) {
+    queuePairs_[localNicIdx].resize(numRemoteNics_);
+    allSetupInfo[localNicIdx].resize(numRemoteNics_);
+    IbvNic& localNic = context_->getIbvNic(localNicIdx);
+    for (size_t remoteNicIdx = 0; remoteNicIdx < numRemoteNics_;
+         remoteNicIdx++) {
+      IbvLib::qp_init_attr initAttr;
+      std::memset(&initAttr, 0, sizeof(initAttr));
+      initAttr.qp_type = IbvLib::QPT_RC;
+      initAttr.send_cq = localNic.getIbvCq().get();
+      initAttr.recv_cq = localNic.getIbvCq().get();
+      initAttr.cap.max_send_wr = kNumSends;
+      initAttr.cap.max_send_sge = 1;
+      initAttr.cap.max_recv_wr = kNumRecvs;
+      initAttr.cap.max_recv_sge = 1;
+      initAttr.sq_sig_all = 1;
+      IbvQueuePair qp = createIbvQueuePair(
+          context_->getIbvLib(), localNic.getIbvPd(), initAttr);
+
+      transitionIbvQueuePairToInit(
+          context_->getIbvLib(), qp, localNic.getIbvAddress());
+
+      IbvSetupInformation setupInfo =
+          makeIbvSetupInformation(localNic.getIbvAddress(), qp);
+
+      queuePairs_[localNicIdx][remoteNicIdx] = std::move(qp);
+      allSetupInfo[localNicIdx][remoteNicIdx].fromIbvSetupInformation(
+          setupInfo);
+    }
+  }
+
+  auto nopHolderOut = std::make_shared<NopHolder<HandshakeSetupInfo>>();
+  HandshakeSetupInfo& nopHandshakeSetupInfo = nopHolderOut->getObject();
+  nopHandshakeSetupInfo.setupInfo = std::move(allSetupInfo);
+  TP_VLOG(6) << "Channel " << id_ << " is writing nop object (handshake two)";
+  connection_->write(
+      *nopHolderOut, lazyCallbackWrapper_([nopHolderOut](Impl& impl) {
+        TP_VLOG(6) << "Channel " << impl.id_
+                   << " done writing nop object (handshake two)";
+      }));
+
+  auto nopHolderIn = std::make_shared<NopHolder<HandshakeSetupInfo>>();
+  TP_VLOG(6) << "Channel " << id_ << " is reading nop object (handshake two)";
+  connection_->read(
+      *nopHolderIn, lazyCallbackWrapper_([nopHolderIn](Impl& impl) {
+        TP_VLOG(6) << "Channel " << impl.id_
+                   << " done reading nop object (handshake two)";
+        impl.onReadHandshakeSetupInfo(nopHolderIn->getObject());
+      }));
+
+  state_ = WAITING_FOR_HANDSHAKE_SETUP_INFO;
+}
+
+void Channel::Impl::onReadHandshakeSetupInfo(
+    const HandshakeSetupInfo& nopHandshakeSetupInfo) {
+  TP_DCHECK(context_->inLoop());
+  TP_DCHECK_EQ(state_, WAITING_FOR_HANDSHAKE_SETUP_INFO);
+  TP_DCHECK(!error_);
+
+  const std::vector<std::vector<NopIbvSetupInformation>>& remoteSetupInfo =
+      nopHandshakeSetupInfo.setupInfo;
+
+  TP_DCHECK_EQ(remoteSetupInfo.size(), numRemoteNics_);
+  for (size_t remoteNicIdx = 0; remoteNicIdx < numRemoteNics_; remoteNicIdx++) {
+    TP_DCHECK_EQ(remoteSetupInfo[remoteNicIdx].size(), numLocalNics_);
+    for (size_t localNicIdx = 0; localNicIdx < numLocalNics_; localNicIdx++) {
+      IbvNic& localNic = context_->getIbvNic(localNicIdx);
+      IbvSetupInformation setupInfo =
+          remoteSetupInfo[remoteNicIdx][localNicIdx].toIbvSetupInformation();
+
+      transitionIbvQueuePairToReadyToReceive(
+          context_->getIbvLib(),
+          queuePairs_[localNicIdx][remoteNicIdx],
+          localNic.getIbvAddress(),
+          setupInfo);
+      transitionIbvQueuePairToReadyToSend(
+          context_->getIbvLib(), queuePairs_[localNicIdx][remoteNicIdx]);
+    }
+  }
+
+  state_ = ESTABLISHED;
+  for (auto& sendOp : sendOps_) {
+    processSendOperationFromLoop(sendOp);
+  }
+  for (auto& recvOp : recvOps_) {
+    processRecvOperationFromLoop(recvOp);
+  }
+}
+
+void Channel::send(
+    CudaBuffer buffer,
+    TDescriptorCallback descriptorCallback,
+    TSendCallback callback) {
+  impl_->send(buffer, std::move(descriptorCallback), std::move(callback));
+}
+
+void Channel::Impl::send(
+    CudaBuffer buffer,
+    TDescriptorCallback descriptorCallback,
+    TSendCallback callback) {
+  context_->deferToLoop([impl{this->shared_from_this()},
+                         buffer,
+                         descriptorCallback{std::move(descriptorCallback)},
+                         callback{std::move(callback)}]() mutable {
+    impl->sendFromLoop(
+        buffer, std::move(descriptorCallback), std::move(callback));
+  });
+}
+
+void Channel::Impl::sendFromLoop(
+    CudaBuffer buffer,
+    TDescriptorCallback descriptorCallback,
+    TSendCallback callback) {
+  TP_DCHECK(context_->inLoop());
+
+  const uint64_t sequenceNumber = nextTensorBeingSent_++;
+  TP_VLOG(4) << "Channel " << id_ << " received a send request (#"
+             << sequenceNumber << ")";
+
+  descriptorCallback = [this,
+                        sequenceNumber,
+                        descriptorCallback{std::move(descriptorCallback)}](
+                           const Error& error, TDescriptor descriptor) {
+    // There is no requirement for the channel to invoke callbacks in order.
+    TP_VLOG(4) << "Channel " << id_ << " is calling a descriptor callback (#"
+               << sequenceNumber << ")";
+    descriptorCallback(error, std::move(descriptor));
+    TP_VLOG(4) << "Channel " << id_ << " done calling a descriptor callback (#"
+               << sequenceNumber << ")";
+  };
+
+  callback = [this, sequenceNumber, callback{std::move(callback)}](
+                 const Error& error) {
+    TP_VLOG(4) << "Channel " << id_ << " is calling a send callback (#"
+               << sequenceNumber << ")";
+    callback(error);
+    TP_VLOG(4) << "Channel " << id_ << " done calling a send callback (#"
+               << sequenceNumber << ")";
+  };
+
+  if (error_ || buffer.length == 0) {
+    descriptorCallback(error_, std::string());
+    callback(error_);
+    return;
+  }
+
+  size_t localGpuIdx = cudaDeviceForPointer(buffer.ptr);
+  size_t localNicIdx = context_->getGpuToNicMapping()[localGpuIdx];
+
+  sendOps_.emplace_back(
+      sequenceNumber, buffer, std::move(callback), localGpuIdx, localNicIdx);
+  SendOperation& op = sendOps_.back();
+  op.event.record(op.buffer.stream);
+  if (state_ == ESTABLISHED) {
+    processSendOperationFromLoop(op);
+  }
+
+  NopHolder<Descriptor> nopHolder;
+  Descriptor& nopDescriptor = nopHolder.getObject();
+  nopDescriptor.originNicIdx = localNicIdx;
+  descriptorCallback(Error::kSuccess, saveDescriptor(nopHolder));
+}
+
+void Channel::Impl::processSendOperationFromLoop(SendOperation& op) {
+  TP_DCHECK(context_->inLoop());
+  TP_DCHECK_EQ(state_, ESTABLISHED);
+  TP_DCHECK(!error_);
+
+  auto nopHolderIn = std::make_shared<NopHolder<ReadyToReceive>>();
+  TP_VLOG(6) << "Channel " << id_ << " is reading ready-to-receive (#"
+             << op.sequenceNumber << ")";
+  connection_->read(
+      *nopHolderIn, eagerCallbackWrapper_([&op, nopHolderIn](Impl& impl) {
+        TP_VLOG(6) << "Channel " << impl.id_
+                   << " done reading ready-to-receive (# " << op.sequenceNumber
+                   << ")";
+        impl.onReadReadyToReceive(op, nopHolderIn->getObject());
+      }));
+}
+
+void Channel::Impl::onReadReadyToReceive(
+    SendOperation& op,
+    const ReadyToReceive& readyToReceive) {
+  TP_DCHECK(context_->inLoop());
+  TP_DCHECK_EQ(state_, ESTABLISHED);
+
+  if (error_) {
+    op.callback(error_);
+    eraseOp(op);
+    return;
+  }
+
+  op.remoteNicIdx = readyToReceive.destinationNicIdx;
+
+  TP_VLOG(6) << "Channel " << id_ << " is waiting for CUDA event to send (#"
+             << op.sequenceNumber << ")";
+  // FIXME There is no guarantee that two CUDA events will complete in the order
+  // in which we add them (if they are on different streams). This could mean
+  // that a later tensor might overtake an earlier one and issue its ibverbs
+  // send earlier, thus messing up the order and causing a mismatch with the
+  // receiver. The proper fix for this is a state machine, like the pipe has.
+  context_->waitForCudaEvent(op.event, eagerCallbackWrapper_([&op](Impl& impl) {
+                               TP_VLOG(6)
+                                   << "Channel " << impl.id_
+                                   << " done waiting for CUDA event to send (# "
+                                   << op.sequenceNumber << ")";
+                               impl.onSendEventReady(op);
+                             }));
+}
+
+void Channel::Impl::onSendEventReady(SendOperation& op) {
+  TP_DCHECK(context_->inLoop());
+  TP_DCHECK_EQ(state_, ESTABLISHED);
+
+  if (error_) {
+    op.callback(error_);
+    eraseOp(op);
+    return;
+  }
+
+  IbvNic& localNic = context_->getIbvNic(op.localNicIdx);
+  IbvQueuePair& qp = queuePairs_[op.localNicIdx][op.remoteNicIdx];
+
+  // This could be VEEERY slow the first time we encounter the buffer, but the
+  // result will be cached and subsequent calls will be much faster.
+  IbvMemoryRegion& mr = localNic.registerMemory(op.buffer);
+
+  IbvLib::sge list;
+  list.addr = reinterpret_cast<uint64_t>(op.buffer.ptr);
+  list.length = op.buffer.length;
+  list.lkey = mr->lkey;
+
+  IbvLib::send_wr wr;
+  std::memset(&wr, 0, sizeof(wr));
+  wr.sg_list = &list;
+  wr.num_sge = 1;
+  wr.opcode = IbvLib::WR_SEND;
+
+  TP_VLOG(6) << "Channel " << id_ << " is sending tensor (#"
+             << op.sequenceNumber << ") on QP " << qp->qp_num;
+  localNic.postSend(qp, wr, eagerCallbackWrapper_([&op](Impl& impl) {
+                      TP_VLOG(6) << "Channel " << impl.id_
+                                 << " done sending tensor (# "
+                                 << op.sequenceNumber << ")";
+                      impl.onIbvSendDone(op);
+                    }));
+  numSendsInFlight_++;
+}
+
+void Channel::Impl::onIbvSendDone(SendOperation& op) {
+  TP_DCHECK(context_->inLoop());
+  TP_DCHECK_EQ(state_, ESTABLISHED);
+
+  numSendsInFlight_--;
+
+  op.callback(error_);
+  eraseOp(op);
+
+  tryCleanup();
+}
+
+void Channel::Impl::eraseOp(const SendOperation& op) {
+  auto iter = std::find_if(
+      sendOps_.begin(), sendOps_.end(), [&](const SendOperation& otherOp) {
+        return otherOp.sequenceNumber == op.sequenceNumber;
+      });
+  TP_DCHECK(iter != sendOps_.end());
+  sendOps_.erase(iter);
+}
+
+// Receive memory region from peer.
+void Channel::recv(
+    TDescriptor descriptor,
+    CudaBuffer buffer,
+    TRecvCallback callback) {
+  impl_->recv(std::move(descriptor), buffer, std::move(callback));
+}
+
+void Channel::Impl::recv(
+    TDescriptor descriptor,
+    CudaBuffer buffer,
+    TRecvCallback callback) {
+  context_->deferToLoop([impl{this->shared_from_this()},
+                         descriptor{std::move(descriptor)},
+                         buffer,
+                         callback{std::move(callback)}]() mutable {
+    impl->recvFromLoop(std::move(descriptor), buffer, std::move(callback));
+  });
+}
+
+void Channel::Impl::recvFromLoop(
+    TDescriptor descriptor,
+    CudaBuffer buffer,
+    TRecvCallback callback) {
+  TP_DCHECK(context_->inLoop());
+
+  const uint64_t sequenceNumber = nextTensorBeingReceived_++;
+  TP_VLOG(4) << "Channel " << id_ << " received a recv request (#"
+             << sequenceNumber << ")";
+
+  callback = [this, sequenceNumber, callback{std::move(callback)}](
+                 const Error& error) {
+    TP_VLOG(4) << "Channel " << id_ << " is calling a recv callback (#"
+               << sequenceNumber << ")";
+    callback(error);
+    TP_VLOG(4) << "Channel " << id_ << " done calling a recv callback (#"
+               << sequenceNumber << ")";
+  };
+
+  if (error_ || buffer.length == 0) {
+    callback(error_);
+    return;
+  }
+
+  size_t localGpuIdx = cudaDeviceForPointer(buffer.ptr);
+  size_t localNicIdx = context_->getGpuToNicMapping()[localGpuIdx];
+
+  NopHolder<Descriptor> nopHolder;
+  loadDescriptor(nopHolder, descriptor);
+  Descriptor& nopDescriptor = nopHolder.getObject();
+  size_t remoteNicIdx = nopDescriptor.originNicIdx;
+
+  recvOps_.emplace_back(
+      sequenceNumber,
+      buffer,
+      std::move(callback),
+      localGpuIdx,
+      localNicIdx,
+      remoteNicIdx);
+  RecvOperation& op = recvOps_.back();
+  op.event.record(op.buffer.stream);
+  if (state_ == ESTABLISHED) {
+    processRecvOperationFromLoop(op);
+  }
+}
+
+void Channel::Impl::processRecvOperationFromLoop(RecvOperation& op) {
+  TP_DCHECK(context_->inLoop());
+  TP_DCHECK_EQ(state_, ESTABLISHED);
+  TP_DCHECK(!error_);
+
+  TP_VLOG(6) << "Channel " << id_ << " is waiting for CUDA event to recv (#"
+             << op.sequenceNumber << ")";
+  // FIXME There is no guarantee that two CUDA events will complete in the order
+  // in which we add them (if they are on different streams). This could mean
+  // that a later tensor might overtake an earlier one and issue its ibverbs
+  // recv earlier, thus messing up the order and causing a mismatch with the
+  // sender. The proper fix for this is a state machine, like the pipe has.
+  context_->waitForCudaEvent(op.event, eagerCallbackWrapper_([&op](Impl& impl) {
+                               TP_VLOG(6)
+                                   << "Channel " << impl.id_
+                                   << " done waiting for CUDA event to recv (# "
+                                   << op.sequenceNumber << ")";
+                               impl.onRecvEventReady(op);
+                             }));
+}
+
+void Channel::Impl::onRecvEventReady(RecvOperation& op) {
+  TP_DCHECK(context_->inLoop());
+  TP_DCHECK_EQ(state_, ESTABLISHED);
+
+  if (error_) {
+    op.callback(error_);
+    eraseOp(op);
+    return;
+  }
+
+  IbvNic& localNic = context_->getIbvNic(op.localNicIdx);
+  IbvQueuePair& qp = queuePairs_[op.localNicIdx][op.remoteNicIdx];
+
+  // This could be VEEERY slow the first time we encounter the buffer, but the
+  // result will be cached and subsequent calls will be much faster.
+  IbvMemoryRegion& mr = localNic.registerMemory(op.buffer);
+
+  IbvLib::sge list;
+  list.addr = reinterpret_cast<uint64_t>(op.buffer.ptr);
+  list.length = op.buffer.length;
+  list.lkey = mr->lkey;
+
+  IbvLib::recv_wr wr;
+  std::memset(&wr, 0, sizeof(wr));
+  wr.sg_list = &list;
+  wr.num_sge = 1;
+
+  TP_VLOG(6) << "Channel " << id_ << " is receiving tensor (#"
+             << op.sequenceNumber << ") on QP " << qp->qp_num;
+  localNic.postRecv(qp, wr, eagerCallbackWrapper_([&op](Impl& impl) {
+                      TP_VLOG(6) << "Channel " << impl.id_
+                                 << " done receiving tensor (# "
+                                 << op.sequenceNumber << ")";
+                      impl.onIbvRecvDone(op);
+                    }));
+  numRecvsInFlight_++;
+
+  auto nopHolderOut = std::make_shared<NopHolder<ReadyToReceive>>();
+  ReadyToReceive& nopReadyToReceive = nopHolderOut->getObject();
+  nopReadyToReceive.destinationNicIdx = op.localNicIdx;
+  TP_VLOG(6) << "Channel " << id_ << " is writing ready-to-receive (#"
+             << op.sequenceNumber << ")";
+  connection_->write(
+      *nopHolderOut,
+      lazyCallbackWrapper_(
+          [sequenceNumber{op.sequenceNumber}, nopHolderOut](Impl& impl) {
+            TP_VLOG(6) << "Channel " << impl.id_
+                       << " done writing ready-to-receive (#" << sequenceNumber
+                       << ")";
+          }));
+}
+
+void Channel::Impl::onIbvRecvDone(RecvOperation& op) {
+  TP_DCHECK(context_->inLoop());
+  TP_DCHECK_EQ(state_, ESTABLISHED);
+
+  numRecvsInFlight_--;
+
+  op.callback(error_);
+  eraseOp(op);
+
+  tryCleanup();
+}
+
+void Channel::Impl::eraseOp(const RecvOperation& op) {
+  auto iter = std::find_if(
+      recvOps_.begin(), recvOps_.end(), [&](const RecvOperation& otherOp) {
+        return otherOp.sequenceNumber == op.sequenceNumber;
+      });
+  TP_DCHECK(iter != recvOps_.end());
+  recvOps_.erase(iter);
+}
+
+void Channel::setId(std::string id) {
+  impl_->setId(std::move(id));
+}
+
+void Channel::Impl::setId(std::string id) {
+  context_->deferToLoop(
+      [impl{this->shared_from_this()}, id{std::move(id)}]() mutable {
+        impl->setIdFromLoop(std::move(id));
+      });
+}
+
+void Channel::Impl::setIdFromLoop(std::string id) {
+  TP_DCHECK(context_->inLoop());
+  TP_VLOG(4) << "Channel " << id_ << " was renamed to " << id;
+  id_ = std::move(id);
+}
+
+void Channel::close() {
+  impl_->close();
+}
+
+Channel::~Channel() {
+  close();
+}
+
+void Channel::Impl::close() {
+  context_->deferToLoop(
+      [impl{this->shared_from_this()}]() { impl->closeFromLoop(); });
+}
+
+void Channel::Impl::closeFromLoop() {
+  TP_DCHECK(context_->inLoop());
+  TP_VLOG(4) << "Channel " << id_ << " is closing";
+  setError(TP_CREATE_ERROR(ChannelClosedError));
+}
+
+void Channel::Impl::setError(Error error) {
+  // Don't overwrite an error that's already set.
+  if (error_ || !error) {
+    return;
+  }
+
+  error_ = std::move(error);
+
+  handleError();
+}
+
+void Channel::Impl::handleError() {
+  TP_DCHECK(context_->inLoop());
+  TP_VLOG(5) << "Channel " << id_ << " is handling error " << error_.what();
+
+  if (state_ != ESTABLISHED) {
+    // No operation has yet started being served, hence they can all be safely
+    // aborted.
+    for (auto& sendOp : sendOps_) {
+      sendOp.callback(error_);
+    }
+    sendOps_.clear();
+    for (auto& recvOp : recvOps_) {
+      recvOp.callback(error_);
+    }
+    recvOps_.clear();
+  } else {
+    // All operations are currently waiting for some lower-level operation to
+    // return. We will take care of calling the callback and easing each of them
+    // once their current operation terminates.
+  }
+
+  for (size_t localNicIdx = 0; localNicIdx < numLocalNics_; localNicIdx++) {
+    for (size_t remoteNicIdx = 0; remoteNicIdx < numRemoteNics_;
+         remoteNicIdx++) {
+      transitionIbvQueuePairToError(
+          context_->getIbvLib(), queuePairs_[localNicIdx][remoteNicIdx]);
+    }
+  }
+
+  tryCleanup();
+
+  connection_->close();
+}
+
+void Channel::Impl::tryCleanup() {
+  TP_DCHECK(context_->inLoop());
+
+  if (error_) {
+    if (numSendsInFlight_ == 0 && numRecvsInFlight_ == 0) {
+      cleanup();
+    } else {
+      TP_VLOG(9) << "Connection " << id_
+                 << " cannot proceed to cleanup because it has "
+                 << numSendsInFlight_ << " pending send requests and "
+                 << numRecvsInFlight_ << " pending recv requests";
+    }
+  }
+}
+
+void Channel::Impl::cleanup() {
+  TP_DCHECK(context_->inLoop());
+  TP_VLOG(8) << "Connection " << id_ << " is cleaning up";
+
+  queuePairs_.clear();
+}
+
+} // namespace cuda_gdr
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/cuda_gdr/channel.h
+++ b/tensorpipe/channel/cuda_gdr/channel.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <tensorpipe/channel/channel.h>
+#include <tensorpipe/channel/cuda_context.h>
+#include <tensorpipe/channel/cuda_gdr/context.h>
+
+namespace tensorpipe {
+namespace channel {
+namespace cuda_gdr {
+
+class Channel : public channel::CudaChannel {
+  // Use the passkey idiom to allow make_shared to call what should be a private
+  // constructor. See https://abseil.io/tips/134 for more information.
+  struct ConstructorToken {};
+
+ public:
+  Channel(
+      ConstructorToken token,
+      std::shared_ptr<Context::Impl> context,
+      std::shared_ptr<transport::Connection> connection,
+      std::string id);
+
+  // Send memory region to peer.
+  void send(
+      CudaBuffer buffer,
+      TDescriptorCallback descriptorCallback,
+      TSendCallback callback) override;
+
+  // Receive memory region from peer.
+  void recv(TDescriptor descriptor, CudaBuffer buffer, TRecvCallback callback)
+      override;
+
+  // Tell the channel what its identifier is.
+  void setId(std::string id) override;
+
+  void close() override;
+
+  ~Channel() override;
+
+ private:
+  class Impl;
+
+  // Using a shared_ptr allows us to detach the lifetime of the implementation
+  // from the public object's one and perform the destruction asynchronously.
+  std::shared_ptr<Impl> impl_;
+
+  // Allow context to access constructor token.
+  friend class Context;
+};
+
+} // namespace cuda_gdr
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/cuda_gdr/constants.h
+++ b/tensorpipe/channel/cuda_gdr/constants.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace tensorpipe {
+namespace channel {
+namespace cuda_gdr {
+
+namespace {
+
+// We should probably allow these to be user-configured. But, for now, we'll set
+// them to the lowest value they can have, the rationale being that this way
+// they will always be valid.
+constexpr uint8_t kPortNum = 1;
+constexpr uint8_t kGlobalIdentifierIndex = 0;
+
+// FIXME Instead of hardcoding the next three values, we could use
+// ibv_query_device to obtain max_cqe, max_qp_wr and max_srq_wr and deduce from
+// them the maximum allowed values for these parameters.
+
+constexpr uint32_t kNumRecvs = 1024;
+constexpr uint32_t kNumSends = 1024;
+
+// How many elements the completion queue should be able to hold. These elements
+// will be either the completed receive requests of the SRQ, or the completed
+// send requests from a connection's queue pair. We can bound the former value
+// but not the latter, so we try to add some margin.
+constexpr int kCompletionQueueSize = kNumRecvs + kNumSends;
+
+// How many work completions to poll from the completion queue at each reactor
+// iteration.
+constexpr int kNumPolledWorkCompletions = 32;
+
+} // namespace
+
+} // namespace cuda_gdr
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/cuda_gdr/context.cc
+++ b/tensorpipe/channel/cuda_gdr/context.cc
@@ -1,0 +1,406 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/channel/cuda_gdr/context.h>
+
+#include <unistd.h>
+
+#include <cstring>
+#include <limits>
+#include <unordered_set>
+
+#include <tensorpipe/channel/cuda_gdr/channel.h>
+#include <tensorpipe/channel/cuda_gdr/context_impl.h>
+#include <tensorpipe/channel/cuda_gdr/error.h>
+#include <tensorpipe/channel/error.h>
+#include <tensorpipe/channel/helpers.h>
+#include <tensorpipe/common/busy_polling_loop.h>
+#include <tensorpipe/common/callback.h>
+#include <tensorpipe/common/defs.h>
+#include <tensorpipe/common/error_macros.h>
+#include <tensorpipe/common/optional.h>
+#include <tensorpipe/common/queue.h>
+#include <tensorpipe/common/system.h>
+
+namespace tensorpipe {
+namespace channel {
+namespace cuda_gdr {
+
+namespace {
+
+// NOTE: This is an incomplete implementation of C++17's `std::apply`.
+// It's intended to only work for methods of IbvNic.
+template <class TMethod, class TArgsTuple, std::size_t... I>
+auto applyFuncImpl(
+    IbvNic& subject,
+    TMethod&& method,
+    TArgsTuple&& args,
+    std::index_sequence<I...> /* unused */) {
+  return ((subject).*(method))(std::get<I>(std::forward<TArgsTuple>(args))...);
+}
+
+template <class TMethod, class TArgsTuple>
+auto applyFunc(IbvNic& subject, TMethod&& method, TArgsTuple&& args) {
+  return applyFuncImpl(
+      subject,
+      std::forward<TMethod>(method),
+      std::forward<TArgsTuple>(args),
+      std::make_index_sequence<
+          std::tuple_size<std::remove_reference_t<TArgsTuple>>::value>{});
+}
+
+} // namespace
+
+IbvNic::IbvNic(
+    std::string id,
+    std::string name,
+    IbvLib::device& device,
+    IbvLib& ibvLib)
+    : id_(std::move(id)), name_(std::move(name)), ibvLib_(ibvLib) {
+  ctx_ = createIbvContext(ibvLib_, device);
+  pd_ = createIbvProtectionDomain(ibvLib_, ctx_);
+  cq_ = createIbvCompletionQueue(
+      ibvLib_,
+      ctx_,
+      kCompletionQueueSize,
+      /*cq_context=*/nullptr,
+      /*channel=*/nullptr,
+      /*comp_vector=*/0);
+  addr_ = makeIbvAddress(ibvLib_, ctx_, kPortNum, kGlobalIdentifierIndex);
+}
+
+bool IbvNic::pollOnce() {
+  std::array<IbvLib::wc, kNumPolledWorkCompletions> wcs;
+  auto rv = ibvLib_.poll_cq(cq_.get(), wcs.size(), wcs.data());
+
+  if (rv == 0) {
+    return false;
+  }
+  TP_THROW_SYSTEM_IF(rv < 0, errno);
+
+  int numSends = 0;
+  int numRecvs = 0;
+  for (int wcIdx = 0; wcIdx < rv; wcIdx++) {
+    IbvLib::wc& wc = wcs[wcIdx];
+
+    TP_VLOG(6) << "Channel context " << id_ << " got work completion on device "
+               << name_ << " for request " << wc.wr_id << " for QP "
+               << wc.qp_num << " with status "
+               << ibvLib_.wc_status_str(wc.status) << " and opcode "
+               << ibvWorkCompletionOpcodeToStr(wc.opcode)
+               << " (byte length: " << wc.byte_len << ")";
+
+    auto iter = requestsInFlight_.find(wc.wr_id);
+    TP_THROW_ASSERT_IF(iter == requestsInFlight_.end())
+        << "Got work completion with unknown ID " << wc.wr_id;
+
+    std::function<void(const Error&)> cb = std::move(iter->second);
+    requestsInFlight_.erase(iter);
+
+    if (wc.status != IbvLib::WC_SUCCESS) {
+      cb(TP_CREATE_ERROR(IbvError, ibvLib_.wc_status_str(wc.status)));
+    } else {
+      cb(Error::kSuccess);
+    }
+
+    switch (wc.opcode) {
+      case IbvLib::WC_RECV:
+        numRecvs++;
+        break;
+      case IbvLib::WC_SEND:
+        numSends++;
+        break;
+      default:
+        TP_THROW_ASSERT() << "Unknown opcode: " << wc.opcode;
+    }
+  }
+
+  numAvailableSendSlots_ += numSends;
+  while (!sendsWaitingForSlots_.empty() && numAvailableSendSlots_ > 0) {
+    applyFunc(
+        *this, &IbvNic::postSend, std::move(sendsWaitingForSlots_.front()));
+    sendsWaitingForSlots_.pop_front();
+  }
+
+  numAvailableRecvSlots_ += numRecvs;
+  while (!recvsWaitingForSlots_.empty() && numAvailableRecvSlots_ > 0) {
+    applyFunc(
+        *this, &IbvNic::postRecv, std::move(recvsWaitingForSlots_.front()));
+    recvsWaitingForSlots_.pop_front();
+  }
+
+  return true;
+}
+
+void IbvNic::postSend(
+    IbvQueuePair& qp,
+    IbvLib::send_wr& wr,
+    std::function<void(const Error&)> cb) {
+  TP_DCHECK_EQ(wr.wr_id, 0);
+  if (numAvailableSendSlots_ > 0) {
+    wr.wr_id = nextRequestId_++;
+    IbvLib::send_wr* badWr = nullptr;
+    TP_VLOG(6) << "Channel context " << id_ << " posting send on device "
+               << name_ << " for QP " << qp->qp_num;
+    TP_CHECK_IBV_INT(ibvLib_.post_send(qp.get(), &wr, &badWr));
+    TP_THROW_ASSERT_IF(badWr != nullptr);
+    numAvailableSendSlots_--;
+    requestsInFlight_.emplace(wr.wr_id, std::move(cb));
+  } else {
+    TP_VLOG(6) << "Channel context " << id_ << " queueing up send on device "
+               << name_ << " for QP " << qp->qp_num;
+    sendsWaitingForSlots_.emplace_back(qp, wr, std::move(cb));
+  }
+}
+
+void IbvNic::postRecv(
+    IbvQueuePair& qp,
+    IbvLib::recv_wr& wr,
+    std::function<void(const Error&)> cb) {
+  TP_DCHECK_EQ(wr.wr_id, 0);
+  if (numAvailableRecvSlots_ > 0) {
+    wr.wr_id = nextRequestId_++;
+    IbvLib::recv_wr* badWr = nullptr;
+    TP_VLOG(6) << "Channel context " << id_ << " posting recv on device "
+               << name_ << " for QP " << qp->qp_num;
+    TP_CHECK_IBV_INT(ibvLib_.post_recv(qp.get(), &wr, &badWr));
+    TP_THROW_ASSERT_IF(badWr != nullptr);
+    numAvailableRecvSlots_--;
+    requestsInFlight_.emplace(wr.wr_id, std::move(cb));
+  } else {
+    TP_VLOG(6) << "Channel context " << id_ << " queueing up recv on device "
+               << name_ << " for QP " << qp->qp_num;
+    recvsWaitingForSlots_.emplace_back(qp, wr, std::move(cb));
+  }
+}
+
+IbvMemoryRegion& IbvNic::registerMemory(CudaBuffer buffer) {
+  auto key = std::make_tuple(
+      reinterpret_cast<uintptr_t>(buffer.ptr),
+      static_cast<size_t>(buffer.length));
+  auto iter = memoryRegions_.find(key);
+  if (iter != memoryRegions_.end()) {
+    return iter->second;
+  }
+  std::tie(iter, std::ignore) = memoryRegions_.emplace(
+      key,
+      createIbvMemoryRegion(
+          ibvLib_, pd_, buffer.ptr, buffer.length, IbvLib::ACCESS_LOCAL_WRITE));
+  return iter->second;
+}
+
+bool IbvNic::readyToClose() const {
+  return requestsInFlight_.empty();
+}
+
+void IbvNic::setId(std::string id) {
+  id_ = std::move(id);
+}
+
+Context::Context(std::vector<std::string> gpuIdxToNicName)
+    : impl_(std::make_shared<Context::Impl>(std::move(gpuIdxToNicName))) {}
+
+Context::Impl::Impl(std::vector<std::string> gpuIdxToNicName)
+    : domainDescriptor_("*") {
+  Error error;
+  std::tie(error, ibvLib_) = IbvLib::create();
+  // FIXME Instead of throwing away the error and setting a bool, we should have
+  // a way to set the reactor in an error state, and use that for viability.
+  if (error) {
+    TP_VLOG(6) << "Channel context " << id_
+               << " couldn't open libibverbs: " << error.what();
+    return;
+  }
+  foundIbvLib_ = true;
+
+  // TODO Check whether the NVIDIA memory peering kernel module is available.
+  // And maybe even allocate and register some CUDA memory to ensure it works.
+
+  std::unordered_set<std::string> nicNames;
+  for (const auto& nicName : gpuIdxToNicName) {
+    nicNames.insert(nicName);
+  }
+
+  IbvDeviceList deviceList(getIbvLib());
+  std::unordered_map<std::string, size_t> nicNameToNicIdx;
+  // The device index is among all available devices, the NIC index is among the
+  // ones we will use.
+  size_t nicIdx = 0;
+  for (size_t deviceIdx = 0; deviceIdx < deviceList.size(); deviceIdx++) {
+    IbvLib::device& device = deviceList[deviceIdx];
+    std::string deviceName(TP_CHECK_IBV_PTR(ibvLib_.get_device_name(&device)));
+    auto iter = nicNames.find(deviceName);
+    if (iter != nicNames.end()) {
+      TP_VLOG(5) << "Channel context " << id_ << " is using InfiniBand NIC "
+                 << deviceName << " as device #" << nicIdx;
+      ibvNics_.emplace_back(id_, *iter, device, ibvLib_);
+      nicNameToNicIdx[*iter] = nicIdx;
+      nicIdx++;
+      nicNames.erase(iter);
+    }
+  }
+  TP_THROW_ASSERT_IF(!nicNames.empty())
+      << "Couldn't find all the devices I was supposed to use";
+
+  for (size_t gpuIdx = 0; gpuIdx < gpuIdxToNicName.size(); gpuIdx++) {
+    gpuToNic_.push_back(nicNameToNicIdx[gpuIdxToNicName[gpuIdx]]);
+  }
+
+  startThread("TP_CUDA_GDR_loop");
+}
+
+const std::vector<size_t>& Context::Impl::getGpuToNicMapping() {
+  return gpuToNic_;
+}
+
+IbvLib& Context::Impl::getIbvLib() {
+  return ibvLib_;
+}
+
+IbvNic& Context::Impl::getIbvNic(size_t nicIdx) {
+  TP_DCHECK_LT(nicIdx, ibvNics_.size());
+  return ibvNics_[nicIdx];
+}
+
+bool Context::Impl::pollOnce() {
+  for (IbvNic& ibvNic : ibvNics_) {
+    if (ibvNic.pollOnce()) {
+      return true;
+    }
+  }
+  return pollCudaOnce();
+}
+
+bool Context::Impl::pollCudaOnce() {
+  bool any = false;
+  for (auto iter = pendingCudaEvents_.begin(); iter != pendingCudaEvents_.end();
+       iter++) {
+    const CudaEvent& event = std::get<0>(*iter);
+
+    if (event.query()) {
+      std::function<void(const Error&)> cb = std::move(std::get<1>(*iter));
+      cb(Error::kSuccess);
+      iter = pendingCudaEvents_.erase(iter);
+      any = true;
+    }
+  }
+  return any;
+}
+
+void Context::Impl::waitForCudaEvent(
+    const CudaEvent& event,
+    std::function<void(const Error&)> cb) {
+  deferToLoop([this, &event, cb{std::move(cb)}]() mutable {
+    waitForCudaEventFromLoop(event, std::move(cb));
+  });
+}
+
+void Context::Impl::waitForCudaEventFromLoop(
+    const CudaEvent& event,
+    std::function<void(const Error&)> cb) {
+  TP_DCHECK(inLoop());
+
+  pendingCudaEvents_.emplace_back(event, std::move(cb));
+}
+
+bool Context::Impl::readyToClose() {
+  for (const IbvNic& ibvNic : ibvNics_) {
+    if (!ibvNic.readyToClose()) {
+      return false;
+    }
+  }
+  return pendingCudaEvents_.empty();
+}
+
+void Context::close() {
+  impl_->close();
+}
+
+void Context::Impl::close() {
+  if (!closed_.exchange(true)) {
+    TP_VLOG(4) << "Channel context " << id_ << " is closing";
+
+    closingEmitter_.close();
+
+    stopBusyPolling();
+
+    TP_VLOG(4) << "Channel context " << id_ << " done closing";
+  }
+}
+
+void Context::join() {
+  impl_->join();
+}
+
+void Context::Impl::join() {
+  close();
+
+  if (!joined_.exchange(true)) {
+    TP_VLOG(4) << "Channel context " << id_ << " is joining";
+
+    joinThread();
+
+    // FIXME It would be nice if this could be done by the thread itself just
+    // before it returns, rather than by the user.
+    ibvNics_.clear();
+
+    TP_VLOG(4) << "Channel context " << id_ << " done joining";
+  }
+}
+
+Context::~Context() {
+  join();
+}
+
+void Context::setId(std::string id) {
+  impl_->setId(std::move(id));
+}
+
+void Context::Impl::setId(std::string id) {
+  TP_VLOG(4) << "Channel context " << id_ << " was renamed to " << id;
+  id_ = std::move(id);
+  for (IbvNic& ibvNic : ibvNics_) {
+    ibvNic.setId(id_);
+  }
+}
+
+ClosingEmitter& Context::Impl::getClosingEmitter() {
+  return closingEmitter_;
+}
+
+const std::string& Context::domainDescriptor() const {
+  return impl_->domainDescriptor();
+}
+
+const std::string& Context::Impl::domainDescriptor() const {
+  return domainDescriptor_;
+}
+
+std::shared_ptr<channel::CudaChannel> Context::createChannel(
+    std::shared_ptr<transport::Connection> connection,
+    Endpoint endpoint) {
+  return impl_->createChannel(std::move(connection), endpoint);
+}
+
+std::shared_ptr<channel::CudaChannel> Context::Impl::createChannel(
+    std::shared_ptr<transport::Connection> connection,
+    Endpoint /* unused */) {
+  TP_THROW_ASSERT_IF(joined_);
+  std::string channelId = id_ + ".c" + std::to_string(channelCounter_++);
+  TP_VLOG(4) << "Channel context " << id_ << " is opening channel "
+             << channelId;
+  return std::make_shared<Channel>(
+      Channel::ConstructorToken(),
+      shared_from_this(),
+      std::move(connection),
+      std::move(channelId));
+}
+
+} // namespace cuda_gdr
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/cuda_gdr/context.h
+++ b/tensorpipe/channel/cuda_gdr/context.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+
+#include <tensorpipe/channel/cuda_context.h>
+#include <tensorpipe/common/callback.h>
+#include <tensorpipe/common/error.h>
+
+namespace tensorpipe {
+namespace channel {
+namespace cuda_gdr {
+
+class Context : public channel::CudaContext {
+ public:
+  explicit Context(std::vector<std::string> gpuIdxToNicName);
+
+  const std::string& domainDescriptor() const override;
+
+  std::shared_ptr<CudaChannel> createChannel(
+      std::shared_ptr<transport::Connection> connection,
+      Endpoint endpoint) override;
+
+  void setId(std::string id) override;
+
+  void close() override;
+
+  void join() override;
+
+  ~Context() override;
+
+ private:
+  class Impl;
+
+  // The implementation is managed by a shared_ptr because each child object
+  // will also hold a shared_ptr to it (downcast as a shared_ptr to the private
+  // interface). However, its lifetime is tied to the one of this public object,
+  // since when the latter is destroyed the implementation is closed and joined.
+  std::shared_ptr<Impl> impl_;
+
+  // Allow channel to see the private interface.
+  friend class Channel;
+};
+
+} // namespace cuda_gdr
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/cuda_gdr/context_impl.h
+++ b/tensorpipe/channel/cuda_gdr/context_impl.h
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <list>
+#include <map>
+
+#include <tensorpipe/channel/cuda_gdr/constants.h>
+#include <tensorpipe/channel/cuda_gdr/context.h>
+#include <tensorpipe/common/busy_polling_loop.h>
+#include <tensorpipe/common/callback.h>
+#include <tensorpipe/common/cuda.h>
+#include <tensorpipe/common/ibv.h>
+
+namespace tensorpipe {
+namespace channel {
+namespace cuda_gdr {
+
+class IbvNic {
+ public:
+  IbvNic(
+      std::string id,
+      std::string name,
+      IbvLib::device& device,
+      IbvLib& ibvLib);
+
+  IbvProtectionDomain& getIbvPd() {
+    return pd_;
+  }
+
+  IbvCompletionQueue& getIbvCq() {
+    return cq_;
+  }
+
+  const IbvAddress& getIbvAddress() {
+    return addr_;
+  }
+
+  void postSend(
+      IbvQueuePair& qp,
+      IbvLib::send_wr& wr,
+      std::function<void(const Error&)> cb);
+
+  void postRecv(
+      IbvQueuePair& qp,
+      IbvLib::recv_wr& wr,
+      std::function<void(const Error&)> cb);
+
+  bool pollOnce();
+
+  IbvMemoryRegion& registerMemory(CudaBuffer buffer);
+
+  bool readyToClose() const;
+
+  void setId(std::string id);
+
+ private:
+  // The ID of the context, for use in verbose logging.
+  std::string id_{"N/A"};
+  // The name of the InfiniBand device.
+  std::string name_;
+
+  IbvLib& ibvLib_;
+  IbvContext ctx_;
+  IbvProtectionDomain pd_;
+  IbvCompletionQueue cq_;
+  IbvAddress addr_;
+
+  size_t numAvailableRecvSlots_ = kNumRecvs;
+  std::deque<std::tuple<
+      IbvQueuePair&,
+      IbvLib::recv_wr&,
+      std::function<void(const Error&)>>>
+      recvsWaitingForSlots_;
+
+  size_t numAvailableSendSlots_ = kNumSends;
+  std::deque<std::tuple<
+      IbvQueuePair&,
+      IbvLib::send_wr&,
+      std::function<void(const Error&)>>>
+      sendsWaitingForSlots_;
+
+  // We need one common map for both send and recv requests because in principle
+  // we cannot access the opcode of a failed operation, meaning we couldn't
+  // match it to its callback. However, we could group them by QP number or, in
+  // fact, we could have the QP store these requests and we just wake it up when
+  // a completion occurs.
+  std::unordered_map<uint64_t, std::function<void(const Error&)>>
+      requestsInFlight_;
+  uint64_t nextRequestId_ = 0;
+
+  std::map<std::tuple<uintptr_t, size_t>, IbvMemoryRegion> memoryRegions_;
+};
+
+class Context::Impl : public BusyPollingLoop,
+                      public std::enable_shared_from_this<Context::Impl> {
+ public:
+  explicit Impl(std::vector<std::string> gpuIdxToNicName);
+
+  const std::string& domainDescriptor() const;
+
+  std::shared_ptr<channel::CudaChannel> createChannel(
+      std::shared_ptr<transport::Connection> connection,
+      Endpoint endpoint);
+
+  void setId(std::string id);
+
+  ClosingEmitter& getClosingEmitter();
+
+  const std::vector<size_t>& getGpuToNicMapping();
+
+  IbvLib& getIbvLib();
+
+  IbvNic& getIbvNic(size_t nicIdx);
+
+  void waitForCudaEvent(
+      const CudaEvent& event,
+      std::function<void(const Error&)> cb);
+
+  void close();
+
+  void join();
+
+ protected:
+  // Implement BusyPollingLoop hooks.
+  bool pollOnce() override;
+  bool readyToClose() override;
+
+ private:
+  std::string domainDescriptor_;
+  std::atomic<bool> closed_{false};
+  std::atomic<bool> joined_{false};
+  ClosingEmitter closingEmitter_;
+
+  // An identifier for the context, composed of the identifier for the context,
+  // combined with the channel's name. It will only be used for logging and
+  // debugging purposes.
+  std::string id_{"N/A"};
+
+  // Sequence numbers for the channels created by this context, used to create
+  // their identifiers based off this context's identifier. They will only be
+  // used for logging and debugging.
+  std::atomic<uint64_t> channelCounter_{0};
+
+  // InfiniBand stuff
+  bool foundIbvLib_{false};
+  IbvLib ibvLib_;
+  std::vector<IbvNic> ibvNics_;
+
+  std::vector<size_t> gpuToNic_;
+
+  std::list<std::tuple<const CudaEvent&, std::function<void(const Error&)>>>
+      pendingCudaEvents_;
+
+  bool pollCudaOnce();
+
+  void waitForCudaEventFromLoop(
+      const CudaEvent& event,
+      std::function<void(const Error&)> cb);
+};
+
+} // namespace cuda_gdr
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/cuda_gdr/error.h
+++ b/tensorpipe/channel/cuda_gdr/error.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+
+#include <tensorpipe/channel/error.h>
+
+namespace tensorpipe {
+namespace channel {
+namespace cuda_gdr {
+
+class IbvError final : public BaseError {
+ public:
+  explicit IbvError(std::string error) : error_(error) {}
+
+  std::string what() const override {
+    return error_;
+  }
+
+ private:
+  std::string error_;
+};
+
+} // namespace cuda_gdr
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/test/CMakeLists.txt
+++ b/tensorpipe/test/CMakeLists.txt
@@ -76,6 +76,10 @@ if(TP_USE_CUDA)
       channel/cuda_ipc/cuda_ipc_test.cc
       )
   endif()
+
+  target_sources(tensorpipe_test PRIVATE
+    channel/cuda_gdr/cuda_gdr_test.cc
+    )
 endif()
 
 

--- a/tensorpipe/test/channel/cuda_gdr/cuda_gdr_test.cc
+++ b/tensorpipe/test/channel/cuda_gdr/cuda_gdr_test.cc
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <numeric>
+
+#include <tensorpipe/channel/cuda_gdr/context.h>
+#include <tensorpipe/test/channel/channel_test.h>
+
+namespace {
+
+class CudaGdrChannelTestHelper
+    : public ChannelTestHelper<tensorpipe::CudaBuffer> {
+ public:
+  std::shared_ptr<tensorpipe::channel::CudaContext> makeContext(
+      std::string id) override {
+    std::vector<std::string> gpuToNicName = {"mlx5_0", "mlx5_0"};
+    auto context =
+        std::make_shared<tensorpipe::channel::cuda_gdr::Context>(gpuToNicName);
+    context->setId(std::move(id));
+    return context;
+  }
+
+  std::shared_ptr<PeerGroup> makePeerGroup() override {
+    return std::make_shared<ProcessPeerGroup>();
+  }
+};
+
+CudaGdrChannelTestHelper helper;
+
+} // namespace
+
+INSTANTIATE_TEST_CASE_P(
+    CudaGdr,
+    CudaChannelTestSuite,
+    ::testing::Values(&helper));


### PR DESCRIPTION
Summary:
This is a re-land of D25355282 (https://github.com/pytorch/tensorpipe/commit/d146c1f134f9be3e6ca44214277ea467e254fb00).

The CUDA_GDR channel works as follows:
- Upon creation of the context, we receive from the user a mapping from GPU indices to NIC device names. (In a later diff I'll make this automatic, but to keep this diff simple I'm asking the user to provide it). The context then opens each of the given devices.
- Upon creation of a channel, the two ends first exchange how many NICs they each have, and then open a queue pair between all pairs of NICs (in order to support transfers between any pair of GPUs). This could be done lazily, but for simplicity for now it's eager.
- When sending a tensor, we in fact only store the GPU index in the descriptor, and then wait for the receiver to tell us they are ready to receive.
- On the receiver side, we wait for the target tensor to be ready (by adding an event to the stream and having a callback fire when the event becomes ready). At that point, we register the tensor with libibverbs (so the NIC can write to it directly). Then we send an ibverbs recv request, and notify the sender that we're ready to receive.
- When the sender receives this notification, they go through similar steps: they also wait on the event to become ready and they also register the memory with libibverbs. Then they post an ibverbs send request.
- When these requests finish, each side calls the user callback.

For both the ibverbs polling and the wait on the CUDA events we have a busy polling loop in the context. We could consider replacing this busy polling loop with an implementation that goes to sleep (e.g., like we do in CudaLoop), but we'd need to check that it doesn't impact latency. A simpler change we could do is put the loop to sleep while there's no active requests. (Channels have this luxury, as all their transfers are solicited, whereas transports cannot do it... :( )

Also worth noting that registering CUDA memory with libibverbs can be a veeery slow operation, and doing so in the critical path is a bad idea. My "excuse" is that we cache these registrations, and avoid re-doing them if we already have them. Crossing our fingers that users will typically send the same tensors (or the same storage) over and over, this should amortize the cost pretty well over time.

Differential Revision: D25637880

