### PR TITLE
Make Pipe provide multiple connections to channels.

### DIFF
--- a/tensorpipe/channel/basic/context.cc
+++ b/tensorpipe/channel/basic/context.cc
@@ -26,9 +26,13 @@ Context::Context() : impl_(std::make_shared<ContextImpl>()) {}
 // recursive include of private headers into the public ones.
 
 std::shared_ptr<CpuChannel> Context::createChannel(
-    std::shared_ptr<transport::Connection> connection,
+    std::vector<std::shared_ptr<transport::Connection>> connections,
     Endpoint endpoint) {
-  return impl_->createChannel(std::move(connection), endpoint);
+  return impl_->createChannel(std::move(connections), endpoint);
+}
+
+size_t Context::numConnectionsNeeded() const {
+  return impl_->numConnectionsNeeded();
 }
 
 const std::string& Context::domainDescriptor() const {

--- a/tensorpipe/channel/basic/context.h
+++ b/tensorpipe/channel/basic/context.h
@@ -31,8 +31,10 @@ class Context : public CpuContext {
   Context& operator=(Context&&) = delete;
 
   std::shared_ptr<CpuChannel> createChannel(
-      std::shared_ptr<transport::Connection> connection,
+      std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint) override;
+
+  size_t numConnectionsNeeded() const override;
 
   const std::string& domainDescriptor() const override;
 

--- a/tensorpipe/channel/basic/context_impl.cc
+++ b/tensorpipe/channel/basic/context_impl.cc
@@ -21,9 +21,10 @@ ContextImpl::ContextImpl()
     : ContextImplBoilerplate<CpuBuffer, ContextImpl, ChannelImpl>("any") {}
 
 std::shared_ptr<CpuChannel> ContextImpl::createChannel(
-    std::shared_ptr<transport::Connection> connection,
+    std::vector<std::shared_ptr<transport::Connection>> connections,
     Endpoint /* unused */) {
-  return createChannelInternal(std::move(connection));
+  TP_DCHECK_EQ(numConnectionsNeeded(), connections.size());
+  return createChannelInternal(std::move(connections[0]));
 }
 
 void ContextImpl::closeImpl() {}

--- a/tensorpipe/channel/basic/context_impl.h
+++ b/tensorpipe/channel/basic/context_impl.h
@@ -27,7 +27,7 @@ class ContextImpl final
   ContextImpl();
 
   std::shared_ptr<CpuChannel> createChannel(
-      std::shared_ptr<transport::Connection> connection,
+      std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint);
 
   // Implement the DeferredExecutor interface.

--- a/tensorpipe/channel/cma/context.cc
+++ b/tensorpipe/channel/cma/context.cc
@@ -26,9 +26,13 @@ Context::Context() : impl_(ContextImpl::create()) {}
 // recursive include of private headers into the public ones.
 
 std::shared_ptr<CpuChannel> Context::createChannel(
-    std::shared_ptr<transport::Connection> connection,
+    std::vector<std::shared_ptr<transport::Connection>> connections,
     Endpoint endpoint) {
-  return impl_->createChannel(std::move(connection), endpoint);
+  return impl_->createChannel(std::move(connections), endpoint);
+}
+
+size_t Context::numConnectionsNeeded() const {
+  return impl_->numConnectionsNeeded();
 }
 
 const std::string& Context::domainDescriptor() const {

--- a/tensorpipe/channel/cma/context.h
+++ b/tensorpipe/channel/cma/context.h
@@ -31,8 +31,10 @@ class Context : public CpuContext {
   Context& operator=(Context&&) = delete;
 
   std::shared_ptr<CpuChannel> createChannel(
-      std::shared_ptr<transport::Connection> connection,
+      std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint) override;
+
+  size_t numConnectionsNeeded() const override;
 
   const std::string& domainDescriptor() const override;
 

--- a/tensorpipe/channel/cma/context_impl.cc
+++ b/tensorpipe/channel/cma/context_impl.cc
@@ -233,9 +233,10 @@ ContextImpl::ContextImpl(bool isVIable, std::string domainDescriptor)
 }
 
 std::shared_ptr<CpuChannel> ContextImpl::createChannel(
-    std::shared_ptr<transport::Connection> connection,
+    std::vector<std::shared_ptr<transport::Connection>> connections,
     Endpoint /* unused */) {
-  return createChannelInternal(std::move(connection));
+  TP_DCHECK_EQ(numConnectionsNeeded(), connections.size());
+  return createChannelInternal(std::move(connections[0]));
 }
 
 bool ContextImpl::isViable() const {

--- a/tensorpipe/channel/cma/context_impl.h
+++ b/tensorpipe/channel/cma/context_impl.h
@@ -34,7 +34,7 @@ class ContextImpl final
   ContextImpl(bool isViable, std::string domainDescriptor);
 
   std::shared_ptr<CpuChannel> createChannel(
-      std::shared_ptr<transport::Connection> connection,
+      std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint);
 
   bool isViable() const;

--- a/tensorpipe/channel/context.h
+++ b/tensorpipe/channel/context.h
@@ -10,6 +10,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <tensorpipe/transport/context.h>
 
@@ -41,6 +42,14 @@ class Context {
     return true;
   }
 
+  // Return the number of control connections needed to create an instance of
+  // this channel.
+  //
+  // Most channels require only one, but some require more (cuda_basic), and
+  // some might require none.
+  //
+  virtual size_t numConnectionsNeeded() const = 0;
+
   // Return string to describe the domain for this channel.
   //
   // Two processes with a channel context of the same type can connect
@@ -64,16 +73,16 @@ class Context {
     return domainDescriptor() == remoteDomainDescriptor;
   }
 
-  // Return newly created channel using the specified connection.
+  // Return newly created channel using the specified connections.
   //
-  // It is up to the channel to either use this connection for further
-  // initialization, or use it directly. Either way, the returned
+  // It is up to the channel to either use these connections for further
+  // initialization, or use them directly. Either way, the returned
   // channel should be immediately usable. If the channel isn't fully
   // initialized yet, take care to queue these operations to execute
   // as soon as initialization has completed.
   //
   virtual std::shared_ptr<Channel<TBuffer>> createChannel(
-      std::shared_ptr<transport::Connection>,
+      std::vector<std::shared_ptr<transport::Connection>>,
       Endpoint) = 0;
 
   // Tell the context what its identifier is.

--- a/tensorpipe/channel/context_impl_boilerplate.h
+++ b/tensorpipe/channel/context_impl_boilerplate.h
@@ -33,6 +33,8 @@ class ContextImplBoilerplate : public virtual DeferredExecutor,
   ContextImplBoilerplate& operator=(const ContextImplBoilerplate&) = delete;
   ContextImplBoilerplate& operator=(ContextImplBoilerplate&&) = delete;
 
+  virtual size_t numConnectionsNeeded() const;
+
   const std::string& domainDescriptor() const;
 
   // Enrolling dependent objects (channels) causes them to be kept alive for as
@@ -105,6 +107,12 @@ std::shared_ptr<Channel<TBuffer>> ContextImplBoilerplate<TBuffer, TCtx, TChan>::
       this->shared_from_this(),
       std::move(channelId),
       std::forward<Args>(args)...);
+}
+
+template <typename TBuffer, typename TCtx, typename TChan>
+size_t ContextImplBoilerplate<TBuffer, TCtx, TChan>::numConnectionsNeeded()
+    const {
+  return 1;
 }
 
 template <typename TBuffer, typename TCtx, typename TChan>

--- a/tensorpipe/channel/cuda_basic/context.cc
+++ b/tensorpipe/channel/cuda_basic/context.cc
@@ -27,9 +27,13 @@ Context::Context(std::shared_ptr<CpuContext> cpuContext)
 // recursive include of private headers into the public ones.
 
 std::shared_ptr<CudaChannel> Context::createChannel(
-    std::shared_ptr<transport::Connection> connection,
+    std::vector<std::shared_ptr<transport::Connection>> connections,
     Endpoint endpoint) {
-  return impl_->createChannel(std::move(connection), endpoint);
+  return impl_->createChannel(std::move(connections), endpoint);
+}
+
+size_t Context::numConnectionsNeeded() const {
+  return impl_->numConnectionsNeeded();
 }
 
 const std::string& Context::domainDescriptor() const {

--- a/tensorpipe/channel/cuda_basic/context.h
+++ b/tensorpipe/channel/cuda_basic/context.h
@@ -31,8 +31,10 @@ class Context : public CudaContext {
   Context& operator=(Context&&) = delete;
 
   std::shared_ptr<CudaChannel> createChannel(
-      std::shared_ptr<transport::Connection> connection,
+      std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint) override;
+
+  size_t numConnectionsNeeded() const override;
 
   const std::string& domainDescriptor() const override;
 

--- a/tensorpipe/channel/cuda_basic/context_impl.cc
+++ b/tensorpipe/channel/cuda_basic/context_impl.cc
@@ -34,9 +34,11 @@ ContextImpl::ContextImpl(std::shared_ptr<CpuContext> cpuContext)
 }
 
 std::shared_ptr<CudaChannel> ContextImpl::createChannel(
-    std::shared_ptr<transport::Connection> connection,
+    std::vector<std::shared_ptr<transport::Connection>> connections,
     Endpoint endpoint) {
-  auto cpuChannel = cpuContext_->createChannel(std::move(connection), endpoint);
+  TP_DCHECK_EQ(numConnectionsNeeded(), connections.size());
+  auto cpuChannel =
+      cpuContext_->createChannel(std::move(connections), endpoint);
   return createChannelInternal(std::move(cpuChannel), cudaLoop_);
 }
 

--- a/tensorpipe/channel/cuda_basic/context_impl.cc
+++ b/tensorpipe/channel/cuda_basic/context_impl.cc
@@ -36,10 +36,13 @@ ContextImpl::ContextImpl(std::shared_ptr<CpuContext> cpuContext)
 std::shared_ptr<CudaChannel> ContextImpl::createChannel(
     std::vector<std::shared_ptr<transport::Connection>> connections,
     Endpoint endpoint) {
-  TP_DCHECK_EQ(numConnectionsNeeded(), connections.size());
   auto cpuChannel =
       cpuContext_->createChannel(std::move(connections), endpoint);
   return createChannelInternal(std::move(cpuChannel), cudaLoop_);
+}
+
+size_t ContextImpl::numConnectionsNeeded() const {
+  return cpuContext_->numConnectionsNeeded();
 }
 
 bool ContextImpl::isViable() const {

--- a/tensorpipe/channel/cuda_basic/context_impl.h
+++ b/tensorpipe/channel/cuda_basic/context_impl.h
@@ -31,6 +31,8 @@ class ContextImpl final
       std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint);
 
+  size_t numConnectionsNeeded() const override;
+
   bool isViable() const;
 
   const CudaLib& getCudaLib();

--- a/tensorpipe/channel/cuda_basic/context_impl.h
+++ b/tensorpipe/channel/cuda_basic/context_impl.h
@@ -28,7 +28,7 @@ class ContextImpl final
   explicit ContextImpl(std::shared_ptr<CpuContext> cpuContext);
 
   std::shared_ptr<CudaChannel> createChannel(
-      std::shared_ptr<transport::Connection> connection,
+      std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint);
 
   bool isViable() const;

--- a/tensorpipe/channel/cuda_gdr/context.cc
+++ b/tensorpipe/channel/cuda_gdr/context.cc
@@ -28,9 +28,13 @@ Context::Context(optional<std::vector<std::string>> gpuIdxToNicName)
 // recursive include of private headers into the public ones.
 
 std::shared_ptr<CudaChannel> Context::createChannel(
-    std::shared_ptr<transport::Connection> connection,
+    std::vector<std::shared_ptr<transport::Connection>> connections,
     Endpoint endpoint) {
-  return impl_->createChannel(std::move(connection), endpoint);
+  return impl_->createChannel(std::move(connections), endpoint);
+}
+
+size_t Context::numConnectionsNeeded() const {
+  return impl_->numConnectionsNeeded();
 }
 
 const std::string& Context::domainDescriptor() const {

--- a/tensorpipe/channel/cuda_gdr/context.h
+++ b/tensorpipe/channel/cuda_gdr/context.h
@@ -33,8 +33,10 @@ class Context : public CudaContext {
   Context& operator=(Context&&) = delete;
 
   std::shared_ptr<CudaChannel> createChannel(
-      std::shared_ptr<transport::Connection> connection,
+      std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint) override;
+
+  size_t numConnectionsNeeded() const override;
 
   const std::string& domainDescriptor() const override;
 

--- a/tensorpipe/channel/cuda_gdr/context_impl.cc
+++ b/tensorpipe/channel/cuda_gdr/context_impl.cc
@@ -521,9 +521,10 @@ void ContextImpl::setIdImpl() {
 }
 
 std::shared_ptr<CudaChannel> ContextImpl::createChannel(
-    std::shared_ptr<transport::Connection> connection,
+    std::vector<std::shared_ptr<transport::Connection>> connections,
     Endpoint /* unused */) {
-  return createChannelInternal(std::move(connection));
+  TP_DCHECK_EQ(numConnectionsNeeded(), connections.size());
+  return createChannelInternal(std::move(connections[0]));
 }
 
 bool ContextImpl::isViable() const {

--- a/tensorpipe/channel/cuda_gdr/context_impl.h
+++ b/tensorpipe/channel/cuda_gdr/context_impl.h
@@ -128,7 +128,7 @@ class ContextImpl final
       optional<std::vector<std::string>> gpuIdxToNicName = nullopt);
 
   std::shared_ptr<CudaChannel> createChannel(
-      std::shared_ptr<transport::Connection> connection,
+      std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint);
 
   bool isViable() const;

--- a/tensorpipe/channel/cuda_ipc/context.cc
+++ b/tensorpipe/channel/cuda_ipc/context.cc
@@ -26,9 +26,13 @@ Context::Context() : impl_(ContextImpl::create()) {}
 // recursive include of private headers into the public ones.
 
 std::shared_ptr<CudaChannel> Context::createChannel(
-    std::shared_ptr<transport::Connection> connection,
+    std::vector<std::shared_ptr<transport::Connection>> connections,
     Endpoint endpoint) {
-  return impl_->createChannel(std::move(connection), endpoint);
+  return impl_->createChannel(std::move(connections), endpoint);
+}
+
+size_t Context::numConnectionsNeeded() const {
+  return impl_->numConnectionsNeeded();
 }
 
 const std::string& Context::domainDescriptor() const {

--- a/tensorpipe/channel/cuda_ipc/context.h
+++ b/tensorpipe/channel/cuda_ipc/context.h
@@ -30,8 +30,10 @@ class Context : public CudaContext {
   Context& operator=(Context&&) = delete;
 
   std::shared_ptr<CudaChannel> createChannel(
-      std::shared_ptr<transport::Connection> connection,
+      std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint) override;
+
+  size_t numConnectionsNeeded() const override;
 
   const std::string& domainDescriptor() const override;
 

--- a/tensorpipe/channel/cuda_ipc/context_impl.cc
+++ b/tensorpipe/channel/cuda_ipc/context_impl.cc
@@ -319,9 +319,10 @@ ContextImpl::ContextImpl(
       globalIdxOfVisibleDevices_(std::move(globalIdxOfVisibleDevices)) {}
 
 std::shared_ptr<CudaChannel> ContextImpl::createChannel(
-    std::shared_ptr<transport::Connection> connection,
+    std::vector<std::shared_ptr<transport::Connection>> connections,
     Endpoint /* unused */) {
-  return createChannelInternal(std::move(connection));
+  TP_DCHECK_EQ(numConnectionsNeeded(), connections.size());
+  return createChannelInternal(std::move(connections[0]));
 }
 
 bool ContextImpl::isViable() const {

--- a/tensorpipe/channel/cuda_ipc/context_impl.h
+++ b/tensorpipe/channel/cuda_ipc/context_impl.h
@@ -43,7 +43,7 @@ class ContextImpl final
       std::vector<int> globalIdxOfVisibleDevices);
 
   std::shared_ptr<CudaChannel> createChannel(
-      std::shared_ptr<transport::Connection> connection,
+      std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint);
 
   bool isViable() const;

--- a/tensorpipe/channel/cuda_xth/context.cc
+++ b/tensorpipe/channel/cuda_xth/context.cc
@@ -26,9 +26,13 @@ Context::Context() : impl_(std::make_shared<ContextImpl>()) {}
 // recursive include of private headers into the public ones.
 
 std::shared_ptr<CudaChannel> Context::createChannel(
-    std::shared_ptr<transport::Connection> connection,
+    std::vector<std::shared_ptr<transport::Connection>> connections,
     Endpoint endpoint) {
-  return impl_->createChannel(std::move(connection), endpoint);
+  return impl_->createChannel(std::move(connections), endpoint);
+}
+
+size_t Context::numConnectionsNeeded() const {
+  return impl_->numConnectionsNeeded();
 }
 
 const std::string& Context::domainDescriptor() const {

--- a/tensorpipe/channel/cuda_xth/context.h
+++ b/tensorpipe/channel/cuda_xth/context.h
@@ -30,8 +30,10 @@ class Context : public CudaContext {
   Context& operator=(Context&&) = delete;
 
   std::shared_ptr<CudaChannel> createChannel(
-      std::shared_ptr<transport::Connection> connection,
+      std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint) override;
+
+  size_t numConnectionsNeeded() const override;
 
   const std::string& domainDescriptor() const override;
 

--- a/tensorpipe/channel/cuda_xth/context_impl.cc
+++ b/tensorpipe/channel/cuda_xth/context_impl.cc
@@ -57,9 +57,10 @@ ContextImpl::ContextImpl()
 }
 
 std::shared_ptr<CudaChannel> ContextImpl::createChannel(
-    std::shared_ptr<transport::Connection> connection,
+    std::vector<std::shared_ptr<transport::Connection>> connections,
     Endpoint /* unused */) {
-  return createChannelInternal(std::move(connection));
+  TP_DCHECK_EQ(numConnectionsNeeded(), connections.size());
+  return createChannelInternal(std::move(connections[0]));
 }
 
 bool ContextImpl::isViable() const {

--- a/tensorpipe/channel/cuda_xth/context_impl.h
+++ b/tensorpipe/channel/cuda_xth/context_impl.h
@@ -26,7 +26,7 @@ class ContextImpl final
   ContextImpl();
 
   std::shared_ptr<CudaChannel> createChannel(
-      std::shared_ptr<transport::Connection> connection,
+      std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint);
 
   bool isViable() const;

--- a/tensorpipe/channel/mpt/context.cc
+++ b/tensorpipe/channel/mpt/context.cc
@@ -34,9 +34,13 @@ Context::Context(
 // recursive include of private headers into the public ones.
 
 std::shared_ptr<CpuChannel> Context::createChannel(
-    std::shared_ptr<transport::Connection> connection,
+    std::vector<std::shared_ptr<transport::Connection>> connections,
     Endpoint endpoint) {
-  return impl_->createChannel(std::move(connection), endpoint);
+  return impl_->createChannel(std::move(connections), endpoint);
+}
+
+size_t Context::numConnectionsNeeded() const {
+  return impl_->numConnectionsNeeded();
 }
 
 const std::string& Context::domainDescriptor() const {

--- a/tensorpipe/channel/mpt/context.h
+++ b/tensorpipe/channel/mpt/context.h
@@ -33,8 +33,10 @@ class Context : public CpuContext {
   Context& operator=(Context&&) = delete;
 
   std::shared_ptr<CpuChannel> createChannel(
-      std::shared_ptr<transport::Connection> connection,
+      std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint) override;
+
+  size_t numConnectionsNeeded() const override;
 
   const std::string& domainDescriptor() const override;
 

--- a/tensorpipe/channel/mpt/context_impl.cc
+++ b/tensorpipe/channel/mpt/context_impl.cc
@@ -71,9 +71,10 @@ void ContextImpl::initFromLoop() {
 }
 
 std::shared_ptr<CpuChannel> ContextImpl::createChannel(
-    std::shared_ptr<transport::Connection> connection,
+    std::vector<std::shared_ptr<transport::Connection>> connections,
     Endpoint endpoint) {
-  return createChannelInternal(std::move(connection), endpoint, numLanes_);
+  TP_DCHECK_EQ(numConnectionsNeeded(), connections.size());
+  return createChannelInternal(std::move(connections[0]), endpoint, numLanes_);
 }
 
 const std::vector<std::string>& ContextImpl::addresses() const {

--- a/tensorpipe/channel/mpt/context_impl.h
+++ b/tensorpipe/channel/mpt/context_impl.h
@@ -40,7 +40,7 @@ class ContextImpl final
   void init();
 
   std::shared_ptr<CpuChannel> createChannel(
-      std::shared_ptr<transport::Connection> connection,
+      std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint);
 
   // Implement the DeferredExecutor interface.

--- a/tensorpipe/channel/xth/context.cc
+++ b/tensorpipe/channel/xth/context.cc
@@ -26,9 +26,13 @@ Context::Context() : impl_(std::make_shared<ContextImpl>()) {}
 // recursive include of private headers into the public ones.
 
 std::shared_ptr<CpuChannel> Context::createChannel(
-    std::shared_ptr<transport::Connection> connection,
+    std::vector<std::shared_ptr<transport::Connection>> connections,
     Endpoint endpoint) {
-  return impl_->createChannel(std::move(connection), endpoint);
+  return impl_->createChannel(std::move(connections), endpoint);
+}
+
+size_t Context::numConnectionsNeeded() const {
+  return impl_->numConnectionsNeeded();
 }
 
 const std::string& Context::domainDescriptor() const {

--- a/tensorpipe/channel/xth/context.h
+++ b/tensorpipe/channel/xth/context.h
@@ -30,8 +30,10 @@ class Context : public CpuContext {
   Context& operator=(Context&&) = delete;
 
   std::shared_ptr<CpuChannel> createChannel(
-      std::shared_ptr<transport::Connection> connection,
+      std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint) override;
+
+  size_t numConnectionsNeeded() const override;
 
   const std::string& domainDescriptor() const override;
 

--- a/tensorpipe/channel/xth/context_impl.cc
+++ b/tensorpipe/channel/xth/context_impl.cc
@@ -51,9 +51,10 @@ ContextImpl::ContextImpl()
 }
 
 std::shared_ptr<CpuChannel> ContextImpl::createChannel(
-    std::shared_ptr<transport::Connection> connection,
+    std::vector<std::shared_ptr<transport::Connection>> connections,
     Endpoint /* unused */) {
-  return createChannelInternal(std::move(connection));
+  TP_DCHECK_EQ(numConnectionsNeeded(), connections.size());
+  return createChannelInternal(std::move(connections[0]));
 }
 
 void ContextImpl::closeImpl() {

--- a/tensorpipe/channel/xth/context_impl.h
+++ b/tensorpipe/channel/xth/context_impl.h
@@ -32,7 +32,7 @@ class ContextImpl final
   ContextImpl();
 
   std::shared_ptr<CpuChannel> createChannel(
-      std::shared_ptr<transport::Connection> connection,
+      std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint);
 
   // Implement the DeferredExecutor interface.

--- a/tensorpipe/core/nop_types.h
+++ b/tensorpipe/core/nop_types.h
@@ -54,9 +54,9 @@ struct Brochure {
 };
 
 struct ChannelSelection {
-  uint64_t registrationId;
+  std::vector<uint64_t> registrationIds;
   std::string domainDescriptor;
-  NOP_STRUCTURE(ChannelSelection, registrationId, domainDescriptor);
+  NOP_STRUCTURE(ChannelSelection, registrationIds, domainDescriptor);
 };
 
 struct BrochureAnswer {

--- a/tensorpipe/core/pipe_impl.cc
+++ b/tensorpipe/core/pipe_impl.cc
@@ -1344,9 +1344,10 @@ void PipeImpl::onAcceptWhileServerWaitingForChannel(
       channelContext->createChannel(
           std::move(channelReceivedConnections[channelName]),
           channel::Endpoint::kListen);
+  channel->setId(id_ + ".ch_" + channelName);
+
   channelRegistrationIds.erase(channelRegistrationIdsIter);
   channelReceivedConnections.erase(channelName);
-  channel->setId(id_ + ".ch_" + channelName);
 
   auto& channels = channels_.get<TBuffer>();
   TP_DCHECK(channels.find(channelName) == channels.end());

--- a/tensorpipe/core/pipe_impl.h
+++ b/tensorpipe/core/pipe_impl.h
@@ -181,9 +181,16 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
   // different connection or to open some channels.
   optional<uint64_t> registrationId_;
 
-  using TChannelRegistrationMap = std::unordered_map<std::string, uint64_t>;
+  using TChannelRegistrationMap =
+      std::unordered_map<std::string, std::vector<uint64_t>>;
   TP_DEVICE_FIELD(TChannelRegistrationMap, TChannelRegistrationMap)
   channelRegistrationIds_;
+
+  using TChannelConnectionsMap = std::unordered_map<
+      std::string,
+      std::vector<std::shared_ptr<transport::Connection>>>;
+  TP_DEVICE_FIELD(TChannelConnectionsMap, TChannelConnectionsMap)
+  channelReceivedConnections_;
 
   ClosingReceiver closingReceiver_;
 
@@ -269,6 +276,7 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
   template <typename TBuffer>
   void onAcceptWhileServerWaitingForChannel(
       std::string channelName,
+      size_t connId,
       std::string receivedTransport,
       std::shared_ptr<transport::Connection> receivedConnection);
   void onReadOfMessageDescriptor(ReadOperation& op, const Packet& nopPacketIn);

--- a/tensorpipe/test/channel/channel_test.cc
+++ b/tensorpipe/test/channel/channel_test.cc
@@ -47,7 +47,7 @@ class ClientToServerTest : public ClientServerChannelTestCase<TBuffer> {
   void server(std::shared_ptr<transport::Connection> conn) override {
     std::shared_ptr<Context<TBuffer>> ctx =
         this->helper_->makeContext("server");
-    auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
+    auto channel = ctx->createChannel({std::move(conn)}, Endpoint::kListen);
 
     // Initialize with sequential values.
     std::vector<uint8_t> data(kDataSize);
@@ -76,7 +76,7 @@ class ClientToServerTest : public ClientServerChannelTestCase<TBuffer> {
   void client(std::shared_ptr<transport::Connection> conn) override {
     std::shared_ptr<Context<TBuffer>> ctx =
         this->helper_->makeContext("client");
-    auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
+    auto channel = ctx->createChannel({std::move(conn)}, Endpoint::kConnect);
 
     DataWrapper<TBuffer> wrappedData(kDataSize);
 
@@ -110,7 +110,7 @@ class ServerToClientTest : public ClientServerChannelTestCase<TBuffer> {
   void server(std::shared_ptr<transport::Connection> conn) override {
     std::shared_ptr<Context<TBuffer>> ctx =
         this->helper_->makeContext("server");
-    auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
+    auto channel = ctx->createChannel({std::move(conn)}, Endpoint::kListen);
 
     DataWrapper<TBuffer> wrappedData(kDataSize);
 
@@ -136,7 +136,7 @@ class ServerToClientTest : public ClientServerChannelTestCase<TBuffer> {
   void client(std::shared_ptr<transport::Connection> conn) override {
     std::shared_ptr<Context<TBuffer>> ctx =
         this->helper_->makeContext("client");
-    auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
+    auto channel = ctx->createChannel({std::move(conn)}, Endpoint::kConnect);
 
     // Initialize with sequential values.
     std::vector<uint8_t> data(kDataSize);
@@ -176,7 +176,7 @@ class SendMultipleTensorsTest : public ClientServerChannelTestCase<TBuffer> {
   void server(std::shared_ptr<transport::Connection> conn) override {
     std::shared_ptr<Context<TBuffer>> ctx =
         this->helper_->makeContext("server");
-    auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
+    auto channel = ctx->createChannel({std::move(conn)}, Endpoint::kListen);
 
     // Initialize with sequential values.
     std::vector<uint8_t> data(dataSize_);
@@ -213,7 +213,7 @@ class SendMultipleTensorsTest : public ClientServerChannelTestCase<TBuffer> {
   void client(std::shared_ptr<transport::Connection> conn) override {
     std::shared_ptr<Context<TBuffer>> ctx =
         this->helper_->makeContext("client");
-    auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
+    auto channel = ctx->createChannel({std::move(conn)}, Endpoint::kConnect);
 
     std::vector<DataWrapper<TBuffer>> wrappedDataVec;
     for (int i = 0; i < kNumTensors; i++) {
@@ -259,7 +259,7 @@ class SendTensorsBothWaysTest : public ClientServerChannelTestCase<TBuffer> {
   void server(std::shared_ptr<transport::Connection> conn) override {
     std::shared_ptr<Context<TBuffer>> ctx =
         this->helper_->makeContext("server");
-    auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
+    auto channel = ctx->createChannel({std::move(conn)}, Endpoint::kListen);
 
     // Initialize sendBuffer with sequential values.
     std::vector<uint8_t> sendData(kDataSize);
@@ -312,7 +312,7 @@ class SendTensorsBothWaysTest : public ClientServerChannelTestCase<TBuffer> {
   void client(std::shared_ptr<transport::Connection> conn) override {
     std::shared_ptr<Context<TBuffer>> ctx =
         this->helper_->makeContext("client");
-    auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
+    auto channel = ctx->createChannel({std::move(conn)}, Endpoint::kConnect);
 
     // Initialize sendBuffer with sequential values.
     std::vector<uint8_t> sendData(kDataSize);
@@ -376,14 +376,14 @@ class ContextIsNotJoinedTest : public ClientServerChannelTestCase<TBuffer> {
     std::shared_ptr<Context<TBuffer>> context =
         this->helper_->makeContext("server");
     this->peers_->send(PeerGroup::kClient, kReady);
-    context->createChannel(std::move(conn), Endpoint::kListen);
+    context->createChannel({std::move(conn)}, Endpoint::kListen);
   }
 
   void client(std::shared_ptr<transport::Connection> conn) override {
     std::shared_ptr<Context<TBuffer>> context =
         this->helper_->makeContext("client");
     EXPECT_EQ(kReady, this->peers_->recv(PeerGroup::kClient));
-    context->createChannel(std::move(conn), Endpoint::kConnect);
+    context->createChannel({std::move(conn)}, Endpoint::kConnect);
   }
 };
 

--- a/tensorpipe/test/channel/channel_test_cpu.cc
+++ b/tensorpipe/test/channel/channel_test_cpu.cc
@@ -18,7 +18,7 @@ using namespace tensorpipe::channel;
 class NullPointerTest : public ClientServerChannelTestCase<CpuBuffer> {
   void server(std::shared_ptr<transport::Connection> conn) override {
     std::shared_ptr<CpuContext> ctx = this->helper_->makeContext("server");
-    auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
+    auto channel = ctx->createChannel({std::move(conn)}, Endpoint::kListen);
 
     // Perform send and wait for completion.
     std::future<std::tuple<Error, TDescriptor>> descriptorFuture;
@@ -41,7 +41,7 @@ class NullPointerTest : public ClientServerChannelTestCase<CpuBuffer> {
 
   void client(std::shared_ptr<transport::Connection> conn) override {
     std::shared_ptr<CpuContext> ctx = this->helper_->makeContext("client");
-    auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
+    auto channel = ctx->createChannel({std::move(conn)}, Endpoint::kConnect);
 
     // Perform recv and wait for completion.
     auto descriptor = this->peers_->recv(PeerGroup::kClient);
@@ -64,7 +64,7 @@ class EmptyTensorTest : public ClientServerChannelTestCase<CpuBuffer> {
   void server(std::shared_ptr<transport::Connection> conn) override {
     std::shared_ptr<Context<CpuBuffer>> ctx =
         this->helper_->makeContext("server");
-    auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
+    auto channel = ctx->createChannel({std::move(conn)}, Endpoint::kListen);
 
     // Allocate a non-empty vector so that its .data() pointer is non-null.
     std::vector<uint8_t> data(1);
@@ -92,7 +92,7 @@ class EmptyTensorTest : public ClientServerChannelTestCase<CpuBuffer> {
 
   void client(std::shared_ptr<transport::Connection> conn) override {
     std::shared_ptr<CpuContext> ctx = this->helper_->makeContext("client");
-    auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
+    auto channel = ctx->createChannel({std::move(conn)}, Endpoint::kConnect);
 
     // Allocate a non-empty vector so that its .data() pointer is non-null.
     DataWrapper<CpuBuffer> wrappedData(1);
@@ -126,7 +126,7 @@ class CallbacksAreDeferredTest : public ClientServerChannelTestCase<CpuBuffer> {
  public:
   void server(std::shared_ptr<transport::Connection> conn) override {
     std::shared_ptr<CpuContext> ctx = this->helper_->makeContext("server");
-    auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
+    auto channel = ctx->createChannel({std::move(conn)}, Endpoint::kListen);
 
     // Initialize with sequential values.
     std::vector<uint8_t> data(kDataSize);
@@ -165,7 +165,7 @@ class CallbacksAreDeferredTest : public ClientServerChannelTestCase<CpuBuffer> {
 
   void client(std::shared_ptr<transport::Connection> conn) override {
     std::shared_ptr<CpuContext> ctx = this->helper_->makeContext("client");
-    auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
+    auto channel = ctx->createChannel({std::move(conn)}, Endpoint::kConnect);
 
     // Initialize with zeroes.
     std::vector<uint8_t> data(kDataSize);

--- a/tensorpipe/test/channel/channel_test_cuda.cc
+++ b/tensorpipe/test/channel/channel_test_cuda.cc
@@ -24,7 +24,7 @@ class ReceiverWaitsForStartEventTest
 
   void server(std::shared_ptr<transport::Connection> conn) override {
     std::shared_ptr<CudaContext> ctx = this->helper_->makeContext("server");
-    auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
+    auto channel = ctx->createChannel({std::move(conn)}, Endpoint::kListen);
 
     TP_CUDA_CHECK(cudaSetDevice(0));
     cudaStream_t sendStream;
@@ -79,7 +79,7 @@ class ReceiverWaitsForStartEventTest
 
   void client(std::shared_ptr<transport::Connection> conn) override {
     std::shared_ptr<CudaContext> ctx = this->helper_->makeContext("client");
-    auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
+    auto channel = ctx->createChannel({std::move(conn)}, Endpoint::kConnect);
 
     TP_CUDA_CHECK(cudaSetDevice(0));
     cudaStream_t recvStream;
@@ -131,7 +131,7 @@ class SendOffsetAllocationTest
 
   void server(std::shared_ptr<transport::Connection> conn) override {
     std::shared_ptr<CudaContext> ctx = this->helper_->makeContext("server");
-    auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
+    auto channel = ctx->createChannel({std::move(conn)}, Endpoint::kListen);
 
     // Initialize with sequential values.
     void* ptr;
@@ -162,7 +162,7 @@ class SendOffsetAllocationTest
 
   void client(std::shared_ptr<transport::Connection> conn) override {
     std::shared_ptr<CudaContext> ctx = this->helper_->makeContext("client");
-    auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
+    auto channel = ctx->createChannel({std::move(conn)}, Endpoint::kConnect);
 
     DataWrapper<CudaBuffer> wrappedData(kDataSize);
 

--- a/tensorpipe/test/channel/channel_test_cuda_multi_gpu.cc
+++ b/tensorpipe/test/channel/channel_test_cuda_multi_gpu.cc
@@ -32,7 +32,7 @@ class SendAcrossDevicesTest : public ClientServerChannelTestCase<CudaBuffer> {
  private:
   void server(std::shared_ptr<transport::Connection> conn) override {
     std::shared_ptr<CudaContext> ctx = this->helper_->makeContext("server");
-    auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
+    auto channel = ctx->createChannel({std::move(conn)}, Endpoint::kListen);
 
     // Send happens from device #0.
     TP_CUDA_CHECK(cudaSetDevice(0));
@@ -85,7 +85,7 @@ class SendAcrossDevicesTest : public ClientServerChannelTestCase<CudaBuffer> {
 
   void client(std::shared_ptr<transport::Connection> conn) override {
     std::shared_ptr<CudaContext> ctx = this->helper_->makeContext("client");
-    auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
+    auto channel = ctx->createChannel({std::move(conn)}, Endpoint::kConnect);
 
     // Recv happens on device #1.
     TP_CUDA_CHECK(cudaSetDevice(1));
@@ -146,7 +146,7 @@ class SendReverseAcrossDevicesTest
  private:
   void server(std::shared_ptr<transport::Connection> conn) override {
     std::shared_ptr<CudaContext> ctx = this->helper_->makeContext("server");
-    auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
+    auto channel = ctx->createChannel({std::move(conn)}, Endpoint::kListen);
 
     // Send happens from device #1.
     TP_CUDA_CHECK(cudaSetDevice(1));
@@ -199,7 +199,7 @@ class SendReverseAcrossDevicesTest
 
   void client(std::shared_ptr<transport::Connection> conn) override {
     std::shared_ptr<CudaContext> ctx = this->helper_->makeContext("client");
-    auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
+    auto channel = ctx->createChannel({std::move(conn)}, Endpoint::kConnect);
 
     // Recv happens on device #0.
     TP_CUDA_CHECK(cudaSetDevice(0));
@@ -260,7 +260,7 @@ class SendAcrossNonDefaultDevicesTest
  private:
   void server(std::shared_ptr<transport::Connection> conn) override {
     std::shared_ptr<CudaContext> ctx = this->helper_->makeContext("server");
-    auto channel = ctx->createChannel(std::move(conn), Endpoint::kListen);
+    auto channel = ctx->createChannel({std::move(conn)}, Endpoint::kListen);
 
     // Send happens from device #1.
     TP_CUDA_CHECK(cudaSetDevice(1));
@@ -313,7 +313,7 @@ class SendAcrossNonDefaultDevicesTest
 
   void client(std::shared_ptr<transport::Connection> conn) override {
     std::shared_ptr<CudaContext> ctx = this->helper_->makeContext("client");
-    auto channel = ctx->createChannel(std::move(conn), Endpoint::kConnect);
+    auto channel = ctx->createChannel({std::move(conn)}, Endpoint::kConnect);
 
     // Recv happens on device #1.
     TP_CUDA_CHECK(cudaSetDevice(1));


### PR DESCRIPTION
With this change, channel contexts define a `numConnectionsNeeded()` method, which is used by the Pipe to provide the requested number of control connections to the `createChannel()` call, which now takes a vector of connections as argument.
This change is needed in order to introduce a CUDA host memory allocator in CudaBasic to avoid costly `cudaMallocHost()`/`cudaFreeHost()` calls (which can hang under certain circumstances).

The changes in actual channels are all the same: forwarding the `numConnectionsNeeded()` call to the impl. The changes to the tests are all the same: wrapping the (single) connection passed to `createChannel()` into a vector. The main changes are in core/pipe_impl.{h,cc}, core/nop_types.h, channel/context.h, channel/context_impl_boilerplate.h.