### PR TITLE
Fix synchronization in CUDA tests.

### DIFF
--- a/tensorpipe/test/channel/channel_test.h
+++ b/tensorpipe/test/channel/channel_test.h
@@ -74,7 +74,8 @@ class DataWrapper<tensorpipe::CudaBuffer> {
 
   explicit DataWrapper(std::vector<uint8_t> v) : DataWrapper(v.size()) {
     if (length_ > 0) {
-      TP_CUDA_CHECK(cudaMemcpy(cudaPtr_, v.data(), length_, cudaMemcpyDefault));
+      TP_CUDA_CHECK(cudaMemcpyAsync(
+          cudaPtr_, v.data(), length_, cudaMemcpyDefault, stream_));
     }
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #303 Optimize pinned memory allocation in CudaBasic.
* **#302 Fix synchronization in CUDA tests.**
* #289 Add control connection for CudaBasic.
* #288 Refactor channel client-server tests.
* #287 Rewrite domainDescriptor test.

For "generic" channel tests, we wrap an std::vector into a
tensorpipe::CudaBuffer by allocating a CUDA buffer of the same size
and calling cudaMemcpy(). We also create a non-blocking stream for
this buffer's use.
The issue here is that the stream being non-blocking, it can advance
before the copy actually starts, which manifested in the following
diff. Replacing the cudaMemcpy with a cudaMemcpyAsync enqueued on the
stream fixes the issue, and corresponds to the intended use of CUDA
buffers in TensorPipe. I am not certain why it hasn't manifested in
tests for other CUDA channels though.

Differential Revision: [D26575582](https://our.internmc.facebook.com/intern/diff/D26575582)