### PR TITLE
init listener impl boilerplate with runInLoop

### DIFF
--- a/tensorpipe/transport/listener_impl_boilerplate.h
+++ b/tensorpipe/transport/listener_impl_boilerplate.h
@@ -128,7 +128,7 @@ ListenerImplBoilerplate<TCtx, TList, TConn>::ListenerImplBoilerplate(
 
 template <typename TCtx, typename TList, typename TConn>
 void ListenerImplBoilerplate<TCtx, TList, TConn>::init() {
-  context_->deferToLoop(
+  context_->runInLoop(
       [impl{this->shared_from_this()}]() { impl->initFromLoop(); });
 }
 


### PR DESCRIPTION
This fixes a bug in core/listener_impl.cc where:
context->listen(address) does a deferred init of the listener, but listener->addr()) 2 lines down does a runInLoop addr() on the same listener. When this is run from within the loop itself, init will be deferred but addr will be called immediately. addr will then throw an exception since listener has not been initialized.
This fix simply makes init use runInLoop too, which makes it initialize immediately when run from within the loop.
Note that the code usually works since new listeners are usually not created from within the loop, but I don't see why this should not be allowed