### PR TITLE
Don't use unsupported pthread function in old glibc

### DIFF
--- a/tensorpipe/common/system.cc
+++ b/tensorpipe/common/system.cc
@@ -262,7 +262,15 @@ optional<std::string> getPermittedCapabilitiesID() {
 
 void setThreadName(std::string name) {
 #ifdef __linux__
+// In glibc this non-standard call was added in version 2.12, hence we guard it.
+#ifdef __GLIBC__
+#if ((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 12)))
   pthread_setname_np(pthread_self(), name.c_str());
+#endif
+// In other standard libraries we didn't check yet, hence we always enable it.
+#else
+  pthread_setname_np(pthread_self(), name.c_str());
+#endif
 #endif
 }
 


### PR DESCRIPTION
Summary: We've got a report of a user trying to build TensorPipe on a very old toolchain and this was one of the issues (https://github.com/pytorch/tensorpipe/issues/327). Since this pthread call is only used to aid debugging, and since the check to fix it is very small, I think it's fine to include it.

Differential Revision: D27294997

