### PR TITLE
Fix stale reference in CUDA GDR causing segfaults

### DIFF
--- a/tensorpipe/channel/cuda_gdr/context_impl.cc
+++ b/tensorpipe/channel/cuda_gdr/context_impl.cc
@@ -450,7 +450,6 @@ ContextImpl::ContextImpl(
   startThread("TP_CUDA_GDR_loop");
 }
 
-
 const CudaLib& ContextImpl::getCudaLib() {
   return cudaLib_;
 }

--- a/tensorpipe/channel/cuda_gdr/context_impl.cc
+++ b/tensorpipe/channel/cuda_gdr/context_impl.cc
@@ -377,6 +377,28 @@ std::shared_ptr<ContextImpl> ContextImpl::create(
     return std::make_shared<ContextImpl>();
   }
 
+  return std::make_shared<ContextImpl>(
+      std::move(cudaLib),
+      std::move(ibvLib),
+      std::move(deviceList),
+      std::move(gpuIdxToNicName));
+}
+
+ContextImpl::ContextImpl()
+    : ContextImplBoilerplate<CudaBuffer, ContextImpl, ChannelImpl>(
+          /*isViable=*/false,
+          /*domainDescriptor=*/"") {}
+
+ContextImpl::ContextImpl(
+    CudaLib cudaLib,
+    IbvLib ibvLib,
+    IbvDeviceList deviceList,
+    optional<std::vector<std::string>> gpuIdxToNicName)
+    : ContextImplBoilerplate<CudaBuffer, ContextImpl, ChannelImpl>(
+          /*isViable=*/true,
+          /*domainDescriptor=*/"*"),
+      cudaLib_(std::move(cudaLib)),
+      ibvLib_(std::move(ibvLib)) {
   std::vector<std::string> actualGpuIdxToNicName;
   if (gpuIdxToNicName.has_value()) {
     int numGpus;
@@ -402,7 +424,6 @@ std::shared_ptr<ContextImpl> ContextImpl::create(
   }
 
   std::unordered_map<std::string, size_t> nicNameToNicIdx;
-  std::vector<IbvNic> ibvNics;
   // The device index is among all available devices, the NIC index is among the
   // ones we will use.
   size_t nicIdx = 0;
@@ -413,7 +434,7 @@ std::shared_ptr<ContextImpl> ContextImpl::create(
     if (iter != nicNames.end()) {
       TP_VLOG(5) << "CUDA GDR channel is using InfiniBand NIC " << deviceName
                  << " as device #" << nicIdx;
-      ibvNics.emplace_back(*iter, device, ibvLib, cudaLib);
+      ibvNics_.emplace_back(*iter, device, ibvLib_, cudaLib_);
       nicNameToNicIdx[*iter] = nicIdx;
       nicIdx++;
       nicNames.erase(iter);
@@ -422,37 +443,13 @@ std::shared_ptr<ContextImpl> ContextImpl::create(
   TP_THROW_ASSERT_IF(!nicNames.empty())
       << "Couldn't find all the devices I was supposed to use";
 
-  std::vector<size_t> gpuToNic;
   for (size_t gpuIdx = 0; gpuIdx < actualGpuIdxToNicName.size(); gpuIdx++) {
-    gpuToNic.push_back(nicNameToNicIdx[actualGpuIdxToNicName[gpuIdx]]);
+    gpuToNic_.push_back(nicNameToNicIdx[actualGpuIdxToNicName[gpuIdx]]);
   }
 
-  return std::make_shared<ContextImpl>(
-      std::move(cudaLib),
-      std::move(ibvLib),
-      std::move(ibvNics),
-      std::move(gpuToNic));
-}
-
-ContextImpl::ContextImpl()
-    : ContextImplBoilerplate<CudaBuffer, ContextImpl, ChannelImpl>(
-          /*isViable=*/false,
-          /*domainDescriptor=*/"") {}
-
-ContextImpl::ContextImpl(
-    CudaLib cudaLib,
-    IbvLib ibvLib,
-    std::vector<IbvNic> ibvNics,
-    std::vector<size_t> gpuToNic)
-    : ContextImplBoilerplate<CudaBuffer, ContextImpl, ChannelImpl>(
-          /*isViable=*/true,
-          /*domainDescriptor=*/"*"),
-      cudaLib_(std::move(cudaLib)),
-      ibvLib_(std::move(ibvLib)),
-      ibvNics_(std::move(ibvNics)),
-      gpuToNic_(std::move(gpuToNic)) {
   startThread("TP_CUDA_GDR_loop");
 }
+
 
 const CudaLib& ContextImpl::getCudaLib() {
   return cudaLib_;

--- a/tensorpipe/channel/cuda_gdr/context_impl.h
+++ b/tensorpipe/channel/cuda_gdr/context_impl.h
@@ -131,8 +131,8 @@ class ContextImpl final
   ContextImpl(
       CudaLib cudaLib,
       IbvLib ibvLib,
-      std::vector<IbvNic> ibvNics,
-      std::vector<size_t> gpuToNic);
+      IbvDeviceList deviceList,
+      optional<std::vector<std::string>> gpuIdxToNicName);
 
   std::shared_ptr<CudaChannel> createChannel(
       std::vector<std::shared_ptr<transport::Connection>> connections,
@@ -165,7 +165,7 @@ class ContextImpl final
   const IbvLib ibvLib_;
 
   std::vector<IbvNic> ibvNics_;
-  const std::vector<size_t> gpuToNic_;
+  std::vector<size_t> gpuToNic_;
 
   std::list<std::tuple<const CudaEvent&, std::function<void(const Error&)>>>
       pendingCudaEvents_;


### PR DESCRIPTION
By creating an instance of IbvNic in the factory method, it would store a reference to the IbvLib and CudaLib instances that were local variables in that method, and once these objects were moved to the ContextImpl class those references would become stale and cause segfaults when accessed.