### PR TITLE
Make CUDA multi-device tests harder

### DIFF
--- a/tensorpipe/channel/cma/context_impl.cc
+++ b/tensorpipe/channel/cma/context_impl.cc
@@ -22,6 +22,7 @@
 
 #include <tensorpipe/channel/cma/channel_impl.h>
 #include <tensorpipe/common/defs.h>
+#include <tensorpipe/common/strings.h>
 #include <tensorpipe/common/system.h>
 
 namespace tensorpipe {
@@ -49,18 +50,6 @@ bool isProcessVmReadvSyscallAllowed() {
   };
   ssize_t nread = ::process_vm_readv(::getpid(), &target, 1, &source, 1, 0);
   return nread == sizeof(uint64_t) && someTargetValue == someSourceValue;
-}
-
-std::string joinStrs(const std::vector<std::string>& strs) {
-  if (strs.empty()) {
-    return "";
-  }
-  std::ostringstream oss;
-  oss << strs[0];
-  for (size_t idx = 1; idx < strs.size(); idx++) {
-    oss << ", " << strs[idx];
-  }
-  return oss.str();
 }
 
 } // namespace

--- a/tensorpipe/channel/cuda_basic/channel_impl.cc
+++ b/tensorpipe/channel/cuda_basic/channel_impl.cc
@@ -46,15 +46,20 @@ void ChannelImpl::sendImplFromLoop(
     CudaBuffer buffer,
     TDescriptorCallback descriptorCallback,
     TSendCallback callback) {
+  int deviceIdx = cudaDeviceForPointer(context_->getCudaLib(), buffer.ptr);
+
   TP_VLOG(5) << "Channel " << id_ << " is copying buffer #" << sequenceNumber
              << " from CUDA device to CPU";
-  auto tmpBuffer = makeCudaPinnedBuffer(buffer.length);
-  TP_CUDA_CHECK(cudaMemcpyAsync(
-      tmpBuffer.get(),
-      buffer.ptr,
-      buffer.length,
-      cudaMemcpyDeviceToHost,
-      buffer.stream));
+  auto tmpBuffer = makeCudaPinnedBuffer(buffer.length, deviceIdx);
+  {
+    CudaDeviceGuard guard(deviceIdx);
+    TP_CUDA_CHECK(cudaMemcpyAsync(
+        tmpBuffer.get(),
+        buffer.ptr,
+        buffer.length,
+        cudaMemcpyDeviceToHost,
+        buffer.stream));
+  }
 
   sendOperations_.emplace_back();
   auto& op = sendOperations_.back();
@@ -111,7 +116,9 @@ void ChannelImpl::recvImplFromLoop(
     TDescriptor descriptor,
     CudaBuffer buffer,
     TRecvCallback callback) {
-  auto tmpBuffer = makeCudaPinnedBuffer(buffer.length);
+  int deviceIdx = cudaDeviceForPointer(context_->getCudaLib(), buffer.ptr);
+
+  auto tmpBuffer = makeCudaPinnedBuffer(buffer.length, deviceIdx);
   CpuBuffer cpuBuffer{tmpBuffer.get(), buffer.length};
 
   TP_VLOG(6) << "Channel " << id_ << " is receiving buffer #" << sequenceNumber
@@ -121,19 +128,25 @@ void ChannelImpl::recvImplFromLoop(
       cpuBuffer,
       callbackWrapper_([sequenceNumber,
                         buffer,
+                        deviceIdx,
                         tmpBuffer{std::move(tmpBuffer)},
                         callback{std::move(callback)}](
                            ChannelImpl& impl) mutable {
         TP_VLOG(5) << "Channel " << impl.id_ << " is done receiving buffer #"
                    << sequenceNumber << " through CPU channel";
         impl.onCpuChannelRecv(
-            sequenceNumber, buffer, std::move(tmpBuffer), std::move(callback));
+            sequenceNumber,
+            buffer,
+            deviceIdx,
+            std::move(tmpBuffer),
+            std::move(callback));
       }));
 }
 
 void ChannelImpl::onCpuChannelRecv(
     uint64_t sequenceNumber,
     CudaBuffer buffer,
+    int deviceIdx,
     CudaPinnedBuffer tmpBuffer,
     TRecvCallback callback) {
   if (error_) {
@@ -143,12 +156,15 @@ void ChannelImpl::onCpuChannelRecv(
 
   TP_VLOG(5) << "Channel " << id_ << " is copying buffer #" << sequenceNumber
              << " from CPU to CUDA device";
-  TP_CUDA_CHECK(cudaMemcpyAsync(
-      buffer.ptr,
-      tmpBuffer.get(),
-      buffer.length,
-      cudaMemcpyHostToDevice,
-      buffer.stream));
+  {
+    CudaDeviceGuard guard(deviceIdx);
+    TP_CUDA_CHECK(cudaMemcpyAsync(
+        buffer.ptr,
+        tmpBuffer.get(),
+        buffer.length,
+        cudaMemcpyHostToDevice,
+        buffer.stream));
+  }
 
   // Keep tmpBuffer alive until cudaMemcpyAsync is done.
   cudaLoop_.addCallback(

--- a/tensorpipe/channel/cuda_basic/channel_impl.h
+++ b/tensorpipe/channel/cuda_basic/channel_impl.h
@@ -68,6 +68,7 @@ class ChannelImpl final
   void onCpuChannelRecv(
       uint64_t sequenceNumber,
       CudaBuffer buffer,
+      int deviceIdx,
       CudaPinnedBuffer tmpBuffer,
       TRecvCallback callback);
 };

--- a/tensorpipe/channel/cuda_xth/channel_impl.cc
+++ b/tensorpipe/channel/cuda_xth/channel_impl.cc
@@ -40,12 +40,15 @@ class SendOperation {
     startEv_.wait(dstBuffer.stream, dstDeviceIdx);
 
     TP_DCHECK_EQ(buffer_.length, dstBuffer.length);
-    TP_CUDA_CHECK(cudaMemcpyAsync(
-        dstBuffer.ptr,
-        buffer_.ptr,
-        dstBuffer.length,
-        cudaMemcpyDeviceToDevice,
-        dstBuffer.stream));
+    {
+      CudaDeviceGuard guard(dstDeviceIdx);
+      TP_CUDA_CHECK(cudaMemcpyAsync(
+          dstBuffer.ptr,
+          buffer_.ptr,
+          dstBuffer.length,
+          cudaMemcpyDeviceToDevice,
+          dstBuffer.stream));
+    }
 
     CudaEvent stopEv(dstDeviceIdx);
     stopEv.record(dstBuffer.stream);

--- a/tensorpipe/common/cuda.h
+++ b/tensorpipe/common/cuda.h
@@ -74,8 +74,9 @@ class CudaEvent {
   CudaEvent& operator=(const CudaEvent&) = delete;
   CudaEvent& operator=(CudaEvent&&) = delete;
 
-  explicit CudaEvent(int device, bool interprocess = false) {
-    CudaDeviceGuard guard(device);
+  explicit CudaEvent(int device, bool interprocess = false)
+      : deviceIdx_(device) {
+    CudaDeviceGuard guard(deviceIdx_);
     int flags = cudaEventDisableTiming;
     if (interprocess) {
       flags |= cudaEventInterprocess;
@@ -83,13 +84,15 @@ class CudaEvent {
     TP_CUDA_CHECK(cudaEventCreateWithFlags(&ev_, flags));
   }
 
-  explicit CudaEvent(int device, cudaIpcEventHandle_t handle) {
+  explicit CudaEvent(int device, cudaIpcEventHandle_t handle)
+      : deviceIdx_(device) {
     // It could crash if we don't set device when creating events from handles
-    CudaDeviceGuard guard(device);
+    CudaDeviceGuard guard(deviceIdx_);
     TP_CUDA_CHECK(cudaIpcOpenEventHandle(&ev_, handle));
   }
 
   void record(cudaStream_t stream) {
+    CudaDeviceGuard guard(deviceIdx_);
     TP_CUDA_CHECK(cudaEventRecord(ev_, stream));
   }
 
@@ -99,6 +102,7 @@ class CudaEvent {
   }
 
   bool query() const {
+    CudaDeviceGuard guard(deviceIdx_);
     cudaError_t res = cudaEventQuery(ev_);
     if (res == cudaErrorNotReady) {
       return false;
@@ -108,6 +112,7 @@ class CudaEvent {
   }
 
   std::string serializedHandle() {
+    CudaDeviceGuard guard(deviceIdx_);
     cudaIpcEventHandle_t handle;
     TP_CUDA_CHECK(cudaIpcGetEventHandle(&handle, ev_));
 
@@ -115,11 +120,13 @@ class CudaEvent {
   }
 
   ~CudaEvent() {
+    CudaDeviceGuard guard(deviceIdx_);
     TP_CUDA_CHECK(cudaEventDestroy(ev_));
   }
 
  private:
   cudaEvent_t ev_;
+  int deviceIdx_;
 };
 
 inline int cudaDeviceForPointer(const CudaLib& cudaLib, const void* ptr) {
@@ -137,26 +144,29 @@ inline int cudaDeviceForPointer(const CudaLib& cudaLib, const void* ptr) {
   TP_CUDA_DRIVER_CHECK(cudaLib, cudaLib.ctxGetCurrent(&ctx));
   TP_CUDA_DRIVER_CHECK(cudaLib, cudaLib.ctxSetCurrent(nullptr));
 
-  cudaPointerAttributes attrs;
-  TP_CUDA_CHECK(cudaPointerGetAttributes(&attrs, ptr));
-#if (CUDART_VERSION >= 10000)
-  TP_DCHECK_EQ(cudaMemoryTypeDevice, attrs.type);
-#else
-  TP_DCHECK_EQ(cudaMemoryTypeDevice, attrs.memoryType);
-#endif
+  int deviceIdx;
+  TP_CUDA_DRIVER_CHECK(
+      cudaLib,
+      cudaLib.pointerGetAttribute(
+          &deviceIdx,
+          CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL,
+          reinterpret_cast<CUdeviceptr>(ptr)));
 
   TP_CUDA_DRIVER_CHECK(cudaLib, cudaLib.ctxSetCurrent(ctx));
-  return attrs.device;
+  return deviceIdx;
 }
 
 using CudaPinnedBuffer = std::shared_ptr<uint8_t>;
 
-inline CudaPinnedBuffer makeCudaPinnedBuffer(size_t length) {
+inline CudaPinnedBuffer makeCudaPinnedBuffer(size_t length, int deviceIdx) {
+  CudaDeviceGuard guard(deviceIdx);
   void* ptr;
   TP_CUDA_CHECK(cudaMallocHost(&ptr, length));
-  return CudaPinnedBuffer(reinterpret_cast<uint8_t*>(ptr), [](uint8_t* ptr) {
-    TP_CUDA_CHECK(cudaFreeHost(ptr));
-  });
+  return CudaPinnedBuffer(
+      reinterpret_cast<uint8_t*>(ptr), [deviceIdx](uint8_t* ptr) {
+        CudaDeviceGuard guard(deviceIdx);
+        TP_CUDA_CHECK(cudaFreeHost(ptr));
+      });
 }
 
 inline std::vector<std::string> getUuidsOfVisibleDevices(

--- a/tensorpipe/common/nvml_lib.h
+++ b/tensorpipe/common/nvml_lib.h
@@ -30,11 +30,19 @@ namespace tensorpipe {
 // Master list of all symbols we care about from libnvidia-ml.
 
 #define TP_FORALL_NVML_SYMBOLS(_)                                             \
+  _(deviceGetComputeRunningProcesses,                                         \
+    nvmlDeviceGetComputeRunningProcesses,                                     \
+    nvmlReturn_t,                                                             \
+    (nvmlDevice_t, unsigned int*, nvmlProcessInfo_t*))                        \
   _(deviceGetCount_v2, nvmlDeviceGetCount_v2, nvmlReturn_t, (unsigned int*))  \
   _(deviceGetHandleByIndex_v2,                                                \
     nvmlDeviceGetHandleByIndex_v2,                                            \
     nvmlReturn_t,                                                             \
     (unsigned int, nvmlDevice_t*))                                            \
+  _(deviceGetHandleByUUID,                                                    \
+    nvmlDeviceGetHandleByUUID,                                                \
+    nvmlReturn_t,                                                             \
+    (const char*, nvmlDevice_t*))                                             \
   _(deviceGetP2PStatus,                                                       \
     nvmlDeviceGetP2PStatus,                                                   \
     nvmlReturn_t,                                                             \

--- a/tensorpipe/common/strings.h
+++ b/tensorpipe/common/strings.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace tensorpipe {
+
+inline std::string joinStrs(const std::vector<std::string>& strs) {
+  if (strs.empty()) {
+    return "";
+  }
+  std::ostringstream oss;
+  oss << strs[0];
+  for (size_t idx = 1; idx < strs.size(); idx++) {
+    oss << ", " << strs[idx];
+  }
+  return oss.str();
+}
+
+template <typename T>
+std::string formatMatrix(const std::vector<std::vector<T>>& matrix) {
+  std::ostringstream oss;
+  oss << "{";
+  for (size_t rowIdx = 0; rowIdx < matrix.size(); rowIdx++) {
+    if (rowIdx > 0) {
+      oss << ", ";
+    }
+    oss << "{";
+    for (size_t colIdx = 0; colIdx < matrix[rowIdx].size(); colIdx++) {
+      if (colIdx > 0) {
+        oss << ", ";
+      }
+      oss << matrix[rowIdx][colIdx];
+    }
+    oss << "}";
+  }
+  oss << "}";
+  return oss.str();
+}
+
+// Since text manipulation is hard, let's use this to double-check our results.
+inline bool isValidUuid(const std::string& uuid) {
+  // Check it's in this format:
+  // aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+  // |0   |5   |10  |15  |20  |25  |30  |35
+  if (uuid.size() != 36) {
+    return false;
+  }
+  for (int i = 0; i < uuid.size(); i++) {
+    if (i == 8 || i == 13 || i == 18 || i == 23) {
+      if (uuid[i] != '-') {
+        return false;
+      }
+    } else {
+      if (!((uuid[i] >= '0' && uuid[i] <= '9') ||
+            (uuid[i] >= 'a' && uuid[i] <= 'f'))) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+} // namespace tensorpipe

--- a/tensorpipe/test/channel/channel_test_cuda_multi_gpu.cc
+++ b/tensorpipe/test/channel/channel_test_cuda_multi_gpu.cc
@@ -12,6 +12,7 @@
 #include <tensorpipe/channel/cuda_context.h>
 #include <tensorpipe/common/cuda.h>
 #include <tensorpipe/test/channel/channel_test.h>
+#include <tensorpipe/test/channel/cuda_helpers.h>
 #include <tensorpipe/test/test_environment.h>
 
 using namespace tensorpipe;
@@ -81,6 +82,12 @@ class SendAcrossDevicesTest : public ClientServerChannelTestCase<CudaBuffer> {
     this->peers_->join(PeerGroup::kServer);
 
     ctx->join();
+
+    if (this->peers_->endpointsInSameProcess()) {
+      EXPECT_TRUE(openCudaContexts({0, 1}));
+    } else {
+      EXPECT_TRUE(openCudaContexts({0}));
+    }
   }
 
   void client(std::shared_ptr<transport::Connection> conn) override {
@@ -125,6 +132,12 @@ class SendAcrossDevicesTest : public ClientServerChannelTestCase<CudaBuffer> {
     this->peers_->join(PeerGroup::kClient);
 
     ctx->join();
+
+    if (this->peers_->endpointsInSameProcess()) {
+      EXPECT_TRUE(openCudaContexts({0, 1}));
+    } else {
+      EXPECT_TRUE(openCudaContexts({1}));
+    }
   }
 };
 
@@ -195,6 +208,12 @@ class SendReverseAcrossDevicesTest
     this->peers_->join(PeerGroup::kServer);
 
     ctx->join();
+
+    if (this->peers_->endpointsInSameProcess()) {
+      EXPECT_TRUE(openCudaContexts({0, 1}));
+    } else {
+      EXPECT_TRUE(openCudaContexts({1}));
+    }
   }
 
   void client(std::shared_ptr<transport::Connection> conn) override {
@@ -239,6 +258,12 @@ class SendReverseAcrossDevicesTest
     this->peers_->join(PeerGroup::kClient);
 
     ctx->join();
+
+    if (this->peers_->endpointsInSameProcess()) {
+      EXPECT_TRUE(openCudaContexts({0, 1}));
+    } else {
+      EXPECT_TRUE(openCudaContexts({0}));
+    }
   }
 };
 
@@ -309,6 +334,8 @@ class SendAcrossNonDefaultDevicesTest
     this->peers_->join(PeerGroup::kServer);
 
     ctx->join();
+
+    EXPECT_TRUE(openCudaContexts({1}));
   }
 
   void client(std::shared_ptr<transport::Connection> conn) override {
@@ -353,6 +380,8 @@ class SendAcrossNonDefaultDevicesTest
     this->peers_->join(PeerGroup::kClient);
 
     ctx->join();
+
+    EXPECT_TRUE(openCudaContexts({1}));
   }
 };
 

--- a/tensorpipe/test/channel/cuda_helpers.h
+++ b/tensorpipe/test/channel/cuda_helpers.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstdlib>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <tensorpipe/common/cuda.h>
+#include <tensorpipe/common/cuda_lib.h>
+#include <tensorpipe/common/nvml_lib.h>
+
+namespace tensorpipe {
+
+inline bool isContextOpenOnDevice(const NvmlLib& nvmlLib, nvmlDevice_t device) {
+  unsigned int count = 0;
+  std::vector<nvmlProcessInfo_t> processInfos;
+  while (true) {
+    nvmlReturn_t res = nvmlLib.deviceGetComputeRunningProcesses(
+        device, &count, processInfos.data());
+    processInfos.resize(count);
+    if (res == NVML_SUCCESS) {
+      break;
+    }
+    if (res == NVML_ERROR_INSUFFICIENT_SIZE) {
+      continue;
+    }
+    TP_NVML_CHECK(nvmlLib, res);
+  }
+
+  pid_t myPid = ::getpid();
+  for (const nvmlProcessInfo_t& processInfo : processInfos) {
+    if (processInfo.pid == myPid) {
+      return true;
+    }
+  }
+  return false;
+}
+
+inline ::testing::AssertionResult openCudaContexts(
+    const std::vector<int>& expectedDeviceIndices) {
+  // This check won't work when the test is running in a PID namespace, as NVML
+  // will return the PIDs in the root namespace but it doesn't seem possible for
+  // us to map them back to our namespace. Hence we use an env var to allow to
+  // disable this check in such environments.
+  char* shouldSkip = std::getenv("TP_SKIP_CHECK_OPEN_CUDA_CTXS");
+  if (shouldSkip != nullptr) {
+    return ::testing::AssertionSuccess();
+  }
+
+  Error error;
+  CudaLib cudaLib;
+  std::tie(error, cudaLib) = CudaLib::create();
+  TP_THROW_ASSERT_IF(error) << error.what();
+  NvmlLib nvmlLib;
+  std::tie(error, nvmlLib) = NvmlLib::create();
+  TP_THROW_ASSERT_IF(error) << error.what();
+
+  std::vector<std::string> uuids = getUuidsOfVisibleDevices(cudaLib);
+  for (int deviceIdx = 0; deviceIdx < uuids.size(); deviceIdx++) {
+    // NVML uses a different format for UUIDs.
+    std::string nvmlUuid = "GPU-" + uuids[deviceIdx];
+    nvmlDevice_t nvmlDevice;
+    TP_NVML_CHECK(
+        nvmlLib, nvmlLib.deviceGetHandleByUUID(nvmlUuid.c_str(), &nvmlDevice));
+    bool actualHasCtx = isContextOpenOnDevice(nvmlLib, nvmlDevice);
+
+    bool expectedHasCtx = std::find(
+                              expectedDeviceIndices.begin(),
+                              expectedDeviceIndices.end(),
+                              deviceIdx) != expectedDeviceIndices.end();
+
+    if (actualHasCtx && !expectedHasCtx) {
+      return ::testing::AssertionFailure()
+          << "a CUDA context was initialized on device #" << deviceIdx
+          << " but that shouldn't have happened";
+    }
+    if (!actualHasCtx && expectedHasCtx) {
+      return ::testing::AssertionFailure()
+          << "a CUDA context should have been initialized on device #"
+          << deviceIdx << " but that didn't happen";
+    }
+  }
+  return ::testing::AssertionSuccess();
+}
+
+} // namespace tensorpipe

--- a/tensorpipe/test/peer_group.h
+++ b/tensorpipe/test/peer_group.h
@@ -36,6 +36,10 @@ class PeerGroup {
   // Spawn two peers each running one of the provided functions.
   virtual void spawn(std::function<void()>, std::function<void()>) = 0;
 
+  // Whether the two endpoints are two threads in the same process (as opposed
+  // to two separate processes).
+  virtual bool endpointsInSameProcess() const = 0;
+
   // Signal other peers that this peer is done.
   void done(int selfId) {
     send(1 - selfId, doneString_);
@@ -83,6 +87,10 @@ class ThreadPeerGroup : public PeerGroup {
     for (auto& t : ts) {
       t.join();
     }
+  }
+
+  bool endpointsInSameProcess() const override {
+    return true;
   }
 
  private:
@@ -202,6 +210,10 @@ class ProcessPeerGroup : public PeerGroup {
       const int exitStatus = WEXITSTATUS(status);
       EXPECT_EQ(0, exitStatus);
     }
+  }
+
+  bool endpointsInSameProcess() const override {
+    return false;
   }
 
  private:


### PR DESCRIPTION
Summary: Originally, some of the device guards I added in an earlier diff weren't in fact necessary, which I found odd. Then I realized the tests would actually leave the current device set when calling TensorPipe. This doesn't have to be the case, so I changed the tests to reset the current device to 0, and that did it: now every CUDA call needed a guard.

Differential Revision: D26449415

