### PR TITLE
Defer pinning of CudaHostAllocator memory until first allocation.

### DIFF
--- a/tensorpipe/channel/cuda_basic/channel_impl.cc
+++ b/tensorpipe/channel/cuda_basic/channel_impl.cc
@@ -73,7 +73,8 @@ void ChannelImpl::sendImplFromLoop(
     TDescriptorCallback descriptorCallback,
     TSendCallback callback) {
   int deviceIdx = cudaDeviceForPointer(context_->getCudaLib(), buffer.ptr);
-  CudaHostAllocator& cudaHostAllocator = context_->getCudaHostAllocator(deviceIdx);
+  CudaHostAllocator& cudaHostAllocator =
+      context_->getCudaHostAllocator(deviceIdx);
   const size_t chunkLength = cudaHostAllocator.getChunkLength();
   const size_t numChunks = ceilOfRatio(buffer.length, chunkLength);
   for (size_t offset = 0; offset < buffer.length; offset += chunkLength) {
@@ -198,7 +199,8 @@ void ChannelImpl::recvImplFromLoop(
     CudaBuffer buffer,
     TRecvCallback callback) {
   int deviceIdx = cudaDeviceForPointer(context_->getCudaLib(), buffer.ptr);
-  CudaHostAllocator& cudaHostAllocator = context_->getCudaHostAllocator(deviceIdx);
+  CudaHostAllocator& cudaHostAllocator =
+      context_->getCudaHostAllocator(deviceIdx);
   const size_t chunkLength = cudaHostAllocator.getChunkLength();
   const size_t numChunks = ceilOfRatio(buffer.length, chunkLength);
   for (size_t offset = 0; offset < buffer.length; offset += chunkLength) {
@@ -244,7 +246,8 @@ void ChannelImpl::onRecvOpReadDescriptor(
   TP_VLOG(5) << "Channel " << id_
              << " is allocating temporary memory for chunk #" << op.chunkId
              << " of " << op.numChunks << " for buffer #" << op.sequenceNumber;
-  CudaHostAllocator& cudaHostAllocator = context_->getCudaHostAllocator(op.deviceIdx);
+  CudaHostAllocator& cudaHostAllocator =
+      context_->getCudaHostAllocator(op.deviceIdx);
   cudaHostAllocator.alloc(
       op.length,
       callbackWrapper_(

--- a/tensorpipe/channel/cuda_basic/channel_impl.h
+++ b/tensorpipe/channel/cuda_basic/channel_impl.h
@@ -47,8 +47,7 @@ class ChannelImpl final
       std::string id,
       std::shared_ptr<transport::Connection> connection,
       std::shared_ptr<CpuChannel> cpuChannel,
-      CudaLoop& cudaLoop,
-      CudaHostAllocator& cudaHostAllocator);
+      CudaLoop& cudaLoop);
 
  protected:
   // Implement the entry points called by ChannelImplBoilerplate.
@@ -70,7 +69,6 @@ class ChannelImpl final
   const std::shared_ptr<transport::Connection> connection_;
   const std::shared_ptr<CpuChannel> cpuChannel_;
   CudaLoop& cudaLoop_;
-  CudaHostAllocator& cudaHostAllocator_;
   std::deque<Operation> sendOperations_;
   std::deque<Operation> recvOperations_;
 

--- a/tensorpipe/channel/cuda_basic/channel_impl.h
+++ b/tensorpipe/channel/cuda_basic/channel_impl.h
@@ -30,6 +30,7 @@ struct Operation {
   size_t chunkId{0};
   size_t numChunks{0};
   cudaStream_t stream{cudaStreamDefault};
+  int deviceIdx{0};
   void* cudaPtr{nullptr};
   size_t length{0};
   std::shared_ptr<uint8_t[]> tmpBuffer;

--- a/tensorpipe/channel/cuda_basic/context_impl.cc
+++ b/tensorpipe/channel/cuda_basic/context_impl.cc
@@ -50,8 +50,7 @@ ContextImpl::ContextImpl(
           /*isViable=*/true,
           cpuContext->domainDescriptor()),
       cudaLib_(std::move(cudaLib)),
-      cpuContext_(std::move(cpuContext)),
-      cudaHostAllocator_(in_place) {}
+      cpuContext_(std::move(cpuContext)) {}
 
 std::shared_ptr<CudaChannel> ContextImpl::createChannel(
     std::vector<std::shared_ptr<transport::Connection>> connections,
@@ -61,12 +60,10 @@ std::shared_ptr<CudaChannel> ContextImpl::createChannel(
   connections.pop_back();
   auto cpuChannel =
       cpuContext_->createChannel(std::move(connections), endpoint);
-  TP_DCHECK(cudaHostAllocator_.has_value());
   return createChannelInternal(
       std::move(conn),
       std::move(cpuChannel),
-      cudaLoop_,
-      cudaHostAllocator_.value());
+      cudaLoop_);
 }
 
 size_t ContextImpl::numConnectionsNeeded() const {
@@ -75,6 +72,14 @@ size_t ContextImpl::numConnectionsNeeded() const {
 
 const CudaLib& ContextImpl::getCudaLib() {
   return cudaLib_;
+}
+
+CudaHostAllocator& ContextImpl::getCudaHostAllocator() {
+  if (!cudaHostAllocator_.has_value()) {
+    cudaHostAllocator_.emplace();
+  }
+
+  return cudaHostAllocator_.value();
 }
 
 void ContextImpl::handleErrorImpl() {

--- a/tensorpipe/channel/cuda_basic/context_impl.cc
+++ b/tensorpipe/channel/cuda_basic/context_impl.cc
@@ -74,9 +74,9 @@ const CudaLib& ContextImpl::getCudaLib() {
   return cudaLib_;
 }
 
-CudaHostAllocator& ContextImpl::getCudaHostAllocator() {
+CudaHostAllocator& ContextImpl::getCudaHostAllocator(int deviceIdx) {
   if (!cudaHostAllocator_.has_value()) {
-    cudaHostAllocator_.emplace();
+    cudaHostAllocator_.emplace(deviceIdx);
   }
 
   return cudaHostAllocator_.value();

--- a/tensorpipe/channel/cuda_basic/context_impl.cc
+++ b/tensorpipe/channel/cuda_basic/context_impl.cc
@@ -61,9 +61,7 @@ std::shared_ptr<CudaChannel> ContextImpl::createChannel(
   auto cpuChannel =
       cpuContext_->createChannel(std::move(connections), endpoint);
   return createChannelInternal(
-      std::move(conn),
-      std::move(cpuChannel),
-      cudaLoop_);
+      std::move(conn), std::move(cpuChannel), cudaLoop_);
 }
 
 size_t ContextImpl::numConnectionsNeeded() const {

--- a/tensorpipe/channel/cuda_basic/context_impl.h
+++ b/tensorpipe/channel/cuda_basic/context_impl.h
@@ -41,6 +41,7 @@ class ContextImpl final
   size_t numConnectionsNeeded() const override;
 
   const CudaLib& getCudaLib();
+  CudaHostAllocator& getCudaHostAllocator();
 
   // Implement the DeferredExecutor interface.
   bool inLoop() const override;

--- a/tensorpipe/channel/cuda_basic/context_impl.h
+++ b/tensorpipe/channel/cuda_basic/context_impl.h
@@ -41,7 +41,7 @@ class ContextImpl final
   size_t numConnectionsNeeded() const override;
 
   const CudaLib& getCudaLib();
-  CudaHostAllocator& getCudaHostAllocator();
+  CudaHostAllocator& getCudaHostAllocator(int deviceIdx);
 
   // Implement the DeferredExecutor interface.
   bool inLoop() const override;

--- a/tensorpipe/common/cuda_host_allocator.cc
+++ b/tensorpipe/common/cuda_host_allocator.cc
@@ -14,26 +14,32 @@
 
 namespace tensorpipe {
 
+namespace {
+
+uint8_t* allocPinnedBuffer(size_t size) {
+  uint8_t* ptr;
+  TP_CUDA_CHECK(cudaMallocHost(&ptr, size));
+  return ptr;
+}
+
+void freePinnedBuffer(uint8_t* ptr) {
+  TP_CUDA_CHECK(cudaFreeHost(ptr));
+}
+
+} // namespace
+
 CudaHostAllocator::CudaHostAllocator(size_t numChunks, size_t chunkSize)
     : numChunks_(numChunks),
       chunkSize_(chunkSize),
-      data_(numChunks * chunkSize),
+      data_(allocPinnedBuffer(numChunks * chunkSize), freePinnedBuffer),
       chunkAvailable_(numChunks, true) {}
 
 CudaHostAllocator::~CudaHostAllocator() {
   close();
-  if (dataIsRegistered_) {
-    TP_CUDA_CHECK(cudaHostUnregister(data_.data()));
-  }
 }
 
 void CudaHostAllocator::alloc(size_t size, TAllocCallback callback) {
   TP_DCHECK(size <= chunkSize_);
-  if (!dataIsRegistered_) {
-    TP_CUDA_CHECK(
-        cudaHostRegister(data_.data(), data_.size(), cudaHostRegisterDefault));
-    dataIsRegistered_ = true;
-  }
   pendingAllocations_.push_back(std::move(callback));
   processAllocations();
 }
@@ -72,7 +78,7 @@ CudaHostAllocator::THostPtr CudaHostAllocator::getAvailableChunk() {
       chunkAvailable_[curChunk] = false;
       ++allocatedChunks_;
       return THostPtr(
-          data_.data() + curChunk * chunkSize_,
+          data_.get() + curChunk * chunkSize_,
           [this](uint8_t* ptr) { releaseChunk(ptr); });
     }
   }
@@ -81,7 +87,7 @@ CudaHostAllocator::THostPtr CudaHostAllocator::getAvailableChunk() {
 }
 
 void CudaHostAllocator::releaseChunk(uint8_t* ptr) {
-  size_t chunkId = (ptr - data_.data()) / chunkSize_;
+  size_t chunkId = (ptr - data_.get()) / chunkSize_;
   chunkAvailable_[chunkId] = true;
   --allocatedChunks_;
   processAllocations();

--- a/tensorpipe/common/cuda_host_allocator.h
+++ b/tensorpipe/common/cuda_host_allocator.h
@@ -43,8 +43,7 @@ class CudaHostAllocator {
  private:
   const size_t numChunks_;
   const size_t chunkSize_;
-  std::vector<uint8_t> data_;
-  bool dataIsRegistered_{false};
+  const std::unique_ptr<uint8_t[], void (*)(uint8_t*)> data_;
   std::vector<bool> chunkAvailable_;
   size_t allocatedChunks_{0};
   std::deque<TAllocCallback> pendingAllocations_;

--- a/tensorpipe/common/cuda_host_allocator.h
+++ b/tensorpipe/common/cuda_host_allocator.h
@@ -30,6 +30,7 @@ class CudaHostAllocator {
   using TAllocCallback = std::function<void(const Error&, THostPtr)>;
 
   explicit CudaHostAllocator(
+      int deviceIdx,
       size_t numChunks = 16,
       size_t chunkSize = 1024 * 1024);
 
@@ -43,7 +44,7 @@ class CudaHostAllocator {
  private:
   const size_t numChunks_;
   const size_t chunkSize_;
-  const std::unique_ptr<uint8_t[], void (*)(uint8_t*)> data_;
+  const std::unique_ptr<uint8_t[], std::function<void(uint8_t*)>> data_;
   std::vector<bool> chunkAvailable_;
   size_t allocatedChunks_{0};
   std::deque<TAllocCallback> pendingAllocations_;

--- a/tensorpipe/common/cuda_host_allocator.h
+++ b/tensorpipe/common/cuda_host_allocator.h
@@ -43,7 +43,8 @@ class CudaHostAllocator {
  private:
   const size_t numChunks_;
   const size_t chunkSize_;
-  const std::unique_ptr<uint8_t[], void (*)(uint8_t*)> data_;
+  std::vector<uint8_t> data_;
+  bool dataIsRegistered_{false};
   std::vector<bool> chunkAvailable_;
   size_t allocatedChunks_{0};
   std::deque<TAllocCallback> pendingAllocations_;
@@ -52,8 +53,6 @@ class CudaHostAllocator {
   void processAllocations();
   THostPtr getAvailableChunk();
   void releaseChunk(uint8_t* ptr);
-
-  void hostPtrDeleter(uint8_t* ptr);
 };
 
 } // namespace tensorpipe

--- a/tensorpipe/common/cuda_host_allocator.h
+++ b/tensorpipe/common/cuda_host_allocator.h
@@ -24,6 +24,15 @@ class CudaHostAllocatorClosedError final : public BaseError {
   }
 };
 
+class CudaPinnedMemoryDeleter {
+ public:
+  CudaPinnedMemoryDeleter(int deviceIdx);
+  void operator()(uint8_t* ptr);
+
+ private:
+  const int deviceIdx_;
+};
+
 class CudaHostAllocator {
  public:
   using THostPtr = std::shared_ptr<uint8_t[]>;
@@ -44,7 +53,7 @@ class CudaHostAllocator {
  private:
   const size_t numChunks_;
   const size_t chunkSize_;
-  const std::unique_ptr<uint8_t[], std::function<void(uint8_t*)>> data_;
+  const std::unique_ptr<uint8_t[], CudaPinnedMemoryDeleter> data_;
   std::vector<bool> chunkAvailable_;
   size_t allocatedChunks_{0};
   std::deque<TAllocCallback> pendingAllocations_;


### PR DESCRIPTION
The call to `cudaMallocHost()` on channel instantiation would
initialize a CUDA context on the current device, which at that point
might very well be the default device for no other reason that no CUDA
calls have been made prior. Deferring the registration allows us to
make it happen on an existing CUDA context.

Rather than allocating the underlying memory upon first `alloc()`, we
do it on initialization, and register it later via
`cudaHostRegister()`.

The underlying memory slab was previously a `unique_ptr` in order to
have a RAII wrapper around `cudaMallocHost()`/`cudaFreeHost()`. As
this is not wanted anymore, we simply use a `vector` and invoke
`cudaHostUnregister()` in the destructor.