### PR TITLE
Mark cuda_ipc viable only if all devices have peer access available.

### DIFF
--- a/tensorpipe/channel/cuda_ipc/context_impl.cc
+++ b/tensorpipe/channel/cuda_ipc/context_impl.cc
@@ -76,7 +76,7 @@ bool ContextImpl::isViable() const {
 
     // The other two compute modes are "exclusive" and "prohibited", both of
     // which prevent access from an other process.
-    if (!props.computeMode != cudaComputeModeDefault) {
+    if (props.computeMode != cudaComputeModeDefault) {
       TP_VLOG(4) << "Channel context " << id_
                  << " is not viable because CUDA device " << i
                  << " is not in default compute mode";


### PR DESCRIPTION
Since `cudaIpcOpenMemHandle()` will lazily try to enable peer access,
we must ensure it will not fail.
One limitation of this check is that it can be fooled by the
`CUDA_VISIBLE_DEVICES` environment variable, as two processes might be
each limited to a viable set of devices, while pairs across those sets
might not be able to access each other. One option would be to use an
ordered list of device UUIDS as part of the domain descriptor (those
would need to be accessed through the `nvmlDeviceGetUUID()` function
from the nvml library, or through the PCI ids returned in `cudaDeviceGetAttribute()`). A simpler option would be to check the
process' environment and mark the channel non-viable if
`CUDA_VISIBLE_DEVICES` is set, or to add the value of 
`CUDA_VISIBLE_DEVICES` to the domain descriptor.