### PR TITLE
Change CUDA library name to libcuda.so.1

### DIFF
--- a/tensorpipe/common/cuda_lib.h
+++ b/tensorpipe/common/cuda_lib.h
@@ -84,7 +84,7 @@ class CudaLib {
     // through this handle and are not exposed (a.k.a., "leaked") to other
     // shared objects.
     std::tie(error, dlhandle) =
-        createDynamicLibraryHandle("libcuda.so", RTLD_LOCAL | RTLD_LAZY);
+        createDynamicLibraryHandle("libcuda.so.1", RTLD_LOCAL | RTLD_LAZY);
     if (error) {
       return std::make_tuple(std::move(error), CudaLib());
     }


### PR DESCRIPTION
`libcuda.so` is likely to be missing on the system that do not have CUDA toolkit.
Unversioned `.so` symblinks are only supposed to be used by the linker to point to a versioned library, for example:
```
$ printf "#include <cuda.h>\nint main() { return cuInit(0); }"|gcc -x c - -lcuda; ldd -r ./a.out |grep libcuda
	libcuda.so.1 => /lib64/libcuda.so.1 (0x00007ffb0be91000)
```

This may partially address https://github.com/pytorch/tensorpipe/issues/294 and https://github.com/pytorch/pytorch/issues/52137