### PR TITLE
Fix CircleCI job for clang-format.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,7 +244,7 @@ jobs:
       - run:
           name: Verify clang-format
           command: |
-             git ls-files | grep -E  '\.[cc|h]$' | xargs clang-format-10 -i
+             git ls-files | grep -E  '\.(cc|h)$' | xargs clang-format-10 -i
              if git diff --quiet; then
                echo "Formatting OK!"
              else


### PR DESCRIPTION
The regex was bogus, matching only `.c`, `.h`, and `.|`.