### PR TITLE
Ensure tensor order in cuda_basic.

### DIFF
--- a/tensorpipe/channel/cuda_basic/channel_impl.h
+++ b/tensorpipe/channel/cuda_basic/channel_impl.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <deque>
 #include <memory>
 #include <string>
 
@@ -22,6 +23,14 @@ namespace channel {
 namespace cuda_basic {
 
 class ContextImpl;
+
+struct SendOperation {
+  uint64_t sequenceNumber{0};
+  CudaPinnedBuffer tmpBuffer;
+  size_t length{0};
+  TDescriptorCallback descriptorCallback;
+  bool ready{false};
+};
 
 class ChannelImpl final
     : public ChannelImplBoilerplate<CudaBuffer, ContextImpl, ChannelImpl> {
@@ -52,12 +61,9 @@ class ChannelImpl final
  private:
   const std::shared_ptr<CpuChannel> cpuChannel_;
   CudaLoop& cudaLoop_;
+  std::deque<SendOperation> sendOperations_;
 
-  void onTempBufferReadyForSend(
-      uint64_t sequenceNumber,
-      CudaBuffer buffer,
-      CudaPinnedBuffer tmpBuffer,
-      TDescriptorCallback descriptorCallback);
+  void onTempBufferReadyForSend();
 
   void onCpuChannelRecv(
       uint64_t sequenceNumber,


### PR DESCRIPTION
The CudaLoop does not guarantee a FIFO order of callbacks, therefore delaying the `cudaMemcpyAsync()`to the `CudaLoop` can lead to an inversion in the order in which tensors are sent through the CPU channel . This change ensures the tensors are sent through the CPU channel in the same order they are being sent through the wrapping cuda_basic channel.