### PR TITLE
Add channel::Context::supportsDeviceType() helper.

### DIFF
--- a/tensorpipe/channel/basic/context_impl.cc
+++ b/tensorpipe/channel/basic/context_impl.cc
@@ -33,6 +33,10 @@ std::shared_ptr<CpuChannel> ContextImpl::createChannel(
   return createChannelInternal(std::move(connections[0]));
 }
 
+bool ContextImpl::supportsDeviceType(DeviceType type) const {
+  return (DeviceType::kCpu == type);
+}
+
 void ContextImpl::handleErrorImpl() {}
 
 void ContextImpl::joinImpl() {}

--- a/tensorpipe/channel/basic/context_impl.h
+++ b/tensorpipe/channel/basic/context_impl.h
@@ -32,6 +32,8 @@ class ContextImpl final
       std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint);
 
+  bool supportsDeviceType(DeviceType type) const override;
+
   // Implement the DeferredExecutor interface.
   bool inLoop() const override;
   void deferToLoop(std::function<void()> fn) override;

--- a/tensorpipe/channel/cma/context_impl.cc
+++ b/tensorpipe/channel/cma/context_impl.cc
@@ -257,6 +257,10 @@ std::shared_ptr<CpuChannel> ContextImpl::createChannel(
   return createChannelInternal(std::move(connections[0]));
 }
 
+bool ContextImpl::supportsDeviceType(DeviceType type) const {
+  return (DeviceType::kCpu == type);
+}
+
 void ContextImpl::handleErrorImpl() {
   requests_.push(nullopt);
 }

--- a/tensorpipe/channel/cma/context_impl.h
+++ b/tensorpipe/channel/cma/context_impl.h
@@ -39,6 +39,8 @@ class ContextImpl final
       std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint);
 
+  bool supportsDeviceType(DeviceType type) const override;
+
   // Implement the DeferredExecutor interface.
   bool inLoop() const override;
   void deferToLoop(std::function<void()> fn) override;

--- a/tensorpipe/channel/context.h
+++ b/tensorpipe/channel/context.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+#include <tensorpipe/common/buffer.h>
 #include <tensorpipe/transport/context.h>
 
 namespace tensorpipe {
@@ -96,6 +97,11 @@ class Context {
   virtual void join() = 0;
 
   virtual ~Context() = default;
+
+  // FIXME: This is a private, temporary, API. It will be removed once
+  // TensorPipe supports cross-device type transfers.
+  // DO NOT USE IT.
+  virtual bool supportsDeviceType(DeviceType type) const = 0;
 
  private:
   std::string name_;

--- a/tensorpipe/channel/context_boilerplate.h
+++ b/tensorpipe/channel/context_boilerplate.h
@@ -52,6 +52,9 @@ class ContextBoilerplate : public Context<TBuffer> {
 
   ~ContextBoilerplate() override;
 
+  // FIXME: Private, temporary API.
+  bool supportsDeviceType(DeviceType type) const override;
+
  protected:
   // The implementation is managed by a shared_ptr because each child object
   // will also hold a shared_ptr to it. However, its lifetime is tied to the one
@@ -119,6 +122,13 @@ void ContextBoilerplate<TBuffer, TCtx, TChan>::join() {
 template <typename TBuffer, typename TCtx, typename TChan>
 ContextBoilerplate<TBuffer, TCtx, TChan>::~ContextBoilerplate() {
   join();
+}
+
+// FIXME
+template <typename TBuffer, typename TCtx, typename TChan>
+bool ContextBoilerplate<TBuffer, TCtx, TChan>::supportsDeviceType(
+    DeviceType type) const {
+  return impl_->supportsDeviceType(type);
 }
 
 } // namespace channel

--- a/tensorpipe/channel/context_impl_boilerplate.h
+++ b/tensorpipe/channel/context_impl_boilerplate.h
@@ -64,6 +64,9 @@ class ContextImplBoilerplate : public virtual DeferredExecutor,
 
   virtual ~ContextImplBoilerplate() = default;
 
+  // FIXME: Private, temporary API.
+  virtual bool supportsDeviceType(DeviceType type) const = 0;
+
  protected:
   virtual void initImplFromLoop() {}
   virtual void handleErrorImpl() = 0;

--- a/tensorpipe/channel/cuda_basic/context_impl.cc
+++ b/tensorpipe/channel/cuda_basic/context_impl.cc
@@ -68,6 +68,10 @@ size_t ContextImpl::numConnectionsNeeded() const {
   return 1 + cpuContext_->numConnectionsNeeded();
 }
 
+bool ContextImpl::supportsDeviceType(DeviceType type) const {
+  return (DeviceType::kCuda == type);
+}
+
 const CudaLib& ContextImpl::getCudaLib() {
   return cudaLib_;
 }

--- a/tensorpipe/channel/cuda_basic/context_impl.h
+++ b/tensorpipe/channel/cuda_basic/context_impl.h
@@ -40,6 +40,8 @@ class ContextImpl final
 
   size_t numConnectionsNeeded() const override;
 
+  bool supportsDeviceType(DeviceType type) const override;
+
   const CudaLib& getCudaLib();
   CudaHostAllocator& getCudaHostSendAllocator(int deviceIdx);
   CudaHostAllocator& getCudaHostRecvAllocator(int deviceIdx);

--- a/tensorpipe/channel/cuda_gdr/context_impl.cc
+++ b/tensorpipe/channel/cuda_gdr/context_impl.cc
@@ -542,6 +542,10 @@ std::shared_ptr<CudaChannel> ContextImpl::createChannel(
   return createChannelInternal(std::move(connections[0]));
 }
 
+bool ContextImpl::supportsDeviceType(DeviceType type) const {
+  return (DeviceType::kCuda == type);
+}
+
 } // namespace cuda_gdr
 } // namespace channel
 } // namespace tensorpipe

--- a/tensorpipe/channel/cuda_gdr/context_impl.h
+++ b/tensorpipe/channel/cuda_gdr/context_impl.h
@@ -138,6 +138,8 @@ class ContextImpl final
       std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint);
 
+  bool supportsDeviceType(DeviceType type) const override;
+
   const CudaLib& getCudaLib();
 
   const std::vector<size_t>& getGpuToNicMapping();

--- a/tensorpipe/channel/cuda_ipc/context_impl.cc
+++ b/tensorpipe/channel/cuda_ipc/context_impl.cc
@@ -258,6 +258,10 @@ size_t ContextImpl::numConnectionsNeeded() const {
   return 2;
 }
 
+bool ContextImpl::supportsDeviceType(DeviceType type) const {
+  return (DeviceType::kCuda == type);
+}
+
 bool ContextImpl::canCommunicateWithRemote(
     const std::string& remoteDomainDescriptor) const {
   NopHolder<DomainDescriptor> nopHolder;

--- a/tensorpipe/channel/cuda_ipc/context_impl.h
+++ b/tensorpipe/channel/cuda_ipc/context_impl.h
@@ -50,6 +50,8 @@ class ContextImpl final
 
   size_t numConnectionsNeeded() const override;
 
+  bool supportsDeviceType(DeviceType type) const override;
+
   bool canCommunicateWithRemote(
       const std::string& remoteDomainDescriptor) const override;
 

--- a/tensorpipe/channel/cuda_xth/context_impl.cc
+++ b/tensorpipe/channel/cuda_xth/context_impl.cc
@@ -93,6 +93,10 @@ std::shared_ptr<CudaChannel> ContextImpl::createChannel(
   return createChannelInternal(std::move(connections[0]));
 }
 
+bool ContextImpl::supportsDeviceType(DeviceType type) const {
+  return (DeviceType::kCuda == type);
+}
+
 const CudaLib& ContextImpl::getCudaLib() {
   return cudaLib_;
 }

--- a/tensorpipe/channel/cuda_xth/context_impl.h
+++ b/tensorpipe/channel/cuda_xth/context_impl.h
@@ -33,6 +33,8 @@ class ContextImpl final
       std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint);
 
+  bool supportsDeviceType(DeviceType type) const override;
+
   const CudaLib& getCudaLib();
 
   // Implement the DeferredExecutor interface.

--- a/tensorpipe/channel/mpt/context_impl.cc
+++ b/tensorpipe/channel/mpt/context_impl.cc
@@ -90,6 +90,10 @@ std::shared_ptr<CpuChannel> ContextImpl::createChannel(
   return createChannelInternal(std::move(connections[0]), endpoint, numLanes_);
 }
 
+bool ContextImpl::supportsDeviceType(DeviceType type) const {
+  return (DeviceType::kCpu == type);
+}
+
 const std::vector<std::string>& ContextImpl::addresses() const {
   // As this is an immutable member (after it has been initialized in
   // the constructor), we'll access it without deferring to the loop.

--- a/tensorpipe/channel/mpt/context_impl.h
+++ b/tensorpipe/channel/mpt/context_impl.h
@@ -47,6 +47,8 @@ class ContextImpl final
       std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint);
 
+  bool supportsDeviceType(DeviceType type) const override;
+
   // Implement the DeferredExecutor interface.
   bool inLoop() const override;
   void deferToLoop(std::function<void()> fn) override;

--- a/tensorpipe/channel/xth/context_impl.cc
+++ b/tensorpipe/channel/xth/context_impl.cc
@@ -65,6 +65,10 @@ std::shared_ptr<CpuChannel> ContextImpl::createChannel(
   return createChannelInternal(std::move(connections[0]));
 }
 
+bool ContextImpl::supportsDeviceType(DeviceType type) const {
+  return (DeviceType::kCpu == type);
+}
+
 void ContextImpl::handleErrorImpl() {
   requests_.push(nullopt);
 }

--- a/tensorpipe/channel/xth/context_impl.h
+++ b/tensorpipe/channel/xth/context_impl.h
@@ -37,6 +37,8 @@ class ContextImpl final
       std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint);
 
+  bool supportsDeviceType(DeviceType type) const override;
+
   // Implement the DeferredExecutor interface.
   bool inLoop() const override;
   void deferToLoop(std::function<void()> fn) override;


### PR DESCRIPTION
Summary:
This will come in handy for merging the CPU/CUDA channel
hierarchies.

Reviewed By: lw

Differential Revision: D27058358

