### PR TITLE
Make pipes and listeners share loop with context

### DIFF
--- a/tensorpipe/common/callback.h
+++ b/tensorpipe/common/callback.h
@@ -37,15 +37,13 @@ namespace tensorpipe {
 //   to the shared_ptr to make sure the object doesn't get destroyed while the
 //   callable is running.
 template <typename TSubject, typename TBoundFn>
-auto runIfAlive(
-    std::enable_shared_from_this<TSubject>& subject,
-    TBoundFn&& fn) {
+auto runIfAlive(std::enable_shared_from_this<TSubject>& subject, TBoundFn fn) {
   // In C++17 use weak_from_this().
   return [weak{std::weak_ptr<TSubject>(subject.shared_from_this())},
           fn{std::move(fn)}](auto&&... args) mutable {
     std::shared_ptr<TSubject> shared = weak.lock();
     if (shared) {
-      fn(*shared, std::forward<decltype(args)>(args)...);
+      fn(std::move(shared), std::forward<decltype(args)>(args)...);
     }
   };
 }
@@ -128,13 +126,15 @@ class LazyCallbackWrapper {
       : subject_(subject), loop_(loop) {}
 
   template <typename TBoundFn>
-  auto operator()(TBoundFn&& fn) {
+  auto operator()(TBoundFn fn) {
     return runIfAlive(
         subject_,
         [this, fn{std::move(fn)}](
-            TSubject& subject, const Error& error, auto&&... args) mutable {
+            std::shared_ptr<TSubject> subject,
+            const Error& error,
+            auto&&... args) mutable {
           this->entryPoint(
-              subject,
+              std::move(subject),
               std::move(fn),
               error,
               std::forward<decltype(args)>(args)...);
@@ -147,15 +147,19 @@ class LazyCallbackWrapper {
 
   template <typename TBoundFn, typename... Args>
   void entryPoint(
-      TSubject& subject,
-      TBoundFn&& fn,
+      std::shared_ptr<TSubject> subject,
+      TBoundFn fn,
       const Error& error,
       Args&&... args) {
+    // Do *NOT* move subject into the lambda's closure, as the shared_ptr we're
+    // holding may be the last one keeping subject alive, in which case it would
+    // die once the lambda runs, and it might kill the loop in turn too, _while_
+    // the loop's deferToLoop method is running. And that's bad.
     // FIXME We're copying the args here...
     loop_.deferToLoop(
-        [this, &subject, fn{std::move(fn)}, error, args...]() mutable {
+        [this, subject, fn{std::move(fn)}, error{error}, args...]() mutable {
           entryPointFromLoop(
-              subject, std::move(fn), error, std::forward<Args>(args)...);
+              *subject, std::move(fn), error, std::forward<Args>(args)...);
         });
   }
 
@@ -193,11 +197,11 @@ class EagerCallbackWrapper {
       : subject_(subject), loop_(loop) {}
 
   template <typename TBoundFn>
-  auto operator()(TBoundFn&& fn) {
+  auto operator()(TBoundFn fn) {
     return [this, subject{subject_.shared_from_this()}, fn{std::move(fn)}](
                const Error& error, auto&&... args) mutable {
       this->entryPoint(
-          *subject,
+          std::move(subject),
           std::move(fn),
           error,
           std::forward<decltype(args)>(args)...);
@@ -210,15 +214,19 @@ class EagerCallbackWrapper {
 
   template <typename TBoundFn, typename... Args>
   void entryPoint(
-      TSubject& subject,
-      TBoundFn&& fn,
+      std::shared_ptr<TSubject> subject,
+      TBoundFn fn,
       const Error& error,
       Args&&... args) {
+    // Do *NOT* move subject into the lambda's closure, as the shared_ptr we're
+    // holding may be the last one keeping subject alive, in which case it would
+    // die once the lambda runs, and it might kill the loop in turn too, _while_
+    // the loop's deferToLoop method is running. And that's bad.
     // FIXME We're copying the args here...
     loop_.deferToLoop(
-        [this, &subject, fn{std::move(fn)}, error, args...]() mutable {
+        [this, subject, fn{std::move(fn)}, error{error}, args...]() mutable {
           entryPointFromLoop(
-              subject, std::move(fn), error, std::forward<Args>(args)...);
+              *subject, std::move(fn), error, std::forward<Args>(args)...);
         });
   }
 
@@ -294,7 +302,9 @@ class ClosingReceiver {
     token_ = reinterpret_cast<uint64_t>(&subject);
     TP_DCHECK_GT(token_, 0);
     emitter_->subscribe(
-        token_, runIfAlive(subject, [](T& subject) { subject.close(); }));
+        token_, runIfAlive(subject, [](std::shared_ptr<T> subject) {
+          subject->close();
+        }));
   }
 
   ~ClosingReceiver() {

--- a/tensorpipe/core/context_impl.cc
+++ b/tensorpipe/core/context_impl.cc
@@ -205,6 +205,14 @@ const std::string& ContextImpl::getName() {
   return name_;
 }
 
+void ContextImpl::deferToLoop(TTask fn) {
+  loop_.deferToLoop(std::move(fn));
+}
+
+bool ContextImpl::inLoop() const {
+  return loop_.inLoop();
+}
+
 void ContextImpl::close() {
   if (!closed_.exchange(true)) {
     TP_VLOG(1) << "Context " << id_ << " is closing";

--- a/tensorpipe/core/context_impl.h
+++ b/tensorpipe/core/context_impl.h
@@ -29,7 +29,8 @@
 
 namespace tensorpipe {
 
-class ContextImpl final : public std::enable_shared_from_this<ContextImpl> {
+class ContextImpl final : public virtual DeferredExecutor,
+                          public std::enable_shared_from_this<ContextImpl> {
  public:
   explicit ContextImpl(ContextOptions opts);
 
@@ -85,11 +86,17 @@ class ContextImpl final : public std::enable_shared_from_this<ContextImpl> {
   // by the pipes and listener in order to attach it to logged messages.
   const std::string& getName();
 
+  // Implement DeferredExecutor interface.
+  void deferToLoop(TTask fn) override;
+  bool inLoop() const override;
+
   void close();
 
   void join();
 
  private:
+  OnDemandDeferredExecutor loop_;
+
   std::atomic<bool> closed_{false};
   std::atomic<bool> joined_{false};
 

--- a/tensorpipe/core/pipe_impl.h
+++ b/tensorpipe/core/pipe_impl.h
@@ -23,6 +23,7 @@
 #include <tensorpipe/common/optional.h>
 #include <tensorpipe/core/buffer.h>
 #include <tensorpipe/core/buffer_helpers.h>
+#include <tensorpipe/core/context_impl.h>
 #include <tensorpipe/core/message.h>
 #include <tensorpipe/core/nop_types.h>
 #include <tensorpipe/core/pipe.h>
@@ -133,8 +134,6 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
   void close();
 
  private:
-  OnDemandDeferredExecutor loop_;
-
   void initFromLoop();
 
   void readDescriptorFromLoop(read_descriptor_callback_fn fn);
@@ -232,8 +231,8 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
   // Helpers to prepare callbacks from transports and listener
   //
 
-  LazyCallbackWrapper<PipeImpl> lazyCallbackWrapper_{*this, this->loop_};
-  EagerCallbackWrapper<PipeImpl> eagerCallbackWrapper_{*this, this->loop_};
+  LazyCallbackWrapper<PipeImpl> lazyCallbackWrapper_{*this, *this->context_};
+  EagerCallbackWrapper<PipeImpl> eagerCallbackWrapper_{*this, *this->context_};
 
   //
   // Helpers to schedule our callbacks into user code

--- a/tensorpipe/transport/shm/connection_impl.cc
+++ b/tensorpipe/transport/shm/connection_impl.cc
@@ -85,20 +85,18 @@ void ConnectionImpl::initImplFromLoop() {
       << "Couldn't allocate ringbuffer for connection inbox: " << error.what();
 
   // Register method to be called when our peer writes to our inbox.
-  inboxReactorToken_ =
-      context_->addReaction(runIfAlive(*this, [](ConnectionImpl& impl) {
-        TP_VLOG(9) << "Connection " << impl.id_
-                   << " is reacting to the peer writing to the inbox";
-        impl.processReadOperationsFromLoop();
-      }));
+  inboxReactorToken_ = context_->addReaction([this]() {
+    TP_VLOG(9) << "Connection " << id_
+               << " is reacting to the peer writing to the inbox";
+    processReadOperationsFromLoop();
+  });
 
   // Register method to be called when our peer reads from our outbox.
-  outboxReactorToken_ =
-      context_->addReaction(runIfAlive(*this, [](ConnectionImpl& impl) {
-        TP_VLOG(9) << "Connection " << impl.id_
-                   << " is reacting to the peer reading from the outbox";
-        impl.processWriteOperationsFromLoop();
-      }));
+  outboxReactorToken_ = context_->addReaction([this]() {
+    TP_VLOG(9) << "Connection " << id_
+               << " is reacting to the peer reading from the outbox";
+    processWriteOperationsFromLoop();
+  });
 
   // We're sending file descriptors first, so wait for writability.
   state_ = SEND_FDS;


### PR DESCRIPTION
Summary:
This change is somewhat controversial. Each pipe is independent from each other (to some degree), and quite lightweight: all it does is bookkeeping, it doesn't own resources. The core context doesn't have its own thread(s), hence we use on-demand loops, and we used to have one per pipe (and per listener) so that they could all operate in parallel (provided there were enough "real" underlying event loop to power them).

However, pipes and listeners and their context do sometime interact, for example when initing and closing. And at those times, their lack of synchronization could cause problems. For example when the context would shutdown it would try to close in turn the listeners and the pipes, but this would just enqueue a close operation in their loops, which could be delayed and in the meantime they could attempt to execute another operation which might fail if it tried to access the context as it is already closed.

I'm not currently aware of any concrete issue of that type in the wild, but we did have similar real issues with transports and contexts when they followed a similar design. We since fixed those, by having their contexts immediately (synchronously) set their objects into error, and other such fixes. In this stack I want to do the same for the core context and pipes, and this diff is a prerequisite in order to be able to do so: it makes sure that _all_ pipes and listeners of a certain context use a _single_ shared on-demand loop.

The key upside of it is a greater ease of synchronization between objects. The downside is _potential_ worse performance as this centralized loop could act as a bottleneck. This is what's controversial about this diff. I'll try to argue for it in a couple of ways. First of all, the operations of pipes and listeners are so lightweight, that I would be surprised if we were bottlenecked by the fact that they cannot run in parallel: I'd expect the fraction of time spent in the pipe to be small compared to the one spent in transports and channels, where the real heavy lifting happens. Second, even if that were the case, here we'd be trading performance for correctness and safety, and that may still be a good exchange to make. Finally, if that really becomes a problem (in actual benchmarks), I think we could come up with ways to get the best of both worlds, although that would require some tricky design and implementation (think of a shared loop which however is not mutually exclusive, like a shared lock: pipes can acquire a read-only lock for tasks that can run in isolation, but a read-write lock for operations that involve the context).

Reviewed By: beauby

Differential Revision: D26172367

