### PR TITLE
Add MiscCheck.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,13 +18,8 @@ include(Options)
 # Define sanitizer option, if specified.
 include(Sanitize)
 
-# We use the [[nodiscard]] attribute, which GCC 5 complains about.
-# Silence this warning if GCC 5 is used.
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6)
-    add_definitions("-Wno-attributes")
-  endif()
-endif()
+# ---[ Misc checks to cope with various compiler modes
+include(cmake/MiscCheck.cmake)
 
 add_subdirectory(tensorpipe)
 

--- a/cmake/MiscCheck.cmake
+++ b/cmake/MiscCheck.cmake
@@ -9,39 +9,41 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   endif()
 endif()
 
-# Check libc contains process_vm_readv
-CMAKE_PUSH_CHECK_STATE(RESET)
-set(CMAKE_REQUIRED_FLAGS "${CMAKE_CXX_FLAGS}")
-CHECK_CXX_SOURCE_COMPILES("
-#include <sys/uio.h>
-#include <sys/types.h>
-#include <unistd.h>
+if(LINUX)
+  # Check libc contains process_vm_readv
+  CMAKE_PUSH_CHECK_STATE(RESET)
+  set(CMAKE_REQUIRED_FLAGS "${CMAKE_CXX_FLAGS}")
+  CHECK_CXX_SOURCE_COMPILES("
+    #include <sys/uio.h>
+    #include <sys/types.h>
+    #include <unistd.h>
 
-namespace {
-bool isProcessVmReadvSyscallAllowed() {
-  long long someSourceValue = 0x0123456789abcdef;
-  long long someTargetValue = 0;
-  struct iovec source = {
-    .iov_base = &someSourceValue, .iov_len = sizeof(someSourceValue)
-  };
-  struct iovec target = {
-    .iov_base = &someTargetValue, .iov_len = sizeof(someTargetValue)
-  };
-  ssize_t nread = ::process_vm_readv(::getpid(), &target, 1, &source, 1, 0);
-  return nread == sizeof(long long) && someTargetValue == someSourceValue;
-}
-}
+    namespace {
+    bool isProcessVmReadvSyscallAllowed() {
+      long long someSourceValue = 0x0123456789abcdef;
+      long long someTargetValue = 0;
+      struct iovec source = {
+        .iov_base = &someSourceValue, .iov_len = sizeof(someSourceValue)
+      };
+      struct iovec target = {
+        .iov_base = &someTargetValue, .iov_len = sizeof(someTargetValue)
+      };
+      ssize_t nread = ::process_vm_readv(::getpid(), &target, 1, &source, 1, 0);
+      return nread == sizeof(long long) && someTargetValue == someSourceValue;
+    }
+    }
 
-int main() {
-  isProcessVmReadvSyscallAllowed();
-  return 0;
-}" SUPPORT_GLIBCXX_USE_PROCESS_VM_READV)
-if(NOT SUPPORT_GLIBCXX_USE_PROCESS_VM_READV)
-  unset(SUPPORT_GLIBCXX_USE_PROCESS_VM_READV CACHE)
-  message(FATAL_ERROR
-      "The C++ compiler does not support required functions. "
-      "This likely due to an old version of libc.so is used. "
-      "Please check your system linker setting.")
+    int main() {
+      isProcessVmReadvSyscallAllowed();
+      return 0;
+    }" SUPPORT_GLIBCXX_USE_PROCESS_VM_READV)
+  if(NOT SUPPORT_GLIBCXX_USE_PROCESS_VM_READV)
+    unset(SUPPORT_GLIBCXX_USE_PROCESS_VM_READV CACHE)
+    message(FATAL_ERROR
+        "The C++ compiler does not support required functions. "
+        "This likely due to an old version of libc.so is used. "
+        "Please check your system linker setting.")
+  endif()
+  CMAKE_POP_CHECK_STATE()
 endif()
-CMAKE_POP_CHECK_STATE()
 

--- a/cmake/MiscCheck.cmake
+++ b/cmake/MiscCheck.cmake
@@ -1,0 +1,44 @@
+include(CheckCXXSourceCompiles)
+include(CMakePushCheckState)
+
+# We use the [[nodiscard]] attribute, which GCC 5 complains about.
+# Silence this warning if GCC 5 is used.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6)
+    add_definitions("-Wno-attributes")
+  endif()
+endif()
+
+# Check libc contains process_
+CMAKE_PUSH_CHECK_STATE(RESET)
+set(CMAKE_REQUIRED_FLAGS "-std=c++14")
+CHECK_CXX_SOURCE_COMPILES("
+#include<sys/uio.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+namespace {
+bool isProcessVmReadvSyscallAllowed() {
+  long long someSourceValue = 0x0123456789abcdef;
+  long long someTargetValue = 0;
+  struct iovec source = {
+    .iov_base = &someSourceValue, .iov_len = sizeof(someSourceValue)
+  };
+  struct iovec target = {
+    .iov_base = &someTargetValue, .iov_len = sizeof(someTargetValue)
+  };
+  ssize_t nread = ::process_vm_readv(::getpid(), &target, 1, &source, 1, 0);
+  return nread == sizeof(long long) && someTargetValue == someSourceValue;
+}
+}
+
+int main() {
+  return 0;
+}" SUPPORT_GLIBCXX_USE_PROCESS_VM_READV)
+if(NOT SUPPORT_GLIBCXX_USE_PROCESS_VM_READV)
+  message(FATAL_ERROR
+      "The C++ compiler does not support required functions. "
+      "This likely due to an old version of libc.so is used. "
+      "Please check your system linker setting.")
+endif()
+cmake_pop_check_state()

--- a/cmake/MiscCheck.cmake
+++ b/cmake/MiscCheck.cmake
@@ -1,3 +1,9 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 include(CheckCXXSourceCompiles)
 include(CMakePushCheckState)
 

--- a/cmake/MiscCheck.cmake
+++ b/cmake/MiscCheck.cmake
@@ -9,7 +9,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   endif()
 endif()
 
-if(LINUX)
+if(LINUX AND TP_ENABLE_CMA)
   # Check libc contains process_vm_readv
   CMAKE_PUSH_CHECK_STATE(RESET)
   set(CMAKE_REQUIRED_FLAGS "${CMAKE_CXX_FLAGS}")
@@ -39,10 +39,11 @@ if(LINUX)
     }" SUPPORT_GLIBCXX_USE_PROCESS_VM_READV)
   if(NOT SUPPORT_GLIBCXX_USE_PROCESS_VM_READV)
     unset(SUPPORT_GLIBCXX_USE_PROCESS_VM_READV CACHE)
-    message(FATAL_ERROR
+    message(WARNING
         "The C++ compiler does not support required functions. "
         "This likely due to an old version of libc.so is used. "
         "Please check your system linker setting.")
+    set(TP_ENABLE_CMA OFF)
   endif()
   CMAKE_POP_CHECK_STATE()
 endif()

--- a/cmake/MiscCheck.cmake
+++ b/cmake/MiscCheck.cmake
@@ -9,11 +9,11 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   endif()
 endif()
 
-# Check libc contains process_
+# Check libc contains process_vm_readv
 CMAKE_PUSH_CHECK_STATE(RESET)
-set(CMAKE_REQUIRED_FLAGS "-std=c++14")
+set(CMAKE_REQUIRED_FLAGS "${CMAKE_CXX_FLAGS}")
 CHECK_CXX_SOURCE_COMPILES("
-#include<sys/uio.h>
+#include <sys/uio.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -33,12 +33,15 @@ bool isProcessVmReadvSyscallAllowed() {
 }
 
 int main() {
+  isProcessVmReadvSyscallAllowed();
   return 0;
 }" SUPPORT_GLIBCXX_USE_PROCESS_VM_READV)
 if(NOT SUPPORT_GLIBCXX_USE_PROCESS_VM_READV)
+  unset(SUPPORT_GLIBCXX_USE_PROCESS_VM_READV CACHE)
   message(FATAL_ERROR
       "The C++ compiler does not support required functions. "
       "This likely due to an old version of libc.so is used. "
       "Please check your system linker setting.")
 endif()
-cmake_pop_check_state()
+CMAKE_POP_CHECK_STATE()
+


### PR DESCRIPTION
Usage of `::process_vm_readv` is added in 622bdb9a3b1b02b53e988377118e36af2f391088 .
However the function is not available in `<sys/uio.h>` for some older libc distributions such as glibc 2.12. 

This PR 
- Refactors and adds cmake/MiscCheck.cmake file for compilation checker. 
- Adds a checker to explicitly catch libc version error.

Test Plan
CI