### PR TITLE
Fix CMA joining non-existing thread when not viable

### DIFF
--- a/tensorpipe/channel/cma/context_impl.cc
+++ b/tensorpipe/channel/cma/context_impl.cc
@@ -202,7 +202,7 @@ std::shared_ptr<ContextImpl> ContextImpl::create() {
       }
       switch (yamaScope.value()) {
         case YamaPtraceScope::kClassicPtracePermissions:
-          TP_VLOG(5) << "YAMA ptrace scope set to classic ptrace persmissions";
+          TP_VLOG(5) << "YAMA ptrace scope set to classic ptrace permissions";
           break;
         case YamaPtraceScope::kRestrictedPtrace:
           TP_VLOG(5) << "YAMA ptrace scope set to restricted ptrace";
@@ -247,6 +247,7 @@ ContextImpl::ContextImpl(std::string domainDescriptor)
           /*isViable=*/true,
           std::move(domainDescriptor)) {
   thread_ = std::thread(&ContextImpl::handleCopyRequests, this);
+  threadRunning_ = true;
 }
 
 std::shared_ptr<CpuChannel> ContextImpl::createChannel(
@@ -261,7 +262,10 @@ void ContextImpl::handleErrorImpl() {
 }
 
 void ContextImpl::joinImpl() {
-  thread_.join();
+  if (threadRunning_) {
+    thread_.join();
+    threadRunning_ = false;
+  }
   // TP_DCHECK(requests_.empty());
 }
 

--- a/tensorpipe/channel/cma/context_impl.h
+++ b/tensorpipe/channel/cma/context_impl.h
@@ -69,6 +69,8 @@ class ContextImpl final
   };
 
   std::thread thread_;
+  // Whether the thread was started (it isn't if the context isn't viable).
+  bool threadRunning_{false};
   Queue<optional<CopyRequest>> requests_{std::numeric_limits<int>::max()};
 
   // This is atomic because it may be accessed from outside the loop.

--- a/tensorpipe/test/channel/cma/docker_tests.sh
+++ b/tensorpipe/test/channel/cma/docker_tests.sh
@@ -32,13 +32,15 @@ docker run \
   /tmp/build/tensorpipe/test/channel/cma/tensorpipe_channel_cma_probe \
   0 /tmp/report/socket \
   > /tmp/report/probe1_report.json & \
-  # To allow the probe to bind to the socket \
-  sleep 0.1; \
+  probe1_pid=$!; \
+  while [ ! -S /tmp/report/socket ]; do sleep 0.1; done; \
   TP_VERBOSE_LOGGING=5 \
   /tmp/build/tensorpipe/test/channel/cma/tensorpipe_channel_cma_probe \
   1 /tmp/report/socket \
   > /tmp/report/probe2_report.json & \
-  wait'
+  probe2_pid=$!; \
+  wait $probe1_pid; \
+  wait $probe2_pid'
 
 python3 \
   "$(pwd)/tensorpipe/test/channel/cma/probe_report_checker.py" \
@@ -62,13 +64,15 @@ docker run \
   /tmp/build/tensorpipe/test/channel/cma/tensorpipe_channel_cma_probe \
   0 /tmp/report/socket \
   > /tmp/report/probe1_report.json & \
-  # To allow the probe to bind to the socket \
-  sleep 0.1; \
+  probe1_pid=$!; \
+  while [ ! -S /tmp/report/socket ]; do sleep 0.1; done; \
   TP_VERBOSE_LOGGING=5 \
   /tmp/build/tensorpipe/test/channel/cma/tensorpipe_channel_cma_probe \
   1 /tmp/report/socket \
   > /tmp/report/probe2_report.json & \
-  wait'
+  probe2_pid=$!; \
+  wait $probe1_pid; \
+  wait $probe2_pid'
 
 python3 \
   "$(pwd)/tensorpipe/test/channel/cma/probe_report_checker.py" \
@@ -93,13 +97,15 @@ docker run \
   /tmp/build/tensorpipe/test/channel/cma/tensorpipe_channel_cma_probe \
   0 /tmp/report/socket \
   > /tmp/report/probe1_report.json & \
-  # To allow the probe to bind to the socket \
-  sleep 0.1; \
+  probe1_pid=$!; \
+  while [ ! -S /tmp/report/socket ]; do sleep 0.1; done; \
   TP_VERBOSE_LOGGING=5 \
   /tmp/build/tensorpipe/test/channel/cma/tensorpipe_channel_cma_probe \
   1 /tmp/report/socket \
   > /tmp/report/probe2_report.json & \
-  wait'
+  probe2_pid=$!; \
+  wait $probe1_pid; \
+  wait $probe2_pid'
 
 python3 \
   "$(pwd)/tensorpipe/test/channel/cma/probe_report_checker.py" \
@@ -124,13 +130,15 @@ docker run \
   /tmp/build/tensorpipe/test/channel/cma/tensorpipe_channel_cma_probe \
   0 /tmp/report/socket \
   > /tmp/report/probe1_report.json & \
-  # To allow the probe to bind to the socket \
-  sleep 0.1; \
+  probe1_pid=$!; \
+  while [ ! -S /tmp/report/socket ]; do sleep 0.1; done; \
   TP_VERBOSE_LOGGING=5 \
   /tmp/build/tensorpipe/test/channel/cma/tensorpipe_channel_cma_probe \
   1 /tmp/report/socket \
   > /tmp/report/probe2_report.json & \
-  wait'
+  probe2_pid=$!; \
+  wait $probe1_pid; \
+  wait $probe2_pid'
 
 python3 \
   "$(pwd)/tensorpipe/test/channel/cma/probe_report_checker.py" \
@@ -160,13 +168,15 @@ docker run \
   /tmp/build/tensorpipe/test/channel/cma/tensorpipe_channel_cma_probe \
   0 /tmp/report/socket \
   > /tmp/report/probe1_report.json & \
-  # To allow the probe to bind to the socket \
-  sleep 0.1; \
+  probe1_pid=$!; \
+  while [ ! -S /tmp/report/socket ]; do sleep 0.1; done; \
   TP_VERBOSE_LOGGING=5 \
   /tmp/build/tensorpipe/test/channel/cma/tensorpipe_channel_cma_probe \
   1 /tmp/report/socket \
   > /tmp/report/probe2_report.json & \
-  wait'
+  probe2_pid=$!; \
+  wait $probe1_pid; \
+  wait $probe2_pid'
 
 python3 \
   "$(pwd)/tensorpipe/test/channel/cma/probe_report_checker.py" \
@@ -193,8 +203,6 @@ chmod ugo+rwx "$TEMPDIR"
 echo "Using $TEMPDIR for staging data"
 
 docker run \
-  --detach \
-  --cidfile "$TEMPDIR/probe1_container_id" \
   --volume "$TEMPDIR:/tmp/report" \
   --volume "$(pwd)/build:/tmp/build" \
   --security-opt seccomp=unconfined \
@@ -203,12 +211,10 @@ docker run \
   TP_VERBOSE_LOGGING=5 \
   /tmp/build/tensorpipe/test/channel/cma/tensorpipe_channel_cma_probe \
   0 /tmp/report/socket \
-  > /tmp/report/probe1_report.json'
-docker logs --follow "$(cat "$TEMPDIR/probe1_container_id")" &
-sleep 0.1 # To allow probe to bind to socket
+  > /tmp/report/probe1_report.json' &
+probe1_pid=$!
+while [ ! -S "$TEMPDIR/socket" ]; do sleep 0.1; done
 docker run \
-  --detach \
-  --cidfile "$TEMPDIR/probe2_container_id" \
   --volume "$TEMPDIR:/tmp/report" \
   --volume "$(pwd)/build:/tmp/build" \
   --security-opt seccomp=unconfined \
@@ -217,9 +223,10 @@ docker run \
   TP_VERBOSE_LOGGING=5 \
   /tmp/build/tensorpipe/test/channel/cma/tensorpipe_channel_cma_probe \
   1 /tmp/report/socket \
-  > /tmp/report/probe2_report.json'
-docker logs --follow "$(cat "$TEMPDIR/probe2_container_id")" &
-docker wait "$(cat "$TEMPDIR/probe1_container_id")" "$(cat "$TEMPDIR/probe2_container_id")"
+  > /tmp/report/probe2_report.json' &
+probe2_pid=$!
+wait $probe1_pid
+wait $probe2_pid
 
 python3 \
   "$(pwd)/tensorpipe/test/channel/cma/probe_report_checker.py" \
@@ -238,8 +245,6 @@ chmod ugo+rwx "$TEMPDIR"
 echo "Using $TEMPDIR for staging data"
 
 docker run \
-  --detach \
-  --cidfile "$TEMPDIR/probe1_container_id" \
   --volume "$TEMPDIR:/tmp/report" \
   --volume "$(pwd)/build:/tmp/build" \
   --security-opt seccomp=unconfined \
@@ -250,12 +255,10 @@ docker run \
   TP_VERBOSE_LOGGING=5 \
   /tmp/build/tensorpipe/test/channel/cma/tensorpipe_channel_cma_probe \
   0 /tmp/report/socket \
-  > /tmp/report/probe1_report.json'
-docker logs --follow "$(cat "$TEMPDIR/probe1_container_id")" &
-sleep 0.1 # To allow probe to bind to socket
+  > /tmp/report/probe1_report.json' &
+probe1_pid=$!
+while [ ! -S "$TEMPDIR/socket" ]; do sleep 0.1; done
 docker run \
-  --detach \
-  --cidfile "$TEMPDIR/probe2_container_id" \
   --volume "$TEMPDIR:/tmp/report" \
   --volume "$(pwd)/build:/tmp/build" \
   --security-opt seccomp=unconfined \
@@ -266,9 +269,10 @@ docker run \
   TP_VERBOSE_LOGGING=5 \
   /tmp/build/tensorpipe/test/channel/cma/tensorpipe_channel_cma_probe \
   1 /tmp/report/socket \
-  > /tmp/report/probe2_report.json'
-docker logs --follow "$(cat "$TEMPDIR/probe2_container_id")" &
-docker wait "$(cat "$TEMPDIR/probe1_container_id")" "$(cat "$TEMPDIR/probe2_container_id")"
+  > /tmp/report/probe2_report.json' &
+probe2_pid=$!
+wait $probe1_pid
+wait $probe2_pid
 
 python3 \
   "$(pwd)/tensorpipe/test/channel/cma/probe_report_checker.py" \
@@ -283,7 +287,6 @@ chmod ugo+rwx "$TEMPDIR"
 echo "Using $TEMPDIR for staging data"
 
 docker run \
-  --detach \
   --cidfile "$TEMPDIR/probe1_container_id" \
   --volume "$TEMPDIR:/tmp/report" \
   --volume "$(pwd)/build:/tmp/build" \
@@ -293,12 +296,10 @@ docker run \
   TP_VERBOSE_LOGGING=5 \
   /tmp/build/tensorpipe/test/channel/cma/tensorpipe_channel_cma_probe \
   0 /tmp/report/socket \
-  > /tmp/report/probe1_report.json'
-docker logs --follow "$(cat "$TEMPDIR/probe1_container_id")" &
-sleep 0.1 # To allow probe to bind to socket
+  > /tmp/report/probe1_report.json' &
+probe1_pid=$!
+while [ ! -S "$TEMPDIR/socket" ]; do sleep 0.1; done
 docker run \
-  --detach \
-  --cidfile "$TEMPDIR/probe2_container_id" \
   --volume "$TEMPDIR:/tmp/report" \
   --volume "$(pwd)/build:/tmp/build" \
   --pid "container:$(cat "$TEMPDIR/probe1_container_id")" \
@@ -308,9 +309,10 @@ docker run \
   TP_VERBOSE_LOGGING=5 \
   /tmp/build/tensorpipe/test/channel/cma/tensorpipe_channel_cma_probe \
   1 /tmp/report/socket \
-  > /tmp/report/probe2_report.json'
-docker logs --follow "$(cat "$TEMPDIR/probe2_container_id")" &
-docker wait "$(cat "$TEMPDIR/probe1_container_id")" "$(cat "$TEMPDIR/probe2_container_id")"
+  > /tmp/report/probe2_report.json' &
+probe2_pid=$!
+wait $probe1_pid
+wait $probe2_pid
 
 python3 \
   "$(pwd)/tensorpipe/test/channel/cma/probe_report_checker.py" \
@@ -329,8 +331,6 @@ chmod ugo+rwx "$TEMPDIR"
 echo "Using $TEMPDIR for staging data"
 
 docker run \
-  --detach \
-  --cidfile "$TEMPDIR/probe1_container_id" \
   --volume "$TEMPDIR:/tmp/report" \
   --volume "$(pwd)/build:/tmp/build" \
   --security-opt seccomp=unconfined \
@@ -341,17 +341,17 @@ docker run \
   TP_VERBOSE_LOGGING=5 \
   /tmp/build/tensorpipe/test/channel/cma/tensorpipe_channel_cma_probe \
   0 /tmp/report/socket \
-  > /tmp/report/probe1_report.json'
-docker logs --follow "$(cat "$TEMPDIR/probe1_container_id")" &
-sleep 0.1 # To allow probe to bind to socket
+  > /tmp/report/probe1_report.json' &
+probe1_pid=$!
+while [ ! -S "$TEMPDIR/socket" ]; do sleep 0.1; done
 sudo chmod ugo+rwx "$TEMPDIR"/socket
 TP_VERBOSE_LOGGING=5 \
   "$(pwd)/build/tensorpipe/test/channel/cma/tensorpipe_channel_cma_probe" \
   1 "$TEMPDIR/socket" \
-  > "$TEMPDIR/probe2_report.json" \
-  &
-docker wait "$(cat "$TEMPDIR/probe1_container_id")"
-wait
+  > "$TEMPDIR/probe2_report.json" &
+probe2_pid=$!
+wait $probe1_pid
+wait $probe2_pid
 
 python3 \
   "$(pwd)/tensorpipe/test/channel/cma/probe_report_checker.py" \
@@ -366,8 +366,6 @@ chmod ugo+rwx "$TEMPDIR"
 echo "Using $TEMPDIR for staging data"
 
 docker run \
-  --detach \
-  --cidfile "$TEMPDIR/probe1_container_id" \
   --volume "$TEMPDIR:/tmp/report" \
   --volume "$(pwd)/build:/tmp/build" \
   --security-opt seccomp=unconfined \
@@ -380,17 +378,17 @@ docker run \
   TP_VERBOSE_LOGGING=5 \
   /tmp/build/tensorpipe/test/channel/cma/tensorpipe_channel_cma_probe \
   0 /tmp/report/socket \
-  > /tmp/report/probe1_report.json'
-docker logs --follow "$(cat "$TEMPDIR/probe1_container_id")" &
-sleep 0.1 # To allow probe to bind to socket
+  > /tmp/report/probe1_report.json' &
+probe1_pid=$!
+while [ ! -S "$TEMPDIR/socket" ]; do sleep 0.1; done
 sudo chmod ugo+rwx "$TEMPDIR"/socket
 TP_VERBOSE_LOGGING=5 \
   "$(pwd)/build/tensorpipe/test/channel/cma/tensorpipe_channel_cma_probe" \
   1 "$TEMPDIR/socket" \
-  > "$TEMPDIR/probe2_report.json" \
-  &
-docker wait "$(cat "$TEMPDIR/probe1_container_id")"
-wait
+  > "$TEMPDIR/probe2_report.json" &
+probe2_pid=$!
+wait $probe1_pid
+wait $probe2_pid
 
 python3 \
   "$(pwd)/tensorpipe/test/channel/cma/probe_report_checker.py" \
@@ -405,8 +403,6 @@ chmod ugo+rwx "$TEMPDIR"
 echo "Using $TEMPDIR for staging data"
 
 docker run \
-  --detach \
-  --cidfile "$TEMPDIR/probe1_container_id" \
   --volume "$TEMPDIR:/tmp/report" \
   --volume "$(pwd)/build:/tmp/build" \
   --security-opt seccomp=unconfined \
@@ -419,17 +415,17 @@ docker run \
   TP_VERBOSE_LOGGING=5 \
   /tmp/build/tensorpipe/test/channel/cma/tensorpipe_channel_cma_probe \
   0 /tmp/report/socket \
-  > /tmp/report/probe1_report.json'
-docker logs --follow "$(cat "$TEMPDIR/probe1_container_id")" &
-sleep 0.1 # To allow probe to bind to socket
+  > /tmp/report/probe1_report.json' &
+probe1_pid=$!
+while [ ! -S "$TEMPDIR/socket" ]; do sleep 0.1; done
 sudo chmod ugo+rwx "$TEMPDIR"/socket
 TP_VERBOSE_LOGGING=5 \
   "$(pwd)/build/tensorpipe/test/channel/cma/tensorpipe_channel_cma_probe" \
   1 "$TEMPDIR/socket" \
-  > "$TEMPDIR/probe2_report.json" \
-  &
-docker wait "$(cat "$TEMPDIR/probe1_container_id")"
-wait
+  > "$TEMPDIR/probe2_report.json" &
+probe2_pid=$!
+wait $probe1_pid
+wait $probe2_pid
 
 python3 \
   "$(pwd)/tensorpipe/test/channel/cma/probe_report_checker.py" \
@@ -446,15 +442,16 @@ echo "Using $TEMPDIR for staging data"
 TP_VERBOSE_LOGGING=5 \
   "$(pwd)/build/tensorpipe/test/channel/cma/tensorpipe_channel_cma_probe" \
   0 "$TEMPDIR/socket" \
-  > "$TEMPDIR/probe1_report.json" \
-  &
-sleep 0.1 # To allow probe to bind to socket
+  > "$TEMPDIR/probe1_report.json" &
+probe1_pid=$!
+while [ ! -S "$TEMPDIR/socket" ]; do sleep 0.1; done
 TP_VERBOSE_LOGGING=5 \
   "$(pwd)/build/tensorpipe/test/channel/cma/tensorpipe_channel_cma_probe" \
   1 "$TEMPDIR/socket" \
-  > "$TEMPDIR/probe2_report.json" \
-  &
-wait
+  > "$TEMPDIR/probe2_report.json" &
+probe2_pid=$!
+wait $probe1_pid
+wait $probe2_pid
 
 python3 \
   "$(pwd)/tensorpipe/test/channel/cma/probe_report_checker.py" \


### PR DESCRIPTION
Summary:
This was causing a std::system_error exception to be throw by the join method (indirectly called by the destructor) with an EINVAL error.

We had a similar problem in D26072723 (https://github.com/pytorch/tensorpipe/commit/ce59a29d8d5e6e2dea237a87773cff5e9261c696), and hence I'm adopting a similar fix.

This error was actually being triggered in our CI, but it was ignored because of how bash's `wait` works, as in, when it's called without arguments it returns 0 even if some process failed. So here I'm also fixing that test.

I'm replacing `docker run --detach` with `docker run &` because `docker wait`, by design, prints the error codes but always returns 0, thus I'm dropping that in favor of a plain `wait`. I also needed to increase the timeout between the launches of the two endpoints from 0.1s to 0.5s because before the command (`docker run --detach`) would return only once the container had effectively been started, whereas now ( `docker run &`) it doesn't wait for the container to start and thus we need to factor that time in as well.

Differential Revision: D26977908

