### PR TITLE
Use non-blocking CUDA streams in tests.

### DIFF
--- a/tensorpipe/test/channel/channel_test.h
+++ b/tensorpipe/test/channel/channel_test.h
@@ -66,7 +66,7 @@ class DataWrapper<tensorpipe::CudaBuffer> {
   explicit DataWrapper(size_t length) : length_(length) {
     if (length_ > 0) {
       TP_CUDA_CHECK(cudaSetDevice(0));
-      TP_CUDA_CHECK(cudaStreamCreate(&stream_));
+      TP_CUDA_CHECK(cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking));
       TP_CUDA_CHECK(cudaMalloc(&cudaPtr_, length_));
     }
   }
@@ -101,6 +101,7 @@ class DataWrapper<tensorpipe::CudaBuffer> {
   std::vector<uint8_t> unwrap() {
     std::vector<uint8_t> v(length_);
     if (length_ > 0) {
+      TP_CUDA_CHECK(cudaStreamSynchronize(stream_));
       TP_CUDA_CHECK(cudaMemcpy(v.data(), cudaPtr_, length_, cudaMemcpyDefault));
     }
 

--- a/tensorpipe/test/channel/channel_test_cuda.cc
+++ b/tensorpipe/test/channel/channel_test_cuda.cc
@@ -28,7 +28,8 @@ class ReceiverWaitsForStartEventTest
 
     TP_CUDA_CHECK(cudaSetDevice(0));
     cudaStream_t sendStream;
-    TP_CUDA_CHECK(cudaStreamCreate(&sendStream));
+    TP_CUDA_CHECK(
+        cudaStreamCreateWithFlags(&sendStream, cudaStreamNonBlocking));
     void* ptr;
     TP_CUDA_CHECK(cudaMalloc(&ptr, kSize));
 
@@ -82,7 +83,8 @@ class ReceiverWaitsForStartEventTest
 
     TP_CUDA_CHECK(cudaSetDevice(0));
     cudaStream_t recvStream;
-    TP_CUDA_CHECK(cudaStreamCreate(&recvStream));
+    TP_CUDA_CHECK(
+        cudaStreamCreateWithFlags(&recvStream, cudaStreamNonBlocking));
     void* ptr;
     TP_CUDA_CHECK(cudaMalloc(&ptr, kSize));
 
@@ -107,6 +109,7 @@ class ReceiverWaitsForStartEventTest
     EXPECT_FALSE(recvError) << recvError.what();
 
     std::array<uint8_t, kSize> data;
+    TP_CUDA_CHECK(cudaStreamSynchronize(recvStream));
     TP_CUDA_CHECK(cudaMemcpy(data.data(), ptr, kSize, cudaMemcpyDefault));
     EXPECT_THAT(data, ::testing::Each(0x42));
     TP_CUDA_CHECK(cudaFree(ptr));
@@ -140,7 +143,8 @@ class SendAcrossDevicesTest : public ClientServerChannelTestCase<CudaBuffer> {
     // Send happens from device #0.
     TP_CUDA_CHECK(cudaSetDevice(0));
     cudaStream_t sendStream;
-    TP_CUDA_CHECK(cudaStreamCreate(&sendStream));
+    TP_CUDA_CHECK(
+        cudaStreamCreateWithFlags(&sendStream, cudaStreamNonBlocking));
     void* ptr;
     TP_CUDA_CHECK(cudaMalloc(&ptr, kSize));
 
@@ -192,7 +196,9 @@ class SendAcrossDevicesTest : public ClientServerChannelTestCase<CudaBuffer> {
     // Recv happens on device #1.
     TP_CUDA_CHECK(cudaSetDevice(1));
     cudaStream_t recvStream;
-    TP_CUDA_CHECK(cudaStreamCreate(&recvStream));
+    TP_CUDA_CHECK(
+        cudaStreamCreateWithFlags(&recvStream, cudaStreamNonBlocking));
+>>>>>>> b1aca06... Use non-blocking CUDA streams in tests.
     void* ptr;
     TP_CUDA_CHECK(cudaMalloc(&ptr, kSize));
 
@@ -217,6 +223,7 @@ class SendAcrossDevicesTest : public ClientServerChannelTestCase<CudaBuffer> {
     EXPECT_FALSE(recvError) << recvError.what();
 
     std::array<uint8_t, kSize> data;
+    TP_CUDA_CHECK(cudaStreamSynchronize(recvStream));
     TP_CUDA_CHECK(cudaMemcpy(data.data(), ptr, kSize, cudaMemcpyDefault));
     EXPECT_THAT(data, ::testing::Each(0x42));
     TP_CUDA_CHECK(cudaFree(ptr));
@@ -251,7 +258,8 @@ class SendReverseAcrossDevicesTest
     // Send happens from device #1.
     TP_CUDA_CHECK(cudaSetDevice(1));
     cudaStream_t sendStream;
-    TP_CUDA_CHECK(cudaStreamCreate(&sendStream));
+    TP_CUDA_CHECK(
+        cudaStreamCreateWithFlags(&sendStream, cudaStreamNonBlocking));
     void* ptr;
     TP_CUDA_CHECK(cudaMalloc(&ptr, kSize));
 
@@ -303,7 +311,8 @@ class SendReverseAcrossDevicesTest
     // Recv happens on device #0.
     TP_CUDA_CHECK(cudaSetDevice(0));
     cudaStream_t recvStream;
-    TP_CUDA_CHECK(cudaStreamCreate(&recvStream));
+    TP_CUDA_CHECK(
+        cudaStreamCreateWithFlags(&recvStream, cudaStreamNonBlocking));
     void* ptr;
     TP_CUDA_CHECK(cudaMalloc(&ptr, kSize));
 
@@ -328,6 +337,7 @@ class SendReverseAcrossDevicesTest
     EXPECT_FALSE(recvError) << recvError.what();
 
     std::array<uint8_t, kSize> data;
+    TP_CUDA_CHECK(cudaStreamSynchronize(recvStream));
     TP_CUDA_CHECK(cudaMemcpy(data.data(), ptr, kSize, cudaMemcpyDefault));
     EXPECT_THAT(data, ::testing::Each(0x42));
     TP_CUDA_CHECK(cudaFree(ptr));
@@ -362,7 +372,8 @@ class SendAcrossNonDefaultDevicesTest
     // Send happens from device #1.
     TP_CUDA_CHECK(cudaSetDevice(1));
     cudaStream_t sendStream;
-    TP_CUDA_CHECK(cudaStreamCreate(&sendStream));
+    TP_CUDA_CHECK(
+        cudaStreamCreateWithFlags(&sendStream, cudaStreamNonBlocking));
     void* ptr;
     TP_CUDA_CHECK(cudaMalloc(&ptr, kSize));
 
@@ -414,7 +425,8 @@ class SendAcrossNonDefaultDevicesTest
     // Recv happens on device #1.
     TP_CUDA_CHECK(cudaSetDevice(1));
     cudaStream_t recvStream;
-    TP_CUDA_CHECK(cudaStreamCreate(&recvStream));
+    TP_CUDA_CHECK(
+        cudaStreamCreateWithFlags(&recvStream, cudaStreamNonBlocking));
     void* ptr;
     TP_CUDA_CHECK(cudaMalloc(&ptr, kSize));
 
@@ -439,6 +451,7 @@ class SendAcrossNonDefaultDevicesTest
     EXPECT_FALSE(recvError) << recvError.what();
 
     std::array<uint8_t, kSize> data;
+    TP_CUDA_CHECK(cudaStreamSynchronize(recvStream));
     TP_CUDA_CHECK(cudaMemcpy(data.data(), ptr, kSize, cudaMemcpyDefault));
     EXPECT_THAT(data, ::testing::Each(0x42));
     TP_CUDA_CHECK(cudaFree(ptr));

--- a/tensorpipe/test/channel/channel_test_cuda.cc
+++ b/tensorpipe/test/channel/channel_test_cuda.cc
@@ -198,7 +198,6 @@ class SendAcrossDevicesTest : public ClientServerChannelTestCase<CudaBuffer> {
     cudaStream_t recvStream;
     TP_CUDA_CHECK(
         cudaStreamCreateWithFlags(&recvStream, cudaStreamNonBlocking));
->>>>>>> b1aca06... Use non-blocking CUDA streams in tests.
     void* ptr;
     TP_CUDA_CHECK(cudaMalloc(&ptr, kSize));
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #282 Separate test suite for multi-GPU tests.
* **#279 Use non-blocking CUDA streams in tests.**
* #278 Use gmock matchers for array equality in tests.
* #277 Use TP_CUDA_CHECK instead of EXPECT_EQ in CUDA tests.

Blocking streams are being synchronized each time an action is
performed on the default
stream (cf. https://docs.nvidia.com/cuda/cuda-runtime-api/stream-sync-behavior.html#stream-sync-behavior).
Therefore, let us not assume this synchronization in our tests, and
use non-blocking streams instead. This requires manually synchronizing
a stream between a call to `recv()` and a `cudaMemcpy()` (which, in
the non-async version happens on the default stream).

Differential Revision: [D25995770](https://our.internmc.facebook.com/intern/diff/D25995770)