### PR TITLE
Avoid collecting channel descriptors in the Pipe.

### DIFF
--- a/tensorpipe/core/nop_types.h
+++ b/tensorpipe/core/nop_types.h
@@ -94,14 +94,12 @@ struct MessageDescriptor {
 
     DeviceType deviceType;
     std::string channelName;
-    std::string channelDescriptor;
     NOP_STRUCTURE(
         TensorDescriptor,
         sizeInBytes,
         metadata,
         deviceType,
-        channelName,
-        channelDescriptor);
+        channelName);
   };
 
   std::string metadata;

--- a/tensorpipe/core/pipe_impl.cc
+++ b/tensorpipe/core/pipe_impl.cc
@@ -59,8 +59,6 @@ void parseDescriptorOfMessage(ReadOperation& op, const Packet& nopPacketIn) {
     ReadOperation::Tensor tensorBeingAllocated;
     tensorBeingAllocated.length = nopTensorDescriptor.sizeInBytes;
     tensorBeingAllocated.channelName = nopTensorDescriptor.channelName;
-    // FIXME If the nop object wasn't const we could move the string out...
-    tensorBeingAllocated.descriptor = nopTensorDescriptor.channelDescriptor;
 
     message.tensors.emplace_back();
     Message::Tensor& tensor = message.tensors.back();
@@ -143,9 +141,6 @@ std::shared_ptr<NopHolder<Packet>> makeDescriptorForMessage(
         nopMessageDescriptor.tensorDescriptors.back();
     nopTensorDescriptor.metadata = tensor.metadata;
     nopTensorDescriptor.channelName = otherTensor.channelName;
-    // FIXME In principle we could move here.
-    nopTensorDescriptor.channelDescriptor = otherTensor.descriptor;
-
     nopTensorDescriptor.deviceType = tensor.buffer.deviceType();
     nopTensorDescriptor.sizeInBytes = tensor.buffer.length();
   }
@@ -516,7 +511,7 @@ void PipeImpl::readPayloadsAndReceiveTensorsOfMessage(ReadOpIter opIter) {
                << op.sequenceNumber << "." << tensorIdx;
 
     channel->recv(
-        std::move(tensorBeingAllocated.descriptor),
+        "",
         tensor.buffer,
         callbackWrapper_([opIter, tensorIdx](PipeImpl& impl) {
           TP_VLOG(3) << "Pipe " << impl.id_ << " done receiving tensor #"
@@ -749,19 +744,17 @@ void PipeImpl::advanceWriteOperation(
   writeOps_.attemptTransition(
       opIter,
       /*from=*/WriteOperation::UNINITIALIZED,
-      /*to=*/WriteOperation::SENDING_TENSORS_AND_COLLECTING_DESCRIPTORS,
+      /*to=*/WriteOperation::SENDING_TENSORS,
       /*cond=*/!error_ && state_ == ESTABLISHED &&
-          prevOpState >=
-              WriteOperation::SENDING_TENSORS_AND_COLLECTING_DESCRIPTORS,
+          prevOpState >= WriteOperation::SENDING_TENSORS,
       /*actions=*/{&PipeImpl::sendTensorsOfMessage});
 
   // Needs to go after previous op to ensure ordering of callback invocations.
   writeOps_.attemptTransition(
       opIter,
-      /*from=*/WriteOperation::SENDING_TENSORS_AND_COLLECTING_DESCRIPTORS,
+      /*from=*/WriteOperation::SENDING_TENSORS,
       /*to=*/WriteOperation::FINISHED,
-      /*cond=*/error_ && opIter->numTensorDescriptorsBeingCollected == 0 &&
-          opIter->numTensorsBeingSent == 0 &&
+      /*cond=*/error_ && opIter->numTensorsBeingSent == 0 &&
           prevOpState >= WriteOperation::FINISHED,
       /*actions=*/{&PipeImpl::callWriteCallback});
 
@@ -769,9 +762,9 @@ void PipeImpl::advanceWriteOperation(
   // of write calls on the connection.
   writeOps_.attemptTransition(
       opIter,
-      /*from=*/WriteOperation::SENDING_TENSORS_AND_COLLECTING_DESCRIPTORS,
+      /*from=*/WriteOperation::SENDING_TENSORS,
       /*to=*/WriteOperation::WRITING_PAYLOADS_AND_SENDING_TENSORS,
-      /*cond=*/!error_ && opIter->numTensorDescriptorsBeingCollected == 0 &&
+      /*cond=*/!error_ &&
           prevOpState >= WriteOperation::WRITING_PAYLOADS_AND_SENDING_TENSORS,
       /*actions=*/{&PipeImpl::writeDescriptorAndPayloadsOfMessage});
 
@@ -852,12 +845,10 @@ void PipeImpl::sendTensorsOfMessage(WriteOpIter opIter) {
 
       channel.send(
           tensor.buffer,
-          callbackWrapper_([opIter, tensorIdx](
-                               PipeImpl& impl,
-                               channel::TDescriptor descriptor) {
-            TP_VLOG(3) << "Pipe " << impl.id_ << " got tensor descriptor #"
-                       << opIter->sequenceNumber << "." << tensorIdx;
-            impl.onDescriptorOfTensor(opIter, tensorIdx, std::move(descriptor));
+          callbackWrapper_([](PipeImpl& impl, channel::TDescriptor descriptor) {
+            // FIXME: This whole callback will go away once we remove channel
+            // descriptors from the Channel interface.
+            TP_DCHECK_EQ(descriptor, "");
           }),
           callbackWrapper_([opIter, tensorIdx](PipeImpl& impl) {
             TP_VLOG(3) << "Pipe " << impl.id_ << " done sending tensor #"
@@ -873,7 +864,6 @@ void PipeImpl::sendTensorsOfMessage(WriteOpIter opIter) {
     }
     TP_THROW_ASSERT_IF(!foundAChannel);
 
-    ++op.numTensorDescriptorsBeingCollected;
     ++op.numTensorsBeingSent;
   }
 }
@@ -1202,21 +1192,6 @@ void PipeImpl::onReadOfMessageDescriptor(
   }
 
   readOps_.advanceOperation(opIter);
-}
-
-void PipeImpl::onDescriptorOfTensor(
-    WriteOpIter opIter,
-    int64_t tensorIdx,
-    channel::TDescriptor descriptor) {
-  TP_DCHECK(context_->inLoop());
-
-  WriteOperation& op = *opIter;
-
-  TP_DCHECK_LT(tensorIdx, op.tensors.size());
-  op.tensors[tensorIdx].descriptor = std::move(descriptor);
-  --op.numTensorDescriptorsBeingCollected;
-
-  writeOps_.advanceOperation(opIter);
 }
 
 void PipeImpl::onReadOfPayload(ReadOpIter opIter) {

--- a/tensorpipe/core/pipe_impl.cc
+++ b/tensorpipe/core/pipe_impl.cc
@@ -744,29 +744,12 @@ void PipeImpl::advanceWriteOperation(
   writeOps_.attemptTransition(
       opIter,
       /*from=*/WriteOperation::UNINITIALIZED,
-      /*to=*/WriteOperation::SENDING_TENSORS,
-      /*cond=*/!error_ && state_ == ESTABLISHED &&
-          prevOpState >= WriteOperation::SENDING_TENSORS,
-      /*actions=*/{&PipeImpl::sendTensorsOfMessage});
-
-  // Needs to go after previous op to ensure ordering of callback invocations.
-  writeOps_.attemptTransition(
-      opIter,
-      /*from=*/WriteOperation::SENDING_TENSORS,
-      /*to=*/WriteOperation::FINISHED,
-      /*cond=*/error_ && opIter->numTensorsBeingSent == 0 &&
-          prevOpState >= WriteOperation::FINISHED,
-      /*actions=*/{&PipeImpl::callWriteCallback});
-
-  // Needs to go after previous op to ensure predictable and consistent ordering
-  // of write calls on the connection.
-  writeOps_.attemptTransition(
-      opIter,
-      /*from=*/WriteOperation::SENDING_TENSORS,
       /*to=*/WriteOperation::WRITING_PAYLOADS_AND_SENDING_TENSORS,
-      /*cond=*/!error_ &&
+      /*cond=*/!error_ && state_ == ESTABLISHED &&
           prevOpState >= WriteOperation::WRITING_PAYLOADS_AND_SENDING_TENSORS,
-      /*actions=*/{&PipeImpl::writeDescriptorAndPayloadsOfMessage});
+      /*actions=*/
+      {&PipeImpl::sendTensorsOfMessage,
+       &PipeImpl::writeDescriptorAndPayloadsOfMessage});
 
   // Needs to go after previous op to ensure ordering of callback invocations.
   writeOps_.attemptTransition(

--- a/tensorpipe/core/pipe_impl.cc
+++ b/tensorpipe/core/pipe_impl.cc
@@ -740,7 +740,7 @@ void PipeImpl::advanceWriteOperation(
       /*actions=*/{&PipeImpl::callWriteCallback});
 
   // Needs to go after previous op to ensure predictable and consistent ordering
-  // of send calls on channels.
+  // of write calls on the connection and send calls on channels.
   writeOps_.attemptTransition(
       opIter,
       /*from=*/WriteOperation::UNINITIALIZED,

--- a/tensorpipe/core/pipe_impl.h
+++ b/tensorpipe/core/pipe_impl.h
@@ -70,7 +70,6 @@ struct ReadOperation {
     DeviceType type;
     ssize_t length{-1};
     std::string channelName;
-    channel::TDescriptor descriptor;
   };
   std::vector<Tensor> tensors;
 
@@ -84,13 +83,12 @@ struct WriteOperation {
   // Progress indicators.
   enum State {
     UNINITIALIZED,
-    SENDING_TENSORS_AND_COLLECTING_DESCRIPTORS,
+    SENDING_TENSORS,
     WRITING_PAYLOADS_AND_SENDING_TENSORS,
     FINISHED
   };
   State state{UNINITIALIZED};
   int64_t numPayloadsBeingWritten{0};
-  int64_t numTensorDescriptorsBeingCollected{0};
   int64_t numTensorsBeingSent{0};
 
   // Callbacks.
@@ -103,7 +101,6 @@ struct WriteOperation {
   struct Tensor {
     DeviceType type;
     std::string channelName;
-    channel::TDescriptor descriptor;
   };
   std::vector<Tensor> tensors;
 };
@@ -286,10 +283,6 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
       std::string receivedTransport,
       std::shared_ptr<transport::Connection> receivedConnection);
   void onReadOfMessageDescriptor(ReadOpIter opIter, const Packet& nopPacketIn);
-  void onDescriptorOfTensor(
-      WriteOpIter opIter,
-      int64_t tensorIdx,
-      channel::TDescriptor descriptor);
   void onReadOfPayload(ReadOpIter opIter);
   void onRecvOfTensor(ReadOpIter opIter);
   void onWriteOfPayload(WriteOpIter opIter);

--- a/tensorpipe/core/pipe_impl.h
+++ b/tensorpipe/core/pipe_impl.h
@@ -83,7 +83,6 @@ struct WriteOperation {
   // Progress indicators.
   enum State {
     UNINITIALIZED,
-    SENDING_TENSORS,
     WRITING_PAYLOADS_AND_SENDING_TENSORS,
     FINISHED
   };

--- a/tensorpipe/core/pipe_impl.h
+++ b/tensorpipe/core/pipe_impl.h
@@ -81,11 +81,7 @@ struct WriteOperation {
   int64_t sequenceNumber{-1};
 
   // Progress indicators.
-  enum State {
-    UNINITIALIZED,
-    WRITING_PAYLOADS_AND_SENDING_TENSORS,
-    FINISHED
-  };
+  enum State { UNINITIALIZED, WRITING_PAYLOADS_AND_SENDING_TENSORS, FINISHED };
   State state{UNINITIALIZED};
   int64_t numPayloadsBeingWritten{0};
   int64_t numTensorsBeingSent{0};


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #335 Remove descriptor/descriptorCallback from Channel interface.
* #340 Avoid collecting channel descriptors in channel tests.
* **#339 Avoid collecting channel descriptors in the Pipe.**
* #336 In-channel descriptor exchanges for CudaBasic.
* #334 In-channel descriptor exchanges for CudaGdr.
* #333 In-channel descriptor exchanges for CudaXth.
* #332 In-channel descriptor exchanges for Xth.
* #331 In-channel descriptor exchanges for Cma.

Now that we adapted all channels to handle descriptor exchanges
themselves, the Pipe does not need to collect them for each
tensor.

Differential Revision: [D27434727](https://our.internmc.facebook.com/intern/diff/D27434727)