### PR TITLE
Use separate control connections for replies and acks in CUDA IPC

### DIFF
--- a/tensorpipe/channel/cuda_ipc/channel_impl.h
+++ b/tensorpipe/channel/cuda_ipc/channel_impl.h
@@ -85,7 +85,8 @@ class ChannelImpl final
       ConstructorToken token,
       std::shared_ptr<ContextImpl> context,
       std::string id,
-      std::shared_ptr<transport::Connection> connection);
+      std::shared_ptr<transport::Connection> replyConnection,
+      std::shared_ptr<transport::Connection> ackConnection);
 
  protected:
   // Implement the entry points called by ChannelImplBoilerplate.
@@ -103,7 +104,8 @@ class ChannelImpl final
   void handleErrorImpl() override;
 
  private:
-  const std::shared_ptr<transport::Connection> connection_;
+  const std::shared_ptr<transport::Connection> replyConnection_;
+  const std::shared_ptr<transport::Connection> ackConnection_;
 
   // List of alive send operations.
   std::list<SendOperation> sendOperations_;
@@ -111,9 +113,8 @@ class ChannelImpl final
   // List of alive recv operations.
   std::list<RecvOperation> recvOperations_;
 
-  void readPackets();
-  void onReply(const Reply& nopReply);
-  void onAck();
+  void onReply(SendOperation& op, const Reply& nopReply);
+  void onAck(RecvOperation& op);
 };
 
 } // namespace cuda_ipc

--- a/tensorpipe/channel/cuda_ipc/context_impl.cc
+++ b/tensorpipe/channel/cuda_ipc/context_impl.cc
@@ -234,7 +234,15 @@ std::shared_ptr<CudaChannel> ContextImpl::createChannel(
     std::vector<std::shared_ptr<transport::Connection>> connections,
     Endpoint /* unused */) {
   TP_DCHECK_EQ(numConnectionsNeeded(), connections.size());
-  return createChannelInternal(std::move(connections[0]));
+  return createChannelInternal(
+      std::move(connections[0]), std::move(connections[1]));
+}
+
+size_t ContextImpl::numConnectionsNeeded() const {
+  // The control connection needs to carry two unrelated streams in each
+  // direction (the replies and the acks), and it's thus simpler to just use two
+  // such connections.
+  return 2;
 }
 
 bool ContextImpl::canCommunicateWithRemote(

--- a/tensorpipe/channel/cuda_ipc/context_impl.h
+++ b/tensorpipe/channel/cuda_ipc/context_impl.h
@@ -46,6 +46,8 @@ class ContextImpl final
       std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint);
 
+  size_t numConnectionsNeeded() const override;
+
   bool canCommunicateWithRemote(
       const std::string& remoteDomainDescriptor) const override;
 


### PR DESCRIPTION
Summary: CUDA IPC needs to send two independent streams of messages in each direction (replies and acks). It used to do so by multiplexing on a single connection, but it was somewhat awkward, and will make it more complicated to onboard this channel onto a state machine. However, we've recently allowed channels to request more than one control connections, and doing so for IPC would greatly simplify the logic. The only "performance" hit is that we open a few more file descriptors, but this has not proven to be a concern yet.

Differential Revision: D26483685

