### PR TITLE
Use state machine in CUDA XTH

### DIFF
--- a/tensorpipe/channel/cma/channel_impl.cc
+++ b/tensorpipe/channel/cma/channel_impl.cc
@@ -55,26 +55,75 @@ void ChannelImpl::sendImplFromLoop(
     CpuBuffer buffer,
     TDescriptorCallback descriptorCallback,
     TSendCallback callback) {
+  SendOpIter opIter = sendOps_.emplaceBack(sequenceNumber);
+  SendOperation& op = *opIter;
+  op.callback = std::move(callback);
+
+  sendOps_.advanceOperation(opIter);
+
+  NopHolder<Descriptor> nopHolder;
+  Descriptor& nopDescriptor = nopHolder.getObject();
+  nopDescriptor.pid = ::getpid();
+  nopDescriptor.ptr = reinterpret_cast<uint64_t>(buffer.ptr);
+  descriptorCallback(Error::kSuccess, saveDescriptor(nopHolder));
+}
+
+void ChannelImpl::advanceSendOperation(
+    SendOpIter opIter,
+    SendOperation::State prevOpState) {
+  TP_DCHECK(context_->inLoop());
+
+  SendOperation& op = *opIter;
+
+  sendOps_.attemptTransition(
+      opIter,
+      /*from=*/SendOperation::UNINITIALIZED,
+      /*to=*/SendOperation::FINISHED,
+      /*cond=*/error_,
+      /*actions=*/{&ChannelImpl::callSendCallback});
+
+  // Needs to go after previous op to ensure predictable and consistent ordering
+  // of read calls on the control connection.
+  sendOps_.attemptTransition(
+      opIter,
+      /*from=*/SendOperation::UNINITIALIZED,
+      /*to=*/SendOperation::READING_NOTIFICATION,
+      /*cond=*/!error_ && prevOpState >= SendOperation::READING_NOTIFICATION,
+      /*actions=*/{&ChannelImpl::readNotification});
+
+  sendOps_.attemptTransition(
+      opIter,
+      /*from=*/SendOperation::READING_NOTIFICATION,
+      /*to=*/SendOperation::FINISHED,
+      /*cond=*/op.doneReadingNotification,
+      /*actions=*/{&ChannelImpl::callSendCallback});
+}
+
+void ChannelImpl::readNotification(SendOpIter opIter) {
+  SendOperation& op = *opIter;
+
   TP_VLOG(6) << "Channel " << id_ << " is reading notification (#"
-             << sequenceNumber << ")";
+             << op.sequenceNumber << ")";
   connection_->read(
       nullptr,
       0,
-      callbackWrapper_([sequenceNumber, callback{std::move(callback)}](
+      callbackWrapper_([opIter](
                            ChannelImpl& impl,
                            const void* /* unused */,
                            size_t /* unused */) {
         TP_VLOG(6) << "Channel " << impl.id_ << " done reading notification (#"
-                   << sequenceNumber << ")";
-        callback(impl.error_);
+                   << opIter->sequenceNumber << ")";
+        opIter->doneReadingNotification = true;
+        impl.sendOps_.advanceOperation(opIter);
       }));
+}
 
-  NopHolder<Descriptor> nopHolder;
-  Descriptor& nopDescriptor = nopHolder.getObject();
-  nopDescriptor.pid = getpid();
-  nopDescriptor.ptr = reinterpret_cast<uint64_t>(buffer.ptr);
+void ChannelImpl::callSendCallback(SendOpIter opIter) {
+  SendOperation& op = *opIter;
 
-  descriptorCallback(Error::kSuccess, saveDescriptor(nopHolder));
+  op.callback(error_);
+  // Reset callback to release the resources it was holding.
+  op.callback = nullptr;
 }
 
 void ChannelImpl::recvImplFromLoop(
@@ -82,41 +131,105 @@ void ChannelImpl::recvImplFromLoop(
     TDescriptor descriptor,
     CpuBuffer buffer,
     TRecvCallback callback) {
+  RecvOpIter opIter = recvOps_.emplaceBack(sequenceNumber);
+  RecvOperation& op = *opIter;
+  op.ptr = buffer.ptr;
+  op.length = buffer.length;
+  op.callback = std::move(callback);
+
   NopHolder<Descriptor> nopHolder;
   loadDescriptor(nopHolder, descriptor);
   Descriptor& nopDescriptor = nopHolder.getObject();
-  pid_t remotePid = nopDescriptor.pid;
-  void* remotePtr = reinterpret_cast<void*>(nopDescriptor.ptr);
+  op.remotePid = nopDescriptor.pid;
+  op.remotePtr = reinterpret_cast<void*>(nopDescriptor.ptr);
 
-  TP_VLOG(6) << "Channel " << id_ << " is copying payload (#" << sequenceNumber
-             << ")";
+  recvOps_.advanceOperation(opIter);
+}
+
+void ChannelImpl::advanceRecvOperation(
+    RecvOpIter opIter,
+    RecvOperation::State prevOpState) {
+  TP_DCHECK(context_->inLoop());
+
+  RecvOperation& op = *opIter;
+
+  recvOps_.attemptTransition(
+      opIter,
+      /*from=*/RecvOperation::UNINITIALIZED,
+      /*to=*/RecvOperation::FINISHED,
+      /*cond=*/error_,
+      /*actions=*/{&ChannelImpl::callRecvCallback});
+
+  recvOps_.attemptTransition(
+      opIter,
+      /*from=*/RecvOperation::UNINITIALIZED,
+      /*to=*/RecvOperation::COPYING,
+      /*cond=*/!error_,
+      /*actions=*/{&ChannelImpl::copy});
+
+  recvOps_.attemptTransition(
+      opIter,
+      /*from=*/RecvOperation::COPYING,
+      /*to=*/RecvOperation::FINISHED,
+      /*cond=*/error_ && op.doneCopying,
+      /*actions=*/{&ChannelImpl::callRecvCallback});
+
+  // Needs to go after previous op to ensure predictable and consistent ordering
+  // of write calls on the control connection.
+  recvOps_.attemptTransition(
+      opIter,
+      /*from=*/RecvOperation::COPYING,
+      /*to=*/RecvOperation::FINISHED,
+      /*cond=*/!error_ && op.doneCopying &&
+          prevOpState >= RecvOperation::FINISHED,
+      /*actions=*/
+      {&ChannelImpl::callRecvCallback, &ChannelImpl::writeNotification});
+}
+
+void ChannelImpl::copy(RecvOpIter opIter) {
+  RecvOperation& op = *opIter;
+
+  TP_VLOG(6) << "Channel " << id_ << " is copying payload (#"
+             << op.sequenceNumber << ")";
   context_->requestCopy(
-      remotePid,
-      remotePtr,
-      buffer.ptr,
-      buffer.length,
-      callbackWrapper_([sequenceNumber,
-                        callback{std::move(callback)}](ChannelImpl& impl) {
+      op.remotePid,
+      op.remotePtr,
+      op.ptr,
+      op.length,
+      callbackWrapper_([opIter](ChannelImpl& impl) {
         TP_VLOG(6) << "Channel " << impl.id_ << " done copying payload (#"
-                   << sequenceNumber << ")";
+                   << opIter->sequenceNumber << ")";
+        opIter->doneCopying = true;
+        impl.recvOps_.advanceOperation(opIter);
+      }));
+}
 
-        // Let peer know we've completed the copy.
-        TP_VLOG(6) << "Channel " << impl.id_ << " is writing notification (#"
-                   << sequenceNumber << ")";
-        impl.connection_->write(
-            nullptr,
-            0,
-            impl.callbackWrapper_([sequenceNumber](ChannelImpl& impl) {
-              TP_VLOG(6) << "Channel " << impl.id_
-                         << " done writing notification (#" << sequenceNumber
-                         << ")";
-            }));
+void ChannelImpl::callRecvCallback(RecvOpIter opIter) {
+  RecvOperation& op = *opIter;
 
-        callback(impl.error_);
+  op.callback(error_);
+  // Reset callback to release the resources it was holding.
+  op.callback = nullptr;
+}
+
+void ChannelImpl::writeNotification(RecvOpIter opIter) {
+  RecvOperation& op = *opIter;
+
+  TP_VLOG(6) << "Channel " << id_ << " is writing notification (#"
+             << op.sequenceNumber << ")";
+  connection_->write(
+      nullptr,
+      0,
+      callbackWrapper_([sequenceNumber{op.sequenceNumber}](ChannelImpl& impl) {
+        TP_VLOG(6) << "Channel " << impl.id_ << " done writing notification (#"
+                   << sequenceNumber << ")";
       }));
 }
 
 void ChannelImpl::handleErrorImpl() {
+  sendOps_.advanceAllOperations();
+  recvOps_.advanceAllOperations();
+
   connection_->close();
 
   context_->unenroll(*this);

--- a/tensorpipe/channel/cma/channel_impl.h
+++ b/tensorpipe/channel/cma/channel_impl.h
@@ -13,6 +13,7 @@
 
 #include <tensorpipe/channel/channel_impl_boilerplate.h>
 #include <tensorpipe/common/cpu_buffer.h>
+#include <tensorpipe/common/state_machine.h>
 #include <tensorpipe/transport/context.h>
 
 namespace tensorpipe {
@@ -20,6 +21,40 @@ namespace channel {
 namespace cma {
 
 class ContextImpl;
+
+struct SendOperation {
+  enum State { UNINITIALIZED, READING_NOTIFICATION, FINISHED };
+
+  // Fields used by the state machine
+  uint64_t sequenceNumber{0};
+  State state{UNINITIALIZED};
+
+  // Progress flags
+  bool doneReadingNotification{false};
+
+  // Arguments at creation
+  TSendCallback callback;
+};
+
+struct RecvOperation {
+  enum State { UNINITIALIZED, COPYING, FINISHED };
+
+  // Fields used by the state machine
+  uint64_t sequenceNumber{0};
+  State state{UNINITIALIZED};
+
+  // Progress flags
+  bool doneCopying{false};
+
+  // Arguments at creation
+  void* ptr;
+  size_t length;
+  TRecvCallback callback;
+
+  // Other data
+  pid_t remotePid;
+  void* remotePtr;
+};
 
 class ChannelImpl final
     : public ChannelImplBoilerplate<CpuBuffer, ContextImpl, ChannelImpl> {
@@ -47,6 +82,32 @@ class ChannelImpl final
 
  private:
   const std::shared_ptr<transport::Connection> connection_;
+
+  OpsStateMachine<ChannelImpl, SendOperation> sendOps_{
+      *this,
+      &ChannelImpl::advanceSendOperation};
+  using SendOpIter = decltype(sendOps_)::Iter;
+  OpsStateMachine<ChannelImpl, RecvOperation> recvOps_{
+      *this,
+      &ChannelImpl::advanceRecvOperation};
+  using RecvOpIter = decltype(recvOps_)::Iter;
+
+  // State machines for send and recv ops.
+  void advanceSendOperation(
+      SendOpIter opIter,
+      SendOperation::State prevOpState);
+  void advanceRecvOperation(
+      RecvOpIter opIter,
+      RecvOperation::State prevOpState);
+
+  // Actions (i.e., methods that begin a state transition).
+  // For send operations:
+  void readNotification(SendOpIter opIter);
+  void callSendCallback(SendOpIter opIter);
+  // For recv operations:
+  void copy(RecvOpIter opIter);
+  void callRecvCallback(RecvOpIter opIter);
+  void writeNotification(RecvOpIter opIter);
 };
 
 } // namespace cma

--- a/tensorpipe/channel/cuda_xth/channel_impl.cc
+++ b/tensorpipe/channel/cuda_xth/channel_impl.cc
@@ -18,7 +18,6 @@
 
 #include <tensorpipe/channel/cuda_xth/context_impl.h>
 #include <tensorpipe/channel/helpers.h>
-#include <tensorpipe/common/cuda.h>
 #include <tensorpipe/common/defs.h>
 #include <tensorpipe/common/error.h>
 #include <tensorpipe/transport/connection.h>
@@ -29,44 +28,46 @@ namespace cuda_xth {
 
 namespace {
 
-class SendOperation {
- public:
-  explicit SendOperation(int deviceIdx, CudaBuffer buffer)
-      : buffer_(buffer), deviceIdx_(deviceIdx), startEv_(deviceIdx) {
-    startEv_.record(buffer_.stream);
-  }
-
-  void process(int dstDeviceIdx, CudaBuffer dstBuffer) {
-    startEv_.wait(dstBuffer.stream, dstDeviceIdx);
-
-    TP_DCHECK_EQ(buffer_.length, dstBuffer.length);
-    {
-      CudaDeviceGuard guard(dstDeviceIdx);
-      TP_CUDA_CHECK(cudaMemcpyAsync(
-          dstBuffer.ptr,
-          buffer_.ptr,
-          dstBuffer.length,
-          cudaMemcpyDeviceToDevice,
-          dstBuffer.stream));
-    }
-
-    CudaEvent stopEv(dstDeviceIdx);
-    stopEv.record(dstBuffer.stream);
-    stopEv.wait(buffer_.stream, deviceIdx_);
-  }
-
- private:
-  const CudaBuffer buffer_;
-  const int deviceIdx_;
-  CudaEvent startEv_;
-};
-
 struct Descriptor {
-  uintptr_t opPtr;
-  NOP_STRUCTURE(Descriptor, opPtr);
+  uintptr_t startEvent;
+  uintptr_t srcPtr;
+  int srcDeviceIdx;
+  uintptr_t srcStream;
+  NOP_STRUCTURE(Descriptor, startEvent, srcPtr, srcDeviceIdx, srcStream);
 };
 
 } // namespace
+
+SendOperation::SendOperation(
+    int deviceIdx,
+    cudaStream_t stream,
+    TSendCallback callback)
+    : callback(std::move(callback)), startEv(deviceIdx) {
+  startEv.record(stream);
+}
+
+RecvOperation::RecvOperation(
+    int deviceIdx,
+    CudaBuffer buffer,
+    TRecvCallback callback)
+    : ptr(buffer.ptr),
+      length(buffer.length),
+      deviceIdx(deviceIdx),
+      stream(buffer.stream),
+      callback(std::move(callback)) {}
+
+void RecvOperation::process() {
+  {
+    CudaDeviceGuard guard(deviceIdx);
+    TP_CUDA_CHECK(cudaStreamWaitEvent(stream, startEvent, 0));
+    TP_CUDA_CHECK(
+        cudaMemcpyAsync(ptr, srcPtr, length, cudaMemcpyDeviceToDevice, stream));
+  }
+
+  CudaEvent stopEv(deviceIdx);
+  stopEv.record(stream);
+  stopEv.wait(srcStream, srcDeviceIdx);
+}
 
 ChannelImpl::ChannelImpl(
     ConstructorToken token,
@@ -89,30 +90,79 @@ void ChannelImpl::sendImplFromLoop(
     TDescriptorCallback descriptorCallback,
     TSendCallback callback) {
   int deviceIdx = cudaDeviceForPointer(context_->getCudaLib(), buffer.ptr);
+  SendOpIter opIter = sendOps_.emplaceBack(
+      sequenceNumber, deviceIdx, buffer.stream, std::move(callback));
+  SendOperation& op = *opIter;
 
-  // The op must be kept alive until the notification has been received.
-  auto op = std::make_shared<SendOperation>(deviceIdx, buffer);
+  sendOps_.advanceOperation(opIter);
+
   NopHolder<Descriptor> nopHolder;
   Descriptor& nopDescriptor = nopHolder.getObject();
-  nopDescriptor.opPtr = reinterpret_cast<uintptr_t>(op.get());
+  static_assert(std::is_pointer<cudaEvent_t>::value, "");
+  static_assert(std::is_pointer<cudaStream_t>::value, "");
+  nopDescriptor.startEvent = reinterpret_cast<uintptr_t>(op.startEv.raw());
+  nopDescriptor.srcPtr = reinterpret_cast<uintptr_t>(buffer.ptr);
+  nopDescriptor.srcDeviceIdx = deviceIdx;
+  nopDescriptor.srcStream = reinterpret_cast<uintptr_t>(buffer.stream);
+  descriptorCallback(Error::kSuccess, saveDescriptor(nopHolder));
+}
+
+void ChannelImpl::advanceSendOperation(
+    SendOpIter opIter,
+    SendOperation::State prevOpState) {
+  TP_DCHECK(context_->inLoop());
+
+  SendOperation& op = *opIter;
+
+  sendOps_.attemptTransition(
+      opIter,
+      /*from=*/SendOperation::UNINITIALIZED,
+      /*to=*/SendOperation::FINISHED,
+      /*cond=*/error_,
+      /*actions=*/{&ChannelImpl::callSendCallback});
+
+  // Needs to go after previous op to ensure predictable and consistent ordering
+  // of read calls on the control connection.
+  sendOps_.attemptTransition(
+      opIter,
+      /*from=*/SendOperation::UNINITIALIZED,
+      /*to=*/SendOperation::READING_NOTIFICATION,
+      /*cond=*/!error_ && prevOpState >= SendOperation::READING_NOTIFICATION,
+      /*actions=*/{&ChannelImpl::readNotification});
+
+  sendOps_.attemptTransition(
+      opIter,
+      /*from=*/SendOperation::READING_NOTIFICATION,
+      /*to=*/SendOperation::FINISHED,
+      /*cond=*/op.doneReadingNotification,
+      /*actions=*/{&ChannelImpl::callSendCallback});
+}
+
+void ChannelImpl::readNotification(SendOpIter opIter) {
+  SendOperation& op = *opIter;
 
   TP_VLOG(6) << "Channel " << id_ << " is reading notification (#"
-             << sequenceNumber << ")";
+             << op.sequenceNumber << ")";
   connection_->read(
       nullptr,
       0,
-      callbackWrapper_(
-          [sequenceNumber, op{std::move(op)}, callback{std::move(callback)}](
-              ChannelImpl& impl,
-              const void* /* unused */,
-              size_t /* unused */) {
-            TP_VLOG(6) << "Channel " << impl.id_
-                       << " done reading notification (#" << sequenceNumber
-                       << ")";
-            callback(impl.error_);
-          }));
+      callbackWrapper_([opIter](
+                           ChannelImpl& impl,
+                           const void* /* unused */,
+                           size_t /* unused */) {
+        TP_VLOG(6) << "Channel " << impl.id_ << " done reading notification (#"
+                   << opIter->sequenceNumber << ")";
+        opIter->doneReadingNotification = true;
+        impl.sendOps_.advanceOperation(opIter);
+      }));
+}
 
-  descriptorCallback(Error::kSuccess, saveDescriptor(nopHolder));
+void ChannelImpl::callSendCallback(SendOpIter opIter) {
+  SendOperation& op = *opIter;
+
+  op.callback(error_);
+  // Reset callback to release the resources it was holding.
+  op.callback = nullptr;
 }
 
 void ChannelImpl::recvImplFromLoop(
@@ -121,31 +171,85 @@ void ChannelImpl::recvImplFromLoop(
     CudaBuffer buffer,
     TRecvCallback callback) {
   int deviceIdx = cudaDeviceForPointer(context_->getCudaLib(), buffer.ptr);
+  RecvOpIter opIter = recvOps_.emplaceBack(
+      sequenceNumber, deviceIdx, buffer, std::move(callback));
+  RecvOperation& op = *opIter;
 
   NopHolder<Descriptor> nopHolder;
   loadDescriptor(nopHolder, descriptor);
   Descriptor& nopDescriptor = nopHolder.getObject();
-  SendOperation* op = reinterpret_cast<SendOperation*>(nopDescriptor.opPtr);
+  static_assert(std::is_pointer<cudaEvent_t>::value, "");
+  static_assert(std::is_pointer<cudaStream_t>::value, "");
+  op.startEvent = reinterpret_cast<cudaEvent_t>(nopDescriptor.startEvent);
+  op.srcPtr = reinterpret_cast<const void*>(nopDescriptor.srcPtr);
+  op.srcDeviceIdx = nopDescriptor.srcDeviceIdx;
+  op.srcStream = reinterpret_cast<cudaStream_t>(nopDescriptor.srcStream);
 
-  TP_VLOG(6) << "Channel " << id_ << " is copying payload (#" << sequenceNumber
-             << ")";
-  op->process(deviceIdx, buffer);
+  recvOps_.advanceOperation(opIter);
+}
+
+void ChannelImpl::advanceRecvOperation(
+    RecvOpIter opIter,
+    RecvOperation::State prevOpState) {
+  TP_DCHECK(context_->inLoop());
+
+  recvOps_.attemptTransition(
+      opIter,
+      /*from=*/RecvOperation::UNINITIALIZED,
+      /*to=*/RecvOperation::FINISHED,
+      /*cond=*/error_,
+      /*actions=*/{&ChannelImpl::callRecvCallback});
+
+  // Needs to go after previous op to ensure predictable and consistent ordering
+  // of write calls on the control connection.
+  recvOps_.attemptTransition(
+      opIter,
+      /*from=*/RecvOperation::UNINITIALIZED,
+      /*to=*/RecvOperation::FINISHED,
+      /*cond=*/!error_ && prevOpState >= RecvOperation::FINISHED,
+      /*actions=*/
+      {&ChannelImpl::waitOnStartEventAndCopyAndSyncWithSourceStream,
+       &ChannelImpl::callRecvCallback,
+       &ChannelImpl::writeNotification});
+}
+
+void ChannelImpl::waitOnStartEventAndCopyAndSyncWithSourceStream(
+    RecvOpIter opIter) {
+  RecvOperation& op = *opIter;
+
+  TP_VLOG(6) << "Channel " << id_ << " is copying payload (#"
+             << op.sequenceNumber << ")";
+  op.process();
   TP_VLOG(6) << "Channel " << id_ << " done copying payload (#"
-             << sequenceNumber << ")";
+             << op.sequenceNumber << ")";
+}
 
-  // Let peer know we've completed the copy.
+void ChannelImpl::callRecvCallback(RecvOpIter opIter) {
+  RecvOperation& op = *opIter;
+
+  op.callback(error_);
+  // Reset callback to release the resources it was holding.
+  op.callback = nullptr;
+}
+
+void ChannelImpl::writeNotification(RecvOpIter opIter) {
+  RecvOperation& op = *opIter;
+
   TP_VLOG(6) << "Channel " << id_ << " is writing notification (#"
-             << sequenceNumber << ")";
+             << op.sequenceNumber << ")";
   connection_->write(
-      nullptr, 0, callbackWrapper_([sequenceNumber](ChannelImpl& impl) {
+      nullptr,
+      0,
+      callbackWrapper_([sequenceNumber{op.sequenceNumber}](ChannelImpl& impl) {
         TP_VLOG(6) << "Channel " << impl.id_ << " done writing notification (#"
                    << sequenceNumber << ")";
       }));
-
-  callback(error_);
 }
 
 void ChannelImpl::handleErrorImpl() {
+  sendOps_.advanceAllOperations();
+  recvOps_.advanceAllOperations();
+
   connection_->close();
 
   context_->unenroll(*this);

--- a/tensorpipe/common/cuda.h
+++ b/tensorpipe/common/cuda.h
@@ -111,6 +111,10 @@ class CudaEvent {
     return true;
   }
 
+  cudaEvent_t raw() {
+    return ev_;
+  }
+
   std::string serializedHandle() {
     CudaDeviceGuard guard(deviceIdx_);
     cudaIpcEventHandle_t handle;


### PR DESCRIPTION
Summary:
CUDA XTH is now the last channel that doesn't use the state machine. It was also a rather "odd" channel, where the sender would give the receiver a pointer to the SendOp, and the receiver would then manipulate that op. This was odd because it meant the op had to be managed by a shared_ptr (rather than being owned by the sender, and contained within its lifetime) and access to it was potentially done by two different deferred executors, which could lead to races.

In principle CUDA XTH isn't different from XTH and CMA, hence in this diff I align it to those, by using separate Send and RecvOp and by using a descriptor to send relevant data across from one to the other.

Reviewed By: beauby

Differential Revision: D26912573

