### PR TITLE
Add an option to benchmarks to use NCCL

### DIFF
--- a/tensorpipe/benchmark/benchmark_pipe.cc
+++ b/tensorpipe/benchmark/benchmark_pipe.cc
@@ -131,7 +131,7 @@ static void serverPongPingNonBlock(
                   0);
             }
           } else {
-            TP_DCHECK_EQ(message.tensors.size(), 0);
+            TP_DCHECK_EQ(message.payloads.size(), 0);
           }
           if (data.tensorSize > 0) {
             TP_DCHECK_EQ(message.tensors.size(), data.numTensors);
@@ -241,7 +241,7 @@ static void clientPingPongNonBlock(
       message.payloads.push_back(std::move(payload));
     }
   } else {
-    TP_DCHECK_EQ(message.tensors.size(), 0);
+    TP_DCHECK_EQ(message.payloads.size(), 0);
   }
   if (data.tensorSize > 0) {
     for (size_t tensorIdx = 0; tensorIdx < data.numTensors; tensorIdx++) {

--- a/tensorpipe/benchmark/benchmark_pipe.cc
+++ b/tensorpipe/benchmark/benchmark_pipe.cc
@@ -65,10 +65,10 @@ static void printMeasurements(Measurements& measurements, size_t dataLen) {
       measurements.percentile(0.95).count() / 1000.0);
 }
 
-static std::unique_ptr<uint8_t[]> createData(const int size) {
+static std::unique_ptr<uint8_t[]> createData(const size_t size) {
   auto data = std::make_unique<uint8_t[]>(size);
   // Generate fixed data for validation between peers
-  for (int i = 0; i < size; i++) {
+  for (size_t i = 0; i < size; i++) {
     data[i] = (i >> 8) ^ (i & 0xff);
   }
   return data;

--- a/tensorpipe/benchmark/benchmark_pipe.cc
+++ b/tensorpipe/benchmark/benchmark_pipe.cc
@@ -407,6 +407,8 @@ int main(int argc, char** argv) {
   std::cout << "payload_size = " << x.payloadSize << "\n";
   std::cout << "num_tensors = " << x.numTensors << "\n";
   std::cout << "tensor_size = " << x.tensorSize << "\n";
+  std::cout << "tensor_type = "
+            << (x.tensorType == TensorType::kCpu ? "cpu" : "cuda") << "\n";
   std::cout << "metadata_size = " << x.metadataSize << "\n";
 
   if (x.mode == "listen") {

--- a/tensorpipe/benchmark/channel_registry.cc
+++ b/tensorpipe/benchmark/channel_registry.cc
@@ -47,3 +47,43 @@ std::shared_ptr<tensorpipe::channel::Context> makeXthChannel() {
 }
 
 TP_REGISTER_CREATOR(TensorpipeChannelRegistry, xth, makeXthChannel);
+
+// CUDA XTH
+
+std::shared_ptr<tensorpipe::channel::Context> makeCudaXthChannel() {
+  return tensorpipe::channel::cuda_xth::create();
+}
+
+TP_REGISTER_CREATOR(TensorpipeChannelRegistry, cuda_xth, makeCudaXthChannel);
+
+// CUDA BASIC
+
+std::shared_ptr<tensorpipe::channel::Context> makeCudaBasicChannel() {
+  return tensorpipe::channel::cuda_basic::create(
+      tensorpipe::channel::basic::create());
+}
+
+TP_REGISTER_CREATOR(
+    TensorpipeChannelRegistry,
+    cuda_basic,
+    makeCudaBasicChannel);
+
+// CUDA IPC
+
+#if TENSORPIPE_HAS_CUDA_IPC_CHANNEL
+std::shared_ptr<tensorpipe::channel::Context> makeCudaIpcChannel() {
+  return tensorpipe::channel::cuda_ipc::create();
+}
+
+TP_REGISTER_CREATOR(TensorpipeChannelRegistry, cuda_ipc, makeCudaIpcChannel);
+#endif // TENSORPIPE_HAS_CUDA_IPC_CHANNEL
+
+// CUDA GDR
+
+#if TENSORPIPE_HAS_CUDA_GDR_CHANNEL
+std::shared_ptr<tensorpipe::channel::Context> makeCudaGdrChannel() {
+  return tensorpipe::channel::cuda_gdr::create();
+}
+
+TP_REGISTER_CREATOR(TensorpipeChannelRegistry, cuda_gdr, makeCudaGdrChannel);
+#endif // TENSORPIPE_HAS_CUDA_GDR_CHANNEL

--- a/tensorpipe/benchmark/measurements.h
+++ b/tensorpipe/benchmark/measurements.h
@@ -24,8 +24,8 @@ class Measurements {
     start_ = clock::now();
   }
 
-  void markStop() {
-    samples_.push_back(clock::now() - start_);
+  void markStop(size_t count = 1) {
+    samples_.push_back((clock::now() - start_) / count);
   }
 
   void sort() {

--- a/tensorpipe/benchmark/options.cc
+++ b/tensorpipe/benchmark/options.cc
@@ -63,6 +63,7 @@ static void usage(int status, const char* argv0) {
   X("--payload-size=SIZE [optional]  Size of payload of each write/read pair");
   X("--num-tensors=NUM [optional]    Number of tensors of each write/read pair");
   X("--tensor-size=SIZE [optional]   Size of tensor of each write/read pair");
+  X("--tensor-type=TYPE [optional]   Type of tensor (cpu or cuda)");
   X("--metadata-size=SIZE [optional] Size of metadata of each write/read pair");
 
   exit(status);
@@ -106,6 +107,7 @@ struct Options parseOptions(int argc, char** argv) {
     PAYLOAD_SIZE,
     NUM_TENSORS,
     TENSOR_SIZE,
+    TENSOR_TYPE,
     METADATA_SIZE,
     HELP,
   };
@@ -120,6 +122,7 @@ struct Options parseOptions(int argc, char** argv) {
       {"payload-size", required_argument, &flag, PAYLOAD_SIZE},
       {"num-tensors", required_argument, &flag, NUM_TENSORS},
       {"tensor-size", required_argument, &flag, TENSOR_SIZE},
+      {"tensor-type", required_argument, &flag, TENSOR_TYPE},
       {"metadata-size", required_argument, &flag, METADATA_SIZE},
       {"help", no_argument, &flag, HELP},
       {nullptr, 0, nullptr, 0}};
@@ -165,6 +168,17 @@ struct Options parseOptions(int argc, char** argv) {
         break;
       case TENSOR_SIZE:
         options.tensorSize = atoi(optarg);
+        break;
+      case TENSOR_TYPE:
+        if (strcmp(optarg, "cpu") == 0) {
+          options.tensorType = TensorType::kCpu;
+        } else if (strcmp(optarg, "cuda") == 0) {
+          options.tensorType = TensorType::kCuda;
+        } else {
+          fprintf(stderr, "Error:\n");
+          fprintf(stderr, "  --tensor-type must be [cpu|cuda]\n");
+          exit(EXIT_FAILURE);
+        }
         break;
       case METADATA_SIZE:
         options.metadataSize = atoi(optarg);

--- a/tensorpipe/benchmark/options.h
+++ b/tensorpipe/benchmark/options.h
@@ -16,6 +16,11 @@
 namespace tensorpipe {
 namespace benchmark {
 
+enum class TensorType {
+  kCpu,
+  kCuda,
+};
+
 struct Options {
   std::string mode; // server or client
   std::string transport; // shm or uv
@@ -26,6 +31,7 @@ struct Options {
   size_t payloadSize{0};
   size_t numTensors{0};
   size_t tensorSize{0};
+  TensorType tensorType{TensorType::kCpu};
   size_t metadataSize{0};
 };
 


### PR DESCRIPTION
Summary:
A comparison between TensorPipe and NCCL is an apples-to-oranges one, but it's still useful to see whether TensorPipe is completely far off or if they are head-to-head. The benchmark requires surprisingly few changes to use NCCL, but I don't want to deal with including and building NCCL. I also don't want to provide a separate file to do the NCCL benchmark, as it will inevitably get out of sync and unmaintained if it's not regularly built.

Therefore I'm including the NCCL code changes in the pipe's benchmark, but I'm disabling them. If anyone wants to use them, they can just download and build NCCL locally, quickly tinker with CMake to pick it up, and use it right away by just flipping a switch.

It's very ugly, but it works.

Differential Revision: D27326530

