### PR TITLE
Optimize pinned memory allocation in CudaBasic.

### DIFF
--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -85,6 +85,7 @@ if(TP_USE_CUDA)
     channel/cuda_basic/channel_impl.cc
     channel/cuda_basic/context_impl.cc
     channel/cuda_basic/factory.cc
+    common/cuda_host_allocator.cc
     common/cuda_loop.cc)
 
   ### cuda_ipc

--- a/tensorpipe/channel/cuda_basic/channel_impl.cc
+++ b/tensorpipe/channel/cuda_basic/channel_impl.cc
@@ -137,7 +137,7 @@ void ChannelImpl::sendChunkThroughCpuChannel(Operation op) {
   // FIXME: Avoid copying the op twice.
   cpuChannel_->send(
       cpuBuffer,
-      callbackWrapper_([op](ChannelImpl& impl, std::string descriptor) {
+      callbackWrapper_([op](ChannelImpl& impl, std::string descriptor) mutable {
         if (impl.error_) {
           return;
         }

--- a/tensorpipe/channel/cuda_basic/channel_impl.cc
+++ b/tensorpipe/channel/cuda_basic/channel_impl.cc
@@ -156,6 +156,7 @@ void ChannelImpl::sendChunkDescriptor(Operation op, std::string descriptor) {
              << op.sequenceNumber;
   connection_->write(
       &descriptor[0],
+      descriptor.length(),
       callbackWrapper_([op{std::move(op)},
                         descriptor{std::move(descriptor)}](ChannelImpl& impl) {
         TP_VLOG(6) << "Channel " << impl.id_

--- a/tensorpipe/channel/cuda_basic/channel_impl.cc
+++ b/tensorpipe/channel/cuda_basic/channel_impl.cc
@@ -98,7 +98,7 @@ void ChannelImpl::sendImplFromLoop(
     cudaHostAllocator_.alloc(
         op.length,
         callbackWrapper_(
-            [&op](ChannelImpl& impl, std::shared_ptr<uint8_t[]> tmpBuffer) {
+            [&op](ChannelImpl& impl, std::unique_ptr<uint8_t[]> tmpBuffer) {
               TP_VLOG(5) << "Channel " << impl.id_
                          << " is done allocating temporary memory for chunk #"
                          << op.chunkId << " of " << op.numChunks
@@ -243,7 +243,7 @@ void ChannelImpl::onRecvOpReadDescriptor(
       op.length,
       callbackWrapper_(
           [&op, descriptor{std::move(descriptor)}](
-              ChannelImpl& impl, std::shared_ptr<uint8_t[]> tmpBuffer) mutable {
+              ChannelImpl& impl, std::unique_ptr<uint8_t[]> tmpBuffer) mutable {
             TP_VLOG(5) << "Channel " << impl.id_
                        << " is done allocating temporary memory for chunk #"
                        << op.chunkId << " of " << op.numChunks

--- a/tensorpipe/channel/cuda_basic/channel_impl.cc
+++ b/tensorpipe/channel/cuda_basic/channel_impl.cc
@@ -295,9 +295,10 @@ void ChannelImpl::onRecvOpReadyForCopy(Operation& op) {
         TP_VLOG(5) << "Channel " << impl.id_ << " is done copying chunk #"
                    << op.chunkId << " of " << op.numChunks << " for buffer #"
                    << op.sequenceNumber << " from CPU to CUDA device";
-        op.done = true;
-        impl.onRecvOpDone();
       }));
+
+  op.done = true;
+  impl.onRecvOpDone();
 }
 
 void ChannelImpl::onRecvOpDone() {

--- a/tensorpipe/channel/cuda_basic/channel_impl.cc
+++ b/tensorpipe/channel/cuda_basic/channel_impl.cc
@@ -291,7 +291,8 @@ void ChannelImpl::onRecvOpReadyForCopy(Operation& op) {
       op.length,
       deviceIdx,
       op.stream,
-      callbackWrapper_([&op](ChannelImpl& impl) {
+      // TODO: Avoid copying op.
+      callbackWrapper_([op](ChannelImpl& impl) {
         TP_VLOG(5) << "Channel " << impl.id_ << " is done copying chunk #"
                    << op.chunkId << " of " << op.numChunks << " for buffer #"
                    << op.sequenceNumber << " from CPU to CUDA device";

--- a/tensorpipe/channel/cuda_basic/channel_impl.cc
+++ b/tensorpipe/channel/cuda_basic/channel_impl.cc
@@ -19,6 +19,7 @@
 #include <tensorpipe/common/cuda.h>
 #include <tensorpipe/common/defs.h>
 #include <tensorpipe/common/error.h>
+#include <tensorpipe/transport/connection.h>
 
 namespace tensorpipe {
 namespace channel {
@@ -30,17 +31,34 @@ ChannelImpl::ChannelImpl(
     std::string id,
     std::shared_ptr<transport::Connection> connection,
     std::shared_ptr<CpuChannel> cpuChannel,
-    CudaLoop& cudaLoop)
+    CudaLoop& cudaLoop,
+    CudaHostAllocator& cudaHostAllocator)
     : ChannelImplBoilerplate<CudaBuffer, ContextImpl, ChannelImpl>(
           token,
           std::move(context),
           std::move(id)),
       connection_(std::move(connection)),
       cpuChannel_(std::move(cpuChannel)),
-      cudaLoop_(cudaLoop) {}
+      cudaLoop_(cudaLoop),
+      cudaHostAllocator_(cudaHostAllocator) {}
 
 void ChannelImpl::initImplFromLoop() {
   context_->enroll(*this);
+}
+
+void ChannelImpl::cudaCopy(
+    void* dst,
+    const void* src,
+    size_t length,
+    int deviceIdx,
+    cudaStream_t stream,
+    std::function<void(const Error&)> callback) {
+  {
+    CudaDeviceGuard guard(deviceIdx);
+    TP_CUDA_CHECK(cudaMemcpyAsync(dst, src, length, cudaMemcpyDefault, stream));
+  }
+
+  cudaLoop_.addCallback(deviceIdx, stream, std::move(callback));
 }
 
 void ChannelImpl::sendImplFromLoop(
@@ -48,68 +66,123 @@ void ChannelImpl::sendImplFromLoop(
     CudaBuffer buffer,
     TDescriptorCallback descriptorCallback,
     TSendCallback callback) {
-  int deviceIdx = cudaDeviceForPointer(context_->getCudaLib(), buffer.ptr);
+  const size_t chunkLength = cudaHostAllocator_.getChunkLength();
+  const size_t numChunks = (buffer.length + chunkLength - 1) / chunkLength;
+  for (size_t offset = 0; offset < buffer.length; offset += chunkLength) {
+    sendOperations_.emplace_back();
+    Operation& op = sendOperations_.back();
+    op.sequenceNumber = sequenceNumber;
+    op.chunkId = offset / chunkLength;
+    op.numChunks = numChunks;
+    op.stream = buffer.stream;
+    op.cudaPtr = static_cast<uint8_t*>(buffer.ptr) + offset;
+    op.length = std::min(buffer.length - offset, chunkLength);
+    // Operations are processed in order, so we can afford to trigger the
+    // callback once the last operation is done.
+    if (op.chunkId == numChunks - 1) {
+      op.callback = std::move(callback);
+    }
 
-  TP_VLOG(5) << "Channel " << id_ << " is copying buffer #" << sequenceNumber
-             << " from CUDA device to CPU";
-  auto tmpBuffer = makeCudaPinnedBuffer(buffer.length, deviceIdx);
-  {
-    CudaDeviceGuard guard(deviceIdx);
-    TP_CUDA_CHECK(cudaMemcpyAsync(
-        tmpBuffer.get(),
-        buffer.ptr,
-        buffer.length,
-        cudaMemcpyDeviceToHost,
-        buffer.stream));
+    TP_VLOG(6) << "Channel " << id_
+               << " is allocating temporary memory for chunk #" << op.chunkId
+               << " of " << op.numChunks << " for buffer #"
+               << op.sequenceNumber;
+    cudaHostAllocator_.alloc(
+        op.length,
+        callbackWrapper_(
+            [&op](ChannelImpl& impl, std::shared_ptr<uint8_t[]> tmpBuffer) {
+              TP_VLOG(6) << "Channel " << impl.id_
+                         << " is done allocating temporary memory for chunk #"
+                         << op.chunkId << " of " << op.numChunks
+                         << " for buffer #" << op.sequenceNumber;
+              op.tmpBuffer = std::move(tmpBuffer);
+              impl.onSendOpReadyForCopy(op);
+            }));
   }
 
-  sendOperations_.emplace_back();
-  auto& op = sendOperations_.back();
-  op.sequenceNumber = sequenceNumber;
-  op.tmpBuffer = std::move(tmpBuffer);
-  op.length = buffer.length;
-  op.descriptorCallback = std::move(descriptorCallback);
-  op.ready = false;
-
-  cudaLoop_.addCallback(
-      cudaDeviceForPointer(context_->getCudaLib(), buffer.ptr),
-      buffer.stream,
-      callbackWrapper_([&op](ChannelImpl& impl) {
-        TP_VLOG(5) << "Channel " << impl.id_ << " is done copying buffer #"
-                   << op.sequenceNumber << " from CUDA device to CPU";
-        op.ready = true;
-        impl.onTempBufferReadyForSend();
-      }));
-
-  callback(Error::kSuccess);
+  descriptorCallback(error_, std::string());
 }
 
-void ChannelImpl::onTempBufferReadyForSend() {
+void ChannelImpl::onSendOpReadyForCopy(Operation& op) {
+  if (error_) {
+    op.done = true;
+    onSendOpDone();
+    return;
+  }
+
+  TP_VLOG(6) << "Channel " << id_ << " is copying chunk #" << op.chunkId
+             << " of " << op.numChunks << " for buffer #" << op.sequenceNumber
+             << " from CUDA device to CPU";
+  int deviceIdx = cudaDeviceForPointer(context_->getCudaLib(), op.cudaPtr);
+  cudaCopy(
+      op.tmpBuffer.get(),
+      op.cudaPtr,
+      op.length,
+      deviceIdx,
+      op.stream,
+      callbackWrapper_([&op](ChannelImpl& impl) {
+        TP_VLOG(6) << "Channel " << impl.id_ << " is done copying chunk #"
+                   << op.chunkId << " of " << op.numChunks << " for buffer #"
+                   << op.sequenceNumber << " from CUDA device to CPU";
+        op.done = true;
+        impl.onSendOpDone();
+      }));
+}
+
+void ChannelImpl::sendChunkThroughCpuChannel(Operation op) {
+  TP_VLOG(6) << "Channel " << id_ << " is sending chunk #" << op.chunkId
+             << " of " << op.numChunks << " for buffer #" << op.sequenceNumber
+             << " through CPU channel";
+  CpuBuffer cpuBuffer{op.tmpBuffer.get(), op.length};
+  // FIXME: Avoid copying the op twice.
+  cpuChannel_->send(
+      cpuBuffer,
+      callbackWrapper_([op](ChannelImpl& impl, std::string descriptor) {
+        if (impl.error_) {
+          return;
+        }
+        impl.sendChunkDescriptor(std::move(op), std::move(descriptor));
+      }),
+      callbackWrapper_([op](ChannelImpl& impl) {
+        TP_VLOG(6) << "Channel " << impl.id_ << " is done sending chunk #"
+                   << op.chunkId << " of " << op.numChunks << " for buffer #"
+                   << op.sequenceNumber << " through CPU channel";
+      }));
+}
+
+void ChannelImpl::sendChunkDescriptor(Operation op, std::string descriptor) {
+  auto nopHolderOut = std::make_shared<NopHolder<std::string>>();
+  nopHolderOut->getObject() = std::move(descriptor);
+  TP_VLOG(6) << "Channel " << id_ << " is sending descriptor for chunk #"
+             << op.chunkId << " of " << op.numChunks << " for buffer #"
+             << op.sequenceNumber;
+  connection_->write(
+      *nopHolderOut,
+      callbackWrapper_([op{std::move(op)}, nopHolderOut](ChannelImpl& impl) {
+        TP_VLOG(6) << "Channel " << impl.id_
+                   << " is done sending descriptor for chunk #" << op.chunkId
+                   << " of " << op.numChunks << " for buffer #"
+                   << op.sequenceNumber;
+      }));
+}
+
+void ChannelImpl::onSendOpDone() {
   while (!sendOperations_.empty()) {
     auto& op = sendOperations_.front();
-    if (!op.ready) {
+    if (!op.done) {
       break;
     }
-
-    if (error_) {
-      op.descriptorCallback(error_, std::string());
-    } else {
-      CpuBuffer cpuBuffer{op.tmpBuffer.get(), op.length};
-      // Keep tmpBuffer alive until cpuChannel_ is done sending it over.
-      // TODO: This could be a lazy callback wrapper.
-      auto callback = callbackWrapper_(
-          [sequenceNumber{op.sequenceNumber},
-           tmpBuffer{std::move(op.tmpBuffer)}](ChannelImpl& impl) {
-            TP_VLOG(5) << "Channel " << impl.id_ << " is done sending buffer #"
-                       << sequenceNumber << " through CPU channel";
-          });
-      TP_VLOG(6) << "Channel " << id_ << " is sending buffer #"
-                 << op.sequenceNumber << " through CPU channel";
-      cpuChannel_->send(
-          cpuBuffer, std::move(op.descriptorCallback), std::move(callback));
+    if (op.callback) {
+      op.callback(error_);
     }
-
+    if (!error_) {
+      sendChunkThroughCpuChannel(std::move(op));
+    }
     sendOperations_.pop_front();
+  }
+
+  if (error_) {
+    tryCleanup();
   }
 }
 
@@ -118,77 +191,159 @@ void ChannelImpl::recvImplFromLoop(
     TDescriptor descriptor,
     CudaBuffer buffer,
     TRecvCallback callback) {
-  int deviceIdx = cudaDeviceForPointer(context_->getCudaLib(), buffer.ptr);
+  const size_t chunkLength = cudaHostAllocator_.getChunkLength();
+  const size_t numChunks = (buffer.length + chunkLength - 1) / chunkLength;
+  for (size_t offset = 0; offset < buffer.length; offset += chunkLength) {
+    recvOperations_.emplace_back();
+    Operation& op = recvOperations_.back();
+    op.sequenceNumber = sequenceNumber;
+    op.chunkId = offset / chunkLength;
+    op.numChunks = numChunks;
+    op.stream = buffer.stream;
+    op.cudaPtr = static_cast<uint8_t*>(buffer.ptr) + offset;
+    op.length = std::min(buffer.length - offset, chunkLength);
+    // Operations are processed in order, so we can afford to trigger the
+    // callback once the last operation is done.
+    if (op.chunkId == numChunks - 1) {
+      op.callback = std::move(callback);
+    }
 
-  auto tmpBuffer = makeCudaPinnedBuffer(buffer.length, deviceIdx);
-  CpuBuffer cpuBuffer{tmpBuffer.get(), buffer.length};
-
-  TP_VLOG(6) << "Channel " << id_ << " is receiving buffer #" << sequenceNumber
-             << " through CPU channel";
-  cpuChannel_->recv(
-      std::move(descriptor),
-      cpuBuffer,
-      callbackWrapper_([sequenceNumber,
-                        buffer,
-                        deviceIdx,
-                        tmpBuffer{std::move(tmpBuffer)},
-                        callback{std::move(callback)}](
-                           ChannelImpl& impl) mutable {
-        TP_VLOG(5) << "Channel " << impl.id_ << " is done receiving buffer #"
-                   << sequenceNumber << " through CPU channel";
-        impl.onCpuChannelRecv(
-            sequenceNumber,
-            buffer,
-            deviceIdx,
-            std::move(tmpBuffer),
-            std::move(callback));
-      }));
+    TP_VLOG(6) << "Channel " << id_ << " is reading descriptor for chunk #"
+               << op.chunkId << " of " << op.numChunks << " for buffer #"
+               << op.sequenceNumber;
+    auto nopHolderIn = std::make_shared<NopHolder<std::string>>();
+    connection_->read(
+        *nopHolderIn,
+        callbackWrapper_([nopHolderIn, &op](ChannelImpl& impl) mutable {
+          TP_VLOG(6) << "Channel " << impl.id_
+                     << " is done reading descriptor for chunk #" << op.chunkId
+                     << " of " << op.numChunks << " for buffer #"
+                     << op.sequenceNumber;
+          std::string& descriptor = nopHolderIn->getObject();
+          impl.onRecvOpReadDescriptor(op, std::move(descriptor));
+        }));
+  }
 }
 
-void ChannelImpl::onCpuChannelRecv(
-    uint64_t sequenceNumber,
-    CudaBuffer buffer,
-    int deviceIdx,
-    CudaPinnedBuffer tmpBuffer,
-    TRecvCallback callback) {
+void ChannelImpl::onRecvOpReadDescriptor(
+    Operation& op,
+    std::string descriptor) {
   if (error_) {
-    callback(error_);
+    op.done = true;
+    onRecvOpDone();
     return;
   }
 
-  TP_VLOG(5) << "Channel " << id_ << " is copying buffer #" << sequenceNumber
-             << " from CPU to CUDA device";
-  {
-    CudaDeviceGuard guard(deviceIdx);
-    TP_CUDA_CHECK(cudaMemcpyAsync(
-        buffer.ptr,
-        tmpBuffer.get(),
-        buffer.length,
-        cudaMemcpyHostToDevice,
-        buffer.stream));
+  TP_VLOG(6) << "Channel " << id_
+             << " is allocating temporary memory for chunk #" << op.chunkId
+             << " of " << op.numChunks << " for buffer #" << op.sequenceNumber;
+  cudaHostAllocator_.alloc(
+      op.length,
+      callbackWrapper_(
+          [&op, descriptor{std::move(descriptor)}](
+              ChannelImpl& impl, std::shared_ptr<uint8_t[]> tmpBuffer) mutable {
+            TP_VLOG(6) << "Channel " << impl.id_
+                       << " is done allocating temporary memory for chunk #"
+                       << op.chunkId << " of " << op.numChunks
+                       << " for buffer #" << op.sequenceNumber;
+            op.tmpBuffer = std::move(tmpBuffer);
+            impl.onRecvOpReadyForRecv(op, std::move(descriptor));
+          }));
+}
+
+void ChannelImpl::onRecvOpReadyForRecv(Operation& op, std::string descriptor) {
+  if (error_) {
+    op.done = true;
+    onRecvOpDone();
+    return;
   }
 
-  // Keep tmpBuffer alive until cudaMemcpyAsync is done.
-  cudaLoop_.addCallback(
-      cudaDeviceForPointer(context_->getCudaLib(), buffer.ptr),
-      buffer.stream,
-      callbackWrapper_([sequenceNumber, tmpBuffer{std::move(tmpBuffer)}](
-                           ChannelImpl& impl) mutable {
-        TP_VLOG(5) << "Channel " << impl.id_ << " is done copying buffer #"
-                   << sequenceNumber << " from CPU to CUDA device";
+  TP_VLOG(6) << "Channel " << id_ << " is sending chunk #" << op.chunkId
+             << " of " << op.numChunks << " for buffer #" << op.sequenceNumber
+             << " through CPU channel";
+  cpuChannel_->recv(
+      std::move(descriptor),
+      CpuBuffer{op.tmpBuffer.get(), op.length},
+      callbackWrapper_([&op](ChannelImpl& impl) {
+        TP_VLOG(6) << "Channel " << impl.id_ << " is done sending chunk #"
+                   << op.chunkId << " of " << op.numChunks << " for buffer #"
+                   << op.sequenceNumber << " through CPU channel";
+        impl.onRecvOpReadyForCopy(op);
       }));
+}
 
-  callback(Error::kSuccess);
+void ChannelImpl::onRecvOpReadyForCopy(Operation& op) {
+  if (error_) {
+    op.done = true;
+    onRecvOpDone();
+    return;
+  }
+
+  TP_VLOG(6) << "Channel " << id_ << " is copying chunk #" << op.chunkId
+             << " of " << op.numChunks << " for buffer #" << op.sequenceNumber
+             << " from CPU to CUDA device";
+  int deviceIdx = cudaDeviceForPointer(context_->getCudaLib(), op.cudaPtr);
+  cudaCopy(
+      op.cudaPtr,
+      op.tmpBuffer.get(),
+      op.length,
+      deviceIdx,
+      op.stream,
+      callbackWrapper_([&op](ChannelImpl& impl) {
+        TP_VLOG(6) << "Channel " << impl.id_ << " is done copying chunk #"
+                   << op.chunkId << " of " << op.numChunks << " for buffer #"
+                   << op.sequenceNumber << " from CPU to CUDA device";
+        op.done = true;
+        impl.onRecvOpDone();
+      }));
+}
+
+void ChannelImpl::onRecvOpDone() {
+  while (!recvOperations_.empty()) {
+    auto& op = recvOperations_.front();
+    if (!op.done) {
+      break;
+    }
+    if (op.callback) {
+      op.callback(error_);
+    }
+    recvOperations_.pop_front();
+  }
+
+  if (error_) {
+    tryCleanup();
+  }
 }
 
 void ChannelImpl::setIdImpl() {
   cpuChannel_->setId(id_ + ".cpu");
 }
 
+void ChannelImpl::tryCleanup() {
+  TP_DCHECK(context_->inLoop());
+  TP_DCHECK(error_);
+
+  if (sendOperations_.empty() && recvOperations_.empty()) {
+    cleanup();
+  } else {
+    TP_VLOG(6) << "Channel " << id_
+               << " cannot proceed with cleanup because it has "
+               << sendOperations_.size() << " pending send operations and "
+               << recvOperations_.size() << " pending recv operations";
+  }
+}
+
+void ChannelImpl::cleanup() {
+  TP_DCHECK(context_->inLoop());
+  TP_VLOG(6) << "Channel " << id_ << " is cleaning up";
+
+  context_->unenroll(*this);
+}
+
 void ChannelImpl::handleErrorImpl() {
   cpuChannel_->close();
 
-  context_->unenroll(*this);
+  tryCleanup();
 }
 
 } // namespace cuda_basic

--- a/tensorpipe/channel/cuda_basic/channel_impl.cc
+++ b/tensorpipe/channel/cuda_basic/channel_impl.cc
@@ -212,7 +212,7 @@ void ChannelImpl::recvImplFromLoop(
                << op.chunkId << " of " << op.numChunks << " for buffer #"
                << op.sequenceNumber;
     connection_->read(callbackWrapper_(
-        [&op](ChannelImpl& impl const void* ptr, size_t length) {
+        [&op](ChannelImpl& impl, const void* ptr, size_t length) {
           TP_VLOG(6) << "Channel " << impl.id_
                      << " is done reading descriptor for chunk #" << op.chunkId
                      << " of " << op.numChunks << " for buffer #"

--- a/tensorpipe/channel/cuda_basic/channel_impl.cc
+++ b/tensorpipe/channel/cuda_basic/channel_impl.cc
@@ -162,9 +162,11 @@ void ChannelImpl::sendChunkDescriptor(Operation op, std::string descriptor) {
   TP_VLOG(6) << "Channel " << id_ << " is sending descriptor for chunk #"
              << op.chunkId << " of " << op.numChunks << " for buffer #"
              << op.sequenceNumber;
+  const void* descriptorPtr = &descriptor[0];
+  size_t descriptorLength = descriptor.length();
   connection_->write(
-      &descriptor[0],
-      descriptor.length(),
+      descriptorPtr,
+      descriptorLength,
       callbackWrapper_([op{std::move(op)},
                         descriptor{std::move(descriptor)}](ChannelImpl& impl) {
         TP_VLOG(6) << "Channel " << impl.id_

--- a/tensorpipe/channel/cuda_basic/channel_impl.cc
+++ b/tensorpipe/channel/cuda_basic/channel_impl.cc
@@ -217,7 +217,7 @@ void ChannelImpl::recvImplFromLoop(
                      << " is done reading descriptor for chunk #" << op.chunkId
                      << " of " << op.numChunks << " for buffer #"
                      << op.sequenceNumber;
-          std::string descriptor(ptr, length);
+          std::string descriptor(static_cast<char*>(ptr), length);
           impl.onRecvOpReadDescriptor(op, std::move(descriptor));
         }));
   }

--- a/tensorpipe/channel/cuda_basic/channel_impl.cc
+++ b/tensorpipe/channel/cuda_basic/channel_impl.cc
@@ -217,7 +217,7 @@ void ChannelImpl::recvImplFromLoop(
                      << " is done reading descriptor for chunk #" << op.chunkId
                      << " of " << op.numChunks << " for buffer #"
                      << op.sequenceNumber;
-          std::string descriptor(static_cast<char*>(ptr), length);
+          std::string descriptor(static_cast<const char*>(ptr), length);
           impl.onRecvOpReadDescriptor(op, std::move(descriptor));
         }));
   }

--- a/tensorpipe/channel/cuda_basic/channel_impl.cc
+++ b/tensorpipe/channel/cuda_basic/channel_impl.cc
@@ -25,6 +25,14 @@ namespace tensorpipe {
 namespace channel {
 namespace cuda_basic {
 
+namespace {
+
+size_t ceilOfRatio(size_t n, size_t d) {
+  return (n + d - 1) / d;
+}
+
+} // namespace
+
 ChannelImpl::ChannelImpl(
     ConstructorToken token,
     std::shared_ptr<ContextImpl> context,
@@ -67,7 +75,7 @@ void ChannelImpl::sendImplFromLoop(
     TDescriptorCallback descriptorCallback,
     TSendCallback callback) {
   const size_t chunkLength = cudaHostAllocator_.getChunkLength();
-  const size_t numChunks = (buffer.length + chunkLength - 1) / chunkLength;
+  const size_t numChunks = ceilOfRatio(buffer.length, chunkLength);
   for (size_t offset = 0; offset < buffer.length; offset += chunkLength) {
     sendOperations_.emplace_back();
     Operation& op = sendOperations_.back();
@@ -188,7 +196,7 @@ void ChannelImpl::recvImplFromLoop(
     CudaBuffer buffer,
     TRecvCallback callback) {
   const size_t chunkLength = cudaHostAllocator_.getChunkLength();
-  const size_t numChunks = (buffer.length + chunkLength - 1) / chunkLength;
+  const size_t numChunks = ceilOfRatio(buffer.length, chunkLength);
   for (size_t offset = 0; offset < buffer.length; offset += chunkLength) {
     recvOperations_.emplace_back();
     Operation& op = recvOperations_.back();

--- a/tensorpipe/channel/cuda_basic/channel_impl.cc
+++ b/tensorpipe/channel/cuda_basic/channel_impl.cc
@@ -299,7 +299,7 @@ void ChannelImpl::onRecvOpReadyForCopy(Operation& op) {
       }));
 
   op.done = true;
-  impl.onRecvOpDone();
+  onRecvOpDone();
 }
 
 void ChannelImpl::onRecvOpDone() {

--- a/tensorpipe/channel/cuda_basic/channel_impl.cc
+++ b/tensorpipe/channel/cuda_basic/channel_impl.cc
@@ -83,7 +83,7 @@ void ChannelImpl::sendImplFromLoop(
       op.callback = std::move(callback);
     }
 
-    TP_VLOG(6) << "Channel " << id_
+    TP_VLOG(5) << "Channel " << id_
                << " is allocating temporary memory for chunk #" << op.chunkId
                << " of " << op.numChunks << " for buffer #"
                << op.sequenceNumber;
@@ -91,7 +91,7 @@ void ChannelImpl::sendImplFromLoop(
         op.length,
         callbackWrapper_(
             [&op](ChannelImpl& impl, std::shared_ptr<uint8_t[]> tmpBuffer) {
-              TP_VLOG(6) << "Channel " << impl.id_
+              TP_VLOG(5) << "Channel " << impl.id_
                          << " is done allocating temporary memory for chunk #"
                          << op.chunkId << " of " << op.numChunks
                          << " for buffer #" << op.sequenceNumber;
@@ -110,7 +110,7 @@ void ChannelImpl::onSendOpReadyForCopy(Operation& op) {
     return;
   }
 
-  TP_VLOG(6) << "Channel " << id_ << " is copying chunk #" << op.chunkId
+  TP_VLOG(5) << "Channel " << id_ << " is copying chunk #" << op.chunkId
              << " of " << op.numChunks << " for buffer #" << op.sequenceNumber
              << " from CUDA device to CPU";
   int deviceIdx = cudaDeviceForPointer(context_->getCudaLib(), op.cudaPtr);
@@ -121,7 +121,7 @@ void ChannelImpl::onSendOpReadyForCopy(Operation& op) {
       deviceIdx,
       op.stream,
       callbackWrapper_([&op](ChannelImpl& impl) {
-        TP_VLOG(6) << "Channel " << impl.id_ << " is done copying chunk #"
+        TP_VLOG(5) << "Channel " << impl.id_ << " is done copying chunk #"
                    << op.chunkId << " of " << op.numChunks << " for buffer #"
                    << op.sequenceNumber << " from CUDA device to CPU";
         op.done = true;
@@ -234,7 +234,7 @@ void ChannelImpl::onRecvOpReadDescriptor(
     return;
   }
 
-  TP_VLOG(6) << "Channel " << id_
+  TP_VLOG(5) << "Channel " << id_
              << " is allocating temporary memory for chunk #" << op.chunkId
              << " of " << op.numChunks << " for buffer #" << op.sequenceNumber;
   cudaHostAllocator_.alloc(
@@ -242,7 +242,7 @@ void ChannelImpl::onRecvOpReadDescriptor(
       callbackWrapper_(
           [&op, descriptor{std::move(descriptor)}](
               ChannelImpl& impl, std::shared_ptr<uint8_t[]> tmpBuffer) mutable {
-            TP_VLOG(6) << "Channel " << impl.id_
+            TP_VLOG(5) << "Channel " << impl.id_
                        << " is done allocating temporary memory for chunk #"
                        << op.chunkId << " of " << op.numChunks
                        << " for buffer #" << op.sequenceNumber;
@@ -279,7 +279,7 @@ void ChannelImpl::onRecvOpReadyForCopy(Operation& op) {
     return;
   }
 
-  TP_VLOG(6) << "Channel " << id_ << " is copying chunk #" << op.chunkId
+  TP_VLOG(5) << "Channel " << id_ << " is copying chunk #" << op.chunkId
              << " of " << op.numChunks << " for buffer #" << op.sequenceNumber
              << " from CPU to CUDA device";
   int deviceIdx = cudaDeviceForPointer(context_->getCudaLib(), op.cudaPtr);
@@ -290,7 +290,7 @@ void ChannelImpl::onRecvOpReadyForCopy(Operation& op) {
       deviceIdx,
       op.stream,
       callbackWrapper_([&op](ChannelImpl& impl) {
-        TP_VLOG(6) << "Channel " << impl.id_ << " is done copying chunk #"
+        TP_VLOG(5) << "Channel " << impl.id_ << " is done copying chunk #"
                    << op.chunkId << " of " << op.numChunks << " for buffer #"
                    << op.sequenceNumber << " from CPU to CUDA device";
         op.done = true;
@@ -326,7 +326,7 @@ void ChannelImpl::tryCleanup() {
   if (sendOperations_.empty() && recvOperations_.empty()) {
     cleanup();
   } else {
-    TP_VLOG(6) << "Channel " << id_
+    TP_VLOG(5) << "Channel " << id_
                << " cannot proceed with cleanup because it has "
                << sendOperations_.size() << " pending send operations and "
                << recvOperations_.size() << " pending recv operations";
@@ -335,7 +335,7 @@ void ChannelImpl::tryCleanup() {
 
 void ChannelImpl::cleanup() {
   TP_DCHECK(context_->inLoop());
-  TP_VLOG(6) << "Channel " << id_ << " is cleaning up";
+  TP_VLOG(5) << "Channel " << id_ << " is cleaning up";
 
   context_->unenroll(*this);
 }

--- a/tensorpipe/channel/cuda_basic/channel_impl.cc
+++ b/tensorpipe/channel/cuda_basic/channel_impl.cc
@@ -292,6 +292,8 @@ void ChannelImpl::onRecvOpReadyForCopy(Operation& op) {
       deviceIdx,
       op.stream,
       // TODO: Avoid copying op.
+      // NOTE: This callback keeps the temporary CPU buffer alive until its
+      // content is copied to the CUDA device.
       callbackWrapper_([op](ChannelImpl& impl) {
         TP_VLOG(5) << "Channel " << impl.id_ << " is done copying chunk #"
                    << op.chunkId << " of " << op.numChunks << " for buffer #"

--- a/tensorpipe/channel/cuda_basic/channel_impl.cc
+++ b/tensorpipe/channel/cuda_basic/channel_impl.cc
@@ -98,7 +98,7 @@ void ChannelImpl::sendImplFromLoop(
     cudaHostAllocator_.alloc(
         op.length,
         callbackWrapper_(
-            [&op](ChannelImpl& impl, CudaHostAllocator::THostPtr tmpBuffer) {
+            [&op](ChannelImpl& impl, std::shared_ptr<uint8_t[]> tmpBuffer) {
               TP_VLOG(5) << "Channel " << impl.id_
                          << " is done allocating temporary memory for chunk #"
                          << op.chunkId << " of " << op.numChunks
@@ -241,16 +241,16 @@ void ChannelImpl::onRecvOpReadDescriptor(
              << " of " << op.numChunks << " for buffer #" << op.sequenceNumber;
   cudaHostAllocator_.alloc(
       op.length,
-      callbackWrapper_([&op, descriptor{std::move(descriptor)}](
-                           ChannelImpl& impl,
-                           CudaHostAllocator::THostPtr tmpBuffer) mutable {
-        TP_VLOG(5) << "Channel " << impl.id_
-                   << " is done allocating temporary memory for chunk #"
-                   << op.chunkId << " of " << op.numChunks << " for buffer #"
-                   << op.sequenceNumber;
-        op.tmpBuffer = std::move(tmpBuffer);
-        impl.onRecvOpReadyForRecv(op, std::move(descriptor));
-      }));
+      callbackWrapper_(
+          [&op, descriptor{std::move(descriptor)}](
+              ChannelImpl& impl, std::shared_ptr<uint8_t[]> tmpBuffer) mutable {
+            TP_VLOG(5) << "Channel " << impl.id_
+                       << " is done allocating temporary memory for chunk #"
+                       << op.chunkId << " of " << op.numChunks
+                       << " for buffer #" << op.sequenceNumber;
+            op.tmpBuffer = std::move(tmpBuffer);
+            impl.onRecvOpReadyForRecv(op, std::move(descriptor));
+          }));
 }
 
 void ChannelImpl::onRecvOpReadyForRecv(Operation& op, std::string descriptor) {

--- a/tensorpipe/channel/cuda_basic/channel_impl.h
+++ b/tensorpipe/channel/cuda_basic/channel_impl.h
@@ -77,7 +77,7 @@ class ChannelImpl final
       void* dst,
       const void* src,
       size_t length,
-      int devicdIdx,
+      int deviceIdx,
       cudaStream_t stream,
       std::function<void(const Error&)> callback);
 

--- a/tensorpipe/channel/cuda_basic/context_impl.cc
+++ b/tensorpipe/channel/cuda_basic/context_impl.cc
@@ -85,7 +85,6 @@ void ContextImpl::joinImpl() {
     cpuContext_->join();
   }
   cudaLoop_.join();
-  cudaHostAllocator_.join();
 }
 
 bool ContextImpl::inLoop() const {

--- a/tensorpipe/channel/cuda_basic/context_impl.cc
+++ b/tensorpipe/channel/cuda_basic/context_impl.cc
@@ -61,7 +61,7 @@ std::shared_ptr<CudaChannel> ContextImpl::createChannel(
   auto cpuChannel =
       cpuContext_->createChannel(std::move(connections), endpoint);
   return createChannelInternal(
-      std::move(conn), std::move(cpuChannel), cudaLoop_);
+      std::move(conn), std::move(cpuChannel), cudaLoop_, cudaHostAllocator_);
 }
 
 size_t ContextImpl::numConnectionsNeeded() const {
@@ -77,6 +77,7 @@ void ContextImpl::handleErrorImpl() {
     cpuContext_->close();
   }
   cudaLoop_.close();
+  cudaHostAllocator_.close();
 }
 
 void ContextImpl::joinImpl() {
@@ -84,6 +85,7 @@ void ContextImpl::joinImpl() {
     cpuContext_->join();
   }
   cudaLoop_.join();
+  cudaHostAllocator_.join();
 }
 
 bool ContextImpl::inLoop() const {

--- a/tensorpipe/channel/cuda_basic/context_impl.cc
+++ b/tensorpipe/channel/cuda_basic/context_impl.cc
@@ -84,7 +84,7 @@ void ContextImpl::handleErrorImpl() {
   cudaLoop_.close();
 
   if (cudaHostAllocator_.has_value()) {
-    cudaHostAllocator_.close();
+    cudaHostAllocator_->close();
   }
 }
 

--- a/tensorpipe/channel/cuda_basic/context_impl.h
+++ b/tensorpipe/channel/cuda_basic/context_impl.h
@@ -12,6 +12,7 @@
 #include <tensorpipe/channel/cpu_context.h>
 #include <tensorpipe/channel/cuda_context.h>
 #include <tensorpipe/common/cuda_buffer.h>
+#include <tensorpipe/common/cuda_host_allocator.h>
 #include <tensorpipe/common/cuda_lib.h>
 #include <tensorpipe/common/cuda_loop.h>
 #include <tensorpipe/common/deferred_executor.h>
@@ -58,6 +59,7 @@ class ContextImpl final
   const std::shared_ptr<CpuContext> cpuContext_;
   // TODO: Lazy initialization of cuda loop.
   CudaLoop cudaLoop_;
+  CudaHostAllocator cudaHostAllocator_;
 };
 
 } // namespace cuda_basic

--- a/tensorpipe/channel/cuda_basic/context_impl.h
+++ b/tensorpipe/channel/cuda_basic/context_impl.h
@@ -16,6 +16,7 @@
 #include <tensorpipe/common/cuda_lib.h>
 #include <tensorpipe/common/cuda_loop.h>
 #include <tensorpipe/common/deferred_executor.h>
+#include <tensorpipe/common/optional.h>
 
 namespace tensorpipe {
 namespace channel {
@@ -59,7 +60,7 @@ class ContextImpl final
   const std::shared_ptr<CpuContext> cpuContext_;
   // TODO: Lazy initialization of cuda loop.
   CudaLoop cudaLoop_;
-  CudaHostAllocator cudaHostAllocator_;
+  optional<CudaHostAllocator> cudaHostAllocator_;
 };
 
 } // namespace cuda_basic

--- a/tensorpipe/common/cuda_host_allocator.cc
+++ b/tensorpipe/common/cuda_host_allocator.cc
@@ -71,8 +71,8 @@ void CudaHostAllocator::join() {
 void CudaHostAllocator::processAllocations(std::unique_lock<std::mutex> lock) {
   while (!pendingAllocations_.empty()) {
     auto& callback = pendingAllocations_.front();
-    if (error_) {
-      callback(error_);
+    if (closed_) {
+      callback(TP_CREATE_ERROR(CudaHostAllocatorClosedError), nullptr);
     } else {
       THostPtr ptr = getAvailableChunk();
       if (!ptr) {

--- a/tensorpipe/common/cuda_host_allocator.cc
+++ b/tensorpipe/common/cuda_host_allocator.cc
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/common/cuda_host_allocator.h>
+
+#include <cuda_runtime.h>
+
+#include <tensorpipe/common/cuda.h>
+
+namespace tensorpipe {
+
+CudaHostAllocator::CudaHostAllocator(size_t numChunks, size_t chunkSize)
+    : numChunks_(numChunks),
+      chunkSize_(chunkSize),
+      chunkAvailable_(numChunks, true),
+      data_(allocPinnedBuffer(numChunks * chunkSize)) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  thread_ = std::thread([this, lock{std::move(lock)}]() mutable {
+    setThreadName("TP_CUDA_host_allocator_loop");
+    allocLoop(std::move(lock));
+  });
+}
+
+CudaHostAllocator::~CudaHostAllocator() {
+  join();
+}
+
+void CudaHostAllocator::alloc(size_t size, TAllocCallback callback) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  if (closed_) {
+    callback(TP_CREATE_ERROR(CudaHostAllocatorClosedError), THostPtr());
+    return;
+  }
+  TP_DCHECK(size <= chunkSize_);
+  pendingAllocations_.push_back(std::move(callback));
+  cv_.notify_all();
+}
+
+size_t CudaHostAllocator::getChunkLength() const {
+  return chunkSize_;
+}
+
+void CudaHostAllocator::close() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  if (closed_) {
+    return;
+  }
+  closed_ = true;
+  cv_.notify_all();
+}
+
+void CudaHostAllocator::join() {
+  close();
+  if (!joined_.exchange(true)) {
+    thread_.join();
+  }
+}
+
+void CudaHostAllocator::allocLoop(std::unique_lock<std::mutex> lock) {
+  for (;;) {
+    if (closed_ && pendingAllocations_.empty()) {
+      break;
+    } else {
+      cv_.wait(lock);
+    }
+
+    std::deque<TAllocCallback> allocations;
+    std::swap(allocations, pendingAllocations_);
+    lock.unlock();
+    processAllocations(allocations);
+    lock.lock();
+    pendingAllocations_.insert(
+        pendingAllocations_.begin(), allocations.begin(), allocations.end());
+  }
+}
+
+void CudaHostAllocator::processAllocations(
+    std::deque<TAllocCallback>& allocations) {
+  for (size_t curChunk = 0; curChunk < numChunks_; ++curChunk) {
+    if (allocations.empty()) {
+      return;
+    }
+    if (chunkAvailable_[curChunk]) {
+      chunkAvailable_[curChunk] = false;
+
+      // FIXME: Ensure object remains alive until all chunks have been
+      // reclaimed.
+      THostPtr ptr(data_.get() + curChunk * chunkSize_, [this](uint8_t* ptr) {
+        hostPtrDeleter(ptr);
+      });
+      auto& callback = allocations.front();
+      callback(Error::kSuccess, std::move(ptr));
+
+      allocations.pop_front();
+    }
+  }
+}
+
+void CudaHostAllocator::hostPtrDeleter(uint8_t* ptr) {
+  size_t chunkId = (ptr - data_.get()) / chunkSize_;
+  std::unique_lock<std::mutex> lock(mutex_);
+  chunkAvailable_[chunkId] = true;
+  cv_.notify_all();
+}
+
+std::unique_ptr<uint8_t[], std::function<void(uint8_t*)>> CudaHostAllocator::
+    allocPinnedBuffer(size_t size) {
+  void* ptr;
+  TP_CUDA_CHECK(cudaMallocHost(&ptr, size));
+  return std::unique_ptr<uint8_t[], std::function<void(uint8_t*)>>(
+      reinterpret_cast<uint8_t*>(ptr),
+      [](uint8_t* ptr) { TP_CUDA_CHECK(cudaFreeHost(ptr)); });
+}
+
+} // namespace tensorpipe

--- a/tensorpipe/common/cuda_host_allocator.cc
+++ b/tensorpipe/common/cuda_host_allocator.cc
@@ -108,7 +108,7 @@ void CudaHostAllocator::hostPtrDeleter(uint8_t* ptr) {
   cv_.notify_all();
 }
 
-std::unique_ptr<uint8_t[], std::function<void(uint8_t*)>> CudaHostAllocator::
+static std::unique_ptr<uint8_t[], std::function<void(uint8_t*)>> CudaHostAllocator::
     allocPinnedBuffer(size_t size) {
   void* ptr;
   TP_CUDA_CHECK(cudaMallocHost(&ptr, size));

--- a/tensorpipe/common/cuda_host_allocator.cc
+++ b/tensorpipe/common/cuda_host_allocator.cc
@@ -109,7 +109,7 @@ void CudaHostAllocator::releaseChunk(uint8_t* ptr) {
 CudaHostAllocator::HostPtrDeleter(CudaHostAllocator& allocator)
     : allocator_(allocator) {}
 
-void CudaHostAllocator::operator()(uint8_t* ptr) {
+void CudaHostAllocator::HostPtrDeleter::operator()(uint8_t* ptr) {
   allocator_.releaseChunk(ptr);
 }
 

--- a/tensorpipe/common/cuda_host_allocator.cc
+++ b/tensorpipe/common/cuda_host_allocator.cc
@@ -114,7 +114,7 @@ static void* CudaHostAllocator::allocPinnedBuffer(size_t size) {
   return ptr;
 }
 
-static void CudaHostAllocator::freePinnedBuffer(uint8_t* ptr) {
+static void CudaHostAllocator::freePinnedBuffer(void* ptr) {
   TP_CUDA_CHECK(cudaFreeHost(ptr));
 }
 

--- a/tensorpipe/common/cuda_host_allocator.cc
+++ b/tensorpipe/common/cuda_host_allocator.cc
@@ -16,13 +16,13 @@ namespace tensorpipe {
 
 namespace {
 
-uint8_t* CudaHostAllocator::allocPinnedBuffer(size_t size) {
+uint8_t* allocPinnedBuffer(size_t size) {
   uint8_t* ptr;
   TP_CUDA_CHECK(cudaMallocHost(&ptr, size));
   return ptr;
 }
 
-void CudaHostAllocator::freePinnedBuffer(uint8_t* ptr) {
+void freePinnedBuffer(uint8_t* ptr) {
   TP_CUDA_CHECK(cudaFreeHost(ptr));
 }
 

--- a/tensorpipe/common/cuda_host_allocator.cc
+++ b/tensorpipe/common/cuda_host_allocator.cc
@@ -84,7 +84,7 @@ void CudaHostAllocator::processAllocations(std::unique_lock<std::mutex> lock) {
   }
 }
 
-THostPtr CudaHostAllocator::getAvailableChunk() {
+CudaHostAllocator::THostPtr CudaHostAllocator::getAvailableChunk() {
   for (size_t curChunk = 0; curChunk < numChunks_; ++curChunk) {
     if (chunkAvailable_[curChunk]) {
       chunkAvailable_[curChunk] = false;

--- a/tensorpipe/common/cuda_host_allocator.cc
+++ b/tensorpipe/common/cuda_host_allocator.cc
@@ -106,7 +106,7 @@ void CudaHostAllocator::releaseChunk(uint8_t* ptr) {
   cv_.notify_all();
 }
 
-CudaHostAllocator::HostPtrDeleter(CudaHostAllocator& allocator)
+CudaHostAllocator::HostPtrDeleter::HostPtrDeleter(CudaHostAllocator& allocator)
     : allocator_(allocator) {}
 
 void CudaHostAllocator::HostPtrDeleter::operator()(uint8_t* ptr) {

--- a/tensorpipe/common/cuda_host_allocator.cc
+++ b/tensorpipe/common/cuda_host_allocator.cc
@@ -14,6 +14,20 @@
 
 namespace tensorpipe {
 
+namespace {
+
+uint8_t* CudaHostAllocator::allocPinnedBuffer(size_t size) {
+  uint8_t* ptr;
+  TP_CUDA_CHECK(cudaMallocHost(&ptr, size));
+  return ptr;
+}
+
+void CudaHostAllocator::freePinnedBuffer(uint8_t* ptr) {
+  TP_CUDA_CHECK(cudaFreeHost(ptr));
+}
+
+} // namespace
+
 CudaHostAllocator::CudaHostAllocator(size_t numChunks, size_t chunkSize)
     : numChunks_(numChunks),
       chunkSize_(chunkSize),
@@ -106,16 +120,6 @@ void CudaHostAllocator::hostPtrDeleter(uint8_t* ptr) {
   std::unique_lock<std::mutex> lock(mutex_);
   chunkAvailable_[chunkId] = true;
   cv_.notify_all();
-}
-
-static void* CudaHostAllocator::allocPinnedBuffer(size_t size) {
-  void* ptr;
-  TP_CUDA_CHECK(cudaMallocHost(&ptr, size));
-  return ptr;
-}
-
-static void CudaHostAllocator::freePinnedBuffer(void* ptr) {
-  TP_CUDA_CHECK(cudaFreeHost(ptr));
 }
 
 } // namespace tensorpipe

--- a/tensorpipe/common/cuda_host_allocator.cc
+++ b/tensorpipe/common/cuda_host_allocator.cc
@@ -17,8 +17,8 @@ namespace tensorpipe {
 CudaHostAllocator::CudaHostAllocator(size_t numChunks, size_t chunkSize)
     : numChunks_(numChunks),
       chunkSize_(chunkSize),
-      chunkAvailable_(numChunks, true),
-      data_(allocPinnedBuffer(numChunks * chunkSize)) {
+      data_(allocPinnedBuffer(numChunks * chunkSize)),
+      chunkAvailable_(numChunks, true) {
   std::unique_lock<std::mutex> lock(mutex_);
   thread_ = std::thread([this, lock{std::move(lock)}]() mutable {
     setThreadName("TP_CUDA_host_allocator_loop");

--- a/tensorpipe/common/cuda_host_allocator.h
+++ b/tensorpipe/common/cuda_host_allocator.h
@@ -47,7 +47,7 @@ class CudaHostAllocator {
  private:
   const size_t numChunks_;
   const size_t chunkSize_;
-  const std::unique_ptr<uint8_t[], void(uint8_t*)> data_;
+  const std::unique_ptr<uint8_t[], void(*)(uint8_t*)> data_;
   std::vector<bool> chunkAvailable_;
   std::thread thread_;
   std::mutex mutex_;

--- a/tensorpipe/common/cuda_host_allocator.h
+++ b/tensorpipe/common/cuda_host_allocator.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <thread>
+
+#include <tensorpipe/common/error.h>
+#include <tensorpipe/common/system.h>
+
+namespace tensorpipe {
+
+class CudaHostAllocatorClosedError final : public BaseError {
+  std::string what() const override {
+    return "CUDA host allocator closed";
+  }
+};
+
+class CudaHostAllocator {
+ public:
+  using THostPtr = std::shared_ptr<uint8_t[]>;
+  using TAllocCallback = std::function<void(const Error&, THostPtr)>;
+
+  explicit CudaHostAllocator(
+      size_t numChunks = 1024,
+      size_t chunkSize = 1024 * 1024);
+
+  ~CudaHostAllocator();
+
+  void alloc(size_t size, TAllocCallback callback);
+  size_t getChunkLength() const;
+
+  void close();
+  void join();
+
+ private:
+  const size_t numChunks_{0};
+  const size_t chunkSize_{0};
+  const std::unique_ptr<uint8_t[], std::function<void(uint8_t*)>> data_{
+      nullptr};
+  std::vector<bool> chunkAvailable_;
+  std::thread thread_;
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  std::deque<TAllocCallback> pendingAllocations_;
+  bool closed_{false};
+  std::atomic<bool> joined_{false};
+
+  void allocLoop(std::unique_lock<std::mutex> lock);
+  void processAllocations(std::deque<TAllocCallback>& allocations);
+
+  void hostPtrDeleter(uint8_t* ptr);
+  std::unique_ptr<uint8_t[], std::function<void(uint8_t*)>> allocPinnedBuffer(
+      size_t size);
+};
+
+} // namespace tensorpipe

--- a/tensorpipe/common/cuda_host_allocator.h
+++ b/tensorpipe/common/cuda_host_allocator.h
@@ -61,8 +61,8 @@ class CudaHostAllocator {
   void processAllocations(std::deque<TAllocCallback>& allocations);
 
   void hostPtrDeleter(uint8_t* ptr);
-  static std::unique_ptr<uint8_t[], std::function<void(uint8_t*)>> allocPinnedBuffer(
-      size_t size);
+  static void* allocPinnedBuffer(size_t size);
+  static void freePinnedBuffer(uint8_t* ptr);
 };
 
 } // namespace tensorpipe

--- a/tensorpipe/common/cuda_host_allocator.h
+++ b/tensorpipe/common/cuda_host_allocator.h
@@ -28,8 +28,18 @@ class CudaHostAllocatorClosedError final : public BaseError {
 };
 
 class CudaHostAllocator {
+ private:
+  class HostPtrDeleter {
+   public:
+    HostPtrDeleter(CudaHostAllocator& allocator);
+    void operator()(uint8_t* ptr);
+
+   private:
+    CudaHostAllocator& allocator_;
+  };
+
  public:
-  using THostPtr = std::shared_ptr<uint8_t[]>;
+  using THostPtr = std::unique_ptr<uint8_t[], HostPtrDeleter>;
   using TAllocCallback = std::function<void(const Error&, THostPtr)>;
 
   explicit CudaHostAllocator(

--- a/tensorpipe/common/cuda_host_allocator.h
+++ b/tensorpipe/common/cuda_host_allocator.h
@@ -68,6 +68,7 @@ class CudaHostAllocator {
 
   void processAllocations(std::unique_lock<std::mutex> lock);
   THostPtr getAvailableChunk();
+  void releaseChunk(uint8_t* ptr);
 
   void hostPtrDeleter(uint8_t* ptr);
 };

--- a/tensorpipe/common/cuda_host_allocator.h
+++ b/tensorpipe/common/cuda_host_allocator.h
@@ -33,7 +33,7 @@ class CudaHostAllocator {
   using TAllocCallback = std::function<void(const Error&, THostPtr)>;
 
   explicit CudaHostAllocator(
-      size_t numChunks = 1024,
+      size_t numChunks = 16,
       size_t chunkSize = 1024 * 1024);
 
   ~CudaHostAllocator();
@@ -45,8 +45,8 @@ class CudaHostAllocator {
   void join();
 
  private:
-  const size_t numChunks_{0};
-  const size_t chunkSize_{0};
+  const size_t numChunks_;
+  const size_t chunkSize_;
   const std::unique_ptr<uint8_t[], std::function<void(uint8_t*)>> data_{
       nullptr};
   std::vector<bool> chunkAvailable_;

--- a/tensorpipe/common/cuda_host_allocator.h
+++ b/tensorpipe/common/cuda_host_allocator.h
@@ -47,8 +47,7 @@ class CudaHostAllocator {
  private:
   const size_t numChunks_;
   const size_t chunkSize_;
-  const std::unique_ptr<uint8_t[], std::function<void(uint8_t*)>> data_{
-      nullptr};
+  const std::unique_ptr<uint8_t[], decltype(&freePinnedBuffer)> data_;
   std::vector<bool> chunkAvailable_;
   std::thread thread_;
   std::mutex mutex_;
@@ -62,7 +61,7 @@ class CudaHostAllocator {
 
   void hostPtrDeleter(uint8_t* ptr);
   static void* allocPinnedBuffer(size_t size);
-  static void freePinnedBuffer(uint8_t* ptr);
+  static void freePinnedBuffer(void* ptr);
 };
 
 } // namespace tensorpipe

--- a/tensorpipe/common/cuda_host_allocator.h
+++ b/tensorpipe/common/cuda_host_allocator.h
@@ -47,7 +47,7 @@ class CudaHostAllocator {
  private:
   const size_t numChunks_;
   const size_t chunkSize_;
-  const std::unique_ptr<uint8_t[], decltype(&freePinnedBuffer)> data_;
+  const std::unique_ptr<uint8_t[], void(uint8_t*)> data_;
   std::vector<bool> chunkAvailable_;
   std::thread thread_;
   std::mutex mutex_;
@@ -60,8 +60,6 @@ class CudaHostAllocator {
   void processAllocations(std::deque<TAllocCallback>& allocations);
 
   void hostPtrDeleter(uint8_t* ptr);
-  static void* allocPinnedBuffer(size_t size);
-  static void freePinnedBuffer(void* ptr);
 };
 
 } // namespace tensorpipe

--- a/tensorpipe/common/cuda_host_allocator.h
+++ b/tensorpipe/common/cuda_host_allocator.h
@@ -61,7 +61,7 @@ class CudaHostAllocator {
   void processAllocations(std::deque<TAllocCallback>& allocations);
 
   void hostPtrDeleter(uint8_t* ptr);
-  std::unique_ptr<uint8_t[], std::function<void(uint8_t*)>> allocPinnedBuffer(
+  static std::unique_ptr<uint8_t[], std::function<void(uint8_t*)>> allocPinnedBuffer(
       size_t size);
 };
 

--- a/tensorpipe/common/cuda_host_allocator.h
+++ b/tensorpipe/common/cuda_host_allocator.h
@@ -47,17 +47,17 @@ class CudaHostAllocator {
  private:
   const size_t numChunks_;
   const size_t chunkSize_;
-  const std::unique_ptr<uint8_t[], void(*)(uint8_t*)> data_;
+  const std::unique_ptr<uint8_t[], void (*)(uint8_t*)> data_;
   std::vector<bool> chunkAvailable_;
-  std::thread thread_;
+  size_t allocatedChunks_{0};
   std::mutex mutex_;
   std::condition_variable cv_;
   std::deque<TAllocCallback> pendingAllocations_;
   bool closed_{false};
   std::atomic<bool> joined_{false};
 
-  void allocLoop(std::unique_lock<std::mutex> lock);
-  void processAllocations(std::deque<TAllocCallback>& allocations);
+  void processAllocations(std::unique_lock<std::mutex> lock);
+  THostPtr getAvailableChunk();
 
   void hostPtrDeleter(uint8_t* ptr);
 };

--- a/tensorpipe/common/cuda_host_allocator.h
+++ b/tensorpipe/common/cuda_host_allocator.h
@@ -12,6 +12,7 @@
 #include <deque>
 #include <functional>
 #include <memory>
+#include <vector>
 
 #include <tensorpipe/common/error.h>
 

--- a/tensorpipe/common/cuda_host_allocator.h
+++ b/tensorpipe/common/cuda_host_allocator.h
@@ -31,7 +31,7 @@ class CudaHostAllocator {
  private:
   class HostPtrDeleter {
    public:
-    HostPtrDeleter(CudaHostAllocator& allocator);
+    explicit HostPtrDeleter(CudaHostAllocator& allocator);
     void operator()(uint8_t* ptr);
 
    private:

--- a/tensorpipe/common/cuda_host_allocator.h
+++ b/tensorpipe/common/cuda_host_allocator.h
@@ -39,7 +39,7 @@ class CudaHostAllocator {
   };
 
  public:
-  using THostPtr = std::unique_ptr<uint8_t[], HostPtrDeleter>;
+  using THostPtr = std::shared_ptr<uint8_t[]>;
   using TAllocCallback = std::function<void(const Error&, THostPtr)>;
 
   explicit CudaHostAllocator(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#303 Optimize pinned memory allocation in CudaBasic.**

This PR introduces CudaHostAllocator, which allocates a single slab of
pinned host memory. It works by providing fixed-size chunks of memory
for use by the CudaBasic channel.

The CudaBasic channel itself is being reworked to chunk large input
tensors (so that each chunk fits into a pinned memory chunk), and send
each one separately, in order, over the the underlying CPU channel.

NOTE: At the moment, the CudaHostAllocator will block a whole chunk
for each allocation, possibly leading to under-used memory (for
instance when sending several small tensors). It is possible to
mitigate this by fitting multiple allocations per chunk by maintaining
two variables per chunk: `offset` and `used`, the former being
non-decreasing. Each time an allocation for `size` bytes is requested,
each chunk is checked, and if `chunkSize-offset >= size`, `offset` and
`used` are both incremented by `size`. When an allocation is being
reclaimed, the `used` variable is decremented by `size`, and if it
falls to zero, `offset` is reset to zero as well.

Differential Revision: [D26575581](https://our.internmc.facebook.com/intern/diff/D26575581)