### PR TITLE
Add device uuids to domain descriptor of CudaIpc.

### DIFF
--- a/tensorpipe/channel/cuda_ipc/context_impl.cc
+++ b/tensorpipe/channel/cuda_ipc/context_impl.cc
@@ -36,6 +36,8 @@ std::string deviceUUID(int device) {
 #if CUDART_VERSION > 9020
   uuid << std::setfill('0') << std::setw(2);
   for (int j = 0; j < 16; ++j) {
+    // The bitmask is required otherwise a negative value will get promoted to
+    // (signed) int with sign extension if char is signed.
     uuid << (props.uuid.bytes[j] & 0xff);
   }
 #else // CUDART_VERSION <= 9020


### PR DESCRIPTION
This ensures that whenever the domain descriptor matches and the
channel is viable, it will indeed work, avoiding the current loophole
where a machine could have two sets of pairwise p2p-enabled devices
with no p2p across the sets, fooling our viability check if each
process is restricted to one of the sets.