### PR TITLE
Improve caching of memory registrations in CUDA GDR

### DIFF
--- a/tensorpipe/common/cuda_lib.h
+++ b/tensorpipe/common/cuda_lib.h
@@ -40,7 +40,10 @@ namespace tensorpipe {
   _(getErrorString, cuGetErrorString, (CUresult, const char**)) \
   _(memGetAddressRange_v2,                                      \
     cuMemGetAddressRange_v2,                                    \
-    (CUdeviceptr*, size_t*, CUdeviceptr))
+    (CUdeviceptr*, size_t*, CUdeviceptr))                       \
+  _(pointerGetAttribute,                                        \
+    cuPointerGetAttribute,                                      \
+    (void*, CUpointer_attribute, CUdeviceptr))
 
 // Wrapper for libcuda.
 


### PR DESCRIPTION
Summary:
- Register the entire allocation (i.e., the whole region returned by cudaAlloc) even when we're only given a pointer to an internal offset. This should play well with PyTorch's caching allocator which pools small tensors together into a single alloc.
- Index the cache with the buffer ID, which will change if a buffer is de- and re-allocated, preventing us from possibly reusing the wrong registration.

Differential Revision: D25783171

