### PR TITLE
Reuse pinned buffers in cuda_basic.

### DIFF
--- a/tensorpipe/channel/cuda_basic/channel_impl.h
+++ b/tensorpipe/channel/cuda_basic/channel_impl.h
@@ -31,7 +31,8 @@ class ChannelImpl final
       std::shared_ptr<ContextImpl> context,
       std::string id,
       std::shared_ptr<CpuChannel> cpuChannel,
-      CudaLoop& cudaLoop);
+      CudaLoop& cudaLoop,
+      CudaPinnedBufferAllocator& cudaPinnedBufferAllocator);
 
  protected:
   // Implement the entry points called by ChannelImplBoilerplate.
@@ -52,17 +53,18 @@ class ChannelImpl final
  private:
   const std::shared_ptr<CpuChannel> cpuChannel_;
   CudaLoop& cudaLoop_;
+  CudaPinnedBufferAllocator& cudaPinnedBufferAllocator_;
 
   void onTempBufferReadyForSend(
       uint64_t sequenceNumber,
       CudaBuffer buffer,
-      CudaPinnedBuffer tmpBuffer,
+      std::shared_ptr<uint8_t> tmpBuffer,
       TDescriptorCallback descriptorCallback);
 
   void onCpuChannelRecv(
       uint64_t sequenceNumber,
       CudaBuffer buffer,
-      CudaPinnedBuffer tmpBuffer,
+      std::shared_ptr<uint8_t> tmpBuffer,
       TRecvCallback callback);
 };
 

--- a/tensorpipe/channel/cuda_basic/context_impl.cc
+++ b/tensorpipe/channel/cuda_basic/context_impl.cc
@@ -27,7 +27,8 @@ std::shared_ptr<CudaChannel> ContextImpl::createChannel(
     std::shared_ptr<transport::Connection> connection,
     Endpoint endpoint) {
   auto cpuChannel = cpuContext_->createChannel(std::move(connection), endpoint);
-  return createChannelInternal(std::move(cpuChannel), cudaLoop_);
+  return createChannelInternal(
+      std::move(cpuChannel), cudaLoop_, cudaPinnedBufferAllocator_);
 }
 
 void ContextImpl::closeImpl() {

--- a/tensorpipe/channel/cuda_basic/context_impl.h
+++ b/tensorpipe/channel/cuda_basic/context_impl.h
@@ -11,6 +11,7 @@
 #include <tensorpipe/channel/context_impl_boilerplate.h>
 #include <tensorpipe/channel/cpu_context.h>
 #include <tensorpipe/channel/cuda_context.h>
+#include <tensorpipe/common/cuda.h>
 #include <tensorpipe/common/cuda_buffer.h>
 #include <tensorpipe/common/cuda_loop.h>
 #include <tensorpipe/common/deferred_executor.h>
@@ -46,6 +47,7 @@ class ContextImpl final
   const std::shared_ptr<CpuContext> cpuContext_;
   // TODO: Lazy initialization of cuda loop.
   CudaLoop cudaLoop_;
+  CudaPinnedBufferAllocator cudaPinnedBufferAllocator_;
 };
 
 } // namespace cuda_basic

--- a/tensorpipe/common/cuda.h
+++ b/tensorpipe/common/cuda.h
@@ -146,7 +146,6 @@ class CudaPinnedBufferAllocator {
       std::unique_lock<std::mutex> lock(mutex_);
       size_t requestedChunks = (size + kChunkSize_ - 1) / kChunkSize_;
       size_t startChunk = 0;
-      size_t curChunk = 0;
 
       // Linear check for available contiguous chunks.
       for (size_t curChunk = 0; curChunk < kNumChunks_; ++curChunk) {


### PR DESCRIPTION
This PR introduces a `CudaPinnedMemoryAllocator` (shared among
`cuda_basic` channels from a same context) that pre-allocates one
large slab of host pinned memory, divided into chunks that can be
used by channels when they need to stage data to host buffers.

The proposed strategy is to return a whole existing chunk when one is
available and the requested buffer is at most the chunk
size. Otherwise, we fall back to allocating a new temporary pinned
buffer.
We could consider copying a large device tensor to multiple
non-contiguous chunks but it is not clear there would be any perf
benefits of exchanging one `cudaMallocHost()` call for multiple
`cudaMemcpyAsync()`.
~~One optimization that would make sense would be to use several
contiguous chunks when possible.~~ done.