### PR TITLE
Include PID namespace in XTH and CUDA XTH domain descriptor

### DIFF
--- a/tensorpipe/channel/cuda_xth/context_impl.cc
+++ b/tensorpipe/channel/cuda_xth/context_impl.cc
@@ -32,10 +32,13 @@ std::string generateDomainDescriptor() {
   auto bootID = getBootID();
   TP_THROW_ASSERT_IF(!bootID) << "Unable to read boot_id";
 
+  auto nsID = getLinuxNamespaceId(LinuxNamespace::kPid);
+  TP_THROW_ASSERT_IF(!nsID) << "Unable to read PID namespace ID";
+
   pid_t pid = getpid();
 
-  // Combine boot ID and PID.
-  oss << bootID.value() << "-" << pid;
+  // Combine boot ID, namespace ID and PID.
+  oss << bootID.value() << "-" << nsID.value() << "-" << pid;
 
   return oss.str();
 }

--- a/tensorpipe/channel/mpt/context_impl.cc
+++ b/tensorpipe/channel/mpt/context_impl.cc
@@ -45,9 +45,20 @@ std::string generateDomainDescriptor(
 std::shared_ptr<ContextImpl> ContextImpl::create(
     std::vector<std::shared_ptr<transport::Context>> contexts,
     std::vector<std::shared_ptr<transport::Listener>> listeners) {
+  for (const auto& context : contexts) {
+    if (!context->isViable()) {
+      return std::make_shared<ContextImpl>();
+    }
+  }
+
   return std::make_shared<ContextImpl>(
       std::move(contexts), std::move(listeners));
 }
+
+ContextImpl::ContextImpl()
+    : ContextImplBoilerplate<CpuBuffer, ContextImpl, ChannelImpl>(
+          /*isViable=*/false,
+          /*domainDescriptor=*/"") {}
 
 ContextImpl::ContextImpl(
     std::vector<std::shared_ptr<transport::Context>> contexts,

--- a/tensorpipe/channel/mpt/context_impl.h
+++ b/tensorpipe/channel/mpt/context_impl.h
@@ -37,6 +37,8 @@ class ContextImpl final
       std::vector<std::shared_ptr<transport::Context>> contexts,
       std::vector<std::shared_ptr<transport::Listener>> listeners);
 
+  ContextImpl();
+
   ContextImpl(
       std::vector<std::shared_ptr<transport::Context>> contexts,
       std::vector<std::shared_ptr<transport::Listener>> listeners);

--- a/tensorpipe/channel/xth/context_impl.cc
+++ b/tensorpipe/channel/xth/context_impl.cc
@@ -33,10 +33,13 @@ std::string generateDomainDescriptor() {
   auto bootID = getBootID();
   TP_THROW_ASSERT_IF(!bootID) << "Unable to read boot_id";
 
+  auto nsID = getLinuxNamespaceId(LinuxNamespace::kPid);
+  TP_THROW_ASSERT_IF(!nsID) << "Unable to read PID namespace ID";
+
   pid_t pid = getpid();
 
-  // Combine boot ID and PID.
-  oss << bootID.value() << "-" << pid;
+  // Combine boot ID, namespace ID and PID.
+  oss << bootID.value() << "-" << nsID.value() << "-" << pid;
 
   return oss.str();
 }

--- a/tensorpipe/common/system.cc
+++ b/tensorpipe/common/system.cc
@@ -145,7 +145,17 @@ optional<std::string> getBootID() {
   return bootID;
 }
 
-#ifdef __linux__
+#ifdef __APPLE__
+
+// OSX is a UNIX, so often we'd like some of our Linux backends to work there
+// too, but its lack of support for namespaces poses issues. However, that's
+// like saying that in OSX all processes are in the same namespace with respect
+// to all resources, so we pretend namespaces are supported, with a constant ID.
+optional<std::string> getLinuxNamespaceId(LinuxNamespace ns) {
+  return std::string();
+}
+
+#elif defined(__linux__)
 
 // According to namespaces(7):
 // > Each process has a /proc/[pid]/ns/ subdirectory containing one entry for


### PR DESCRIPTION
Summary: Another bug fix: XTH and CUDA_XTH include a PID in their domain descriptor, but this can only be compared with other PIDs if the PID namespace matches.

Reviewed By: beauby

Differential Revision: D26102739

