### PR TITLE
Remove unnecessary CudaDeviceGuard for cudaIpcOpenEventHandle.

### DIFF
--- a/tensorpipe/common/cuda.h
+++ b/tensorpipe/common/cuda.h
@@ -76,8 +76,6 @@ class CudaEvent {
   }
 
   explicit CudaEvent(int device, cudaIpcEventHandle_t handle) {
-    // It could crash if we don't set device when creating events from handles
-    CudaDeviceGuard guard(device);
     TP_CUDA_CHECK(cudaIpcOpenEventHandle(&ev_, handle));
   }
 


### PR DESCRIPTION
As hinted by the (official) simpleIPC CUDA example, calling `cudaSetDevice()` before opening an IPC event handle is not necessary (cf. https://github.com/NVIDIA/cuda-samples/blob/master/Samples/simpleIPC/simpleIPC.cu#L126). Removing the extraneous device guard.