### PR TITLE
Avoid collecting channel descriptors in channel tests.

### DIFF
--- a/tensorpipe/test/channel/channel_test.cc
+++ b/tensorpipe/test/channel/channel_test.cc
@@ -55,15 +55,8 @@ class ClientToServerTest : public ClientServerChannelTestCase<TBuffer> {
     DataWrapper<TBuffer> wrappedData(data);
 
     // Perform send and wait for completion.
-    std::future<std::tuple<Error, TDescriptor>> descriptorFuture;
-    std::future<Error> sendFuture;
-    std::tie(descriptorFuture, sendFuture) =
+    std::future<Error> sendFuture =
         sendWithFuture(channel, wrappedData.buffer());
-    Error descriptorError;
-    TDescriptor descriptor;
-    std::tie(descriptorError, descriptor) = descriptorFuture.get();
-    EXPECT_FALSE(descriptorError) << descriptorError.what();
-    this->peers_->send(PeerGroup::kClient, descriptor);
     Error sendError = sendFuture.get();
     EXPECT_FALSE(sendError) << sendError.what();
 
@@ -75,9 +68,8 @@ class ClientToServerTest : public ClientServerChannelTestCase<TBuffer> {
     DataWrapper<TBuffer> wrappedData(kDataSize);
 
     // Perform recv and wait for completion.
-    auto descriptor = this->peers_->recv(PeerGroup::kClient);
     std::future<Error> recvFuture =
-        recvWithFuture(channel, descriptor, wrappedData.buffer());
+        recvWithFuture(channel, wrappedData.buffer());
     Error recvError = recvFuture.get();
     EXPECT_FALSE(recvError) << recvError.what();
 
@@ -103,9 +95,8 @@ class ServerToClientTest : public ClientServerChannelTestCase<TBuffer> {
     DataWrapper<TBuffer> wrappedData(kDataSize);
 
     // Perform recv and wait for completion.
-    auto descriptor = this->peers_->recv(PeerGroup::kServer);
     std::future<Error> recvFuture =
-        recvWithFuture(channel, descriptor, wrappedData.buffer());
+        recvWithFuture(channel, wrappedData.buffer());
     Error recvError = recvFuture.get();
     EXPECT_FALSE(recvError) << recvError.what();
 
@@ -126,15 +117,8 @@ class ServerToClientTest : public ClientServerChannelTestCase<TBuffer> {
     DataWrapper<TBuffer> wrappedData(data);
 
     // Perform send and wait for completion.
-    std::future<std::tuple<Error, TDescriptor>> descriptorFuture;
-    std::future<Error> sendFuture;
-    std::tie(descriptorFuture, sendFuture) =
+    std::future<Error> sendFuture =
         sendWithFuture(channel, wrappedData.buffer());
-    Error descriptorError;
-    TDescriptor descriptor;
-    std::tie(descriptorError, descriptor) = descriptorFuture.get();
-    EXPECT_FALSE(descriptorError) << descriptorError.what();
-    this->peers_->send(PeerGroup::kServer, descriptor);
     Error sendError = sendFuture.get();
     EXPECT_FALSE(sendError) << sendError.what();
 
@@ -164,15 +148,8 @@ class SendMultipleTensorsTest : public ClientServerChannelTestCase<TBuffer> {
 
     // Perform send and wait for completion.
     for (int i = 0; i < kNumTensors; i++) {
-      std::future<std::tuple<Error, TDescriptor>> descriptorFuture;
-      std::future<Error> sendFuture;
-      std::tie(descriptorFuture, sendFuture) =
+      std::future<Error> sendFuture =
           sendWithFuture(channel, wrappedData.buffer());
-      Error descriptorError;
-      TDescriptor descriptor;
-      std::tie(descriptorError, descriptor) = descriptorFuture.get();
-      EXPECT_FALSE(descriptorError) << descriptorError.what();
-      this->peers_->send(PeerGroup::kClient, descriptor);
       sendFutures.push_back(std::move(sendFuture));
     }
     for (auto& sendFuture : sendFutures) {
@@ -195,9 +172,8 @@ class SendMultipleTensorsTest : public ClientServerChannelTestCase<TBuffer> {
 
     // Perform recv and wait for completion.
     for (auto& wrappedData : wrappedDataVec) {
-      auto descriptor = this->peers_->recv(PeerGroup::kClient);
       std::future<Error> recvFuture =
-          recvWithFuture(channel, descriptor, wrappedData.buffer());
+          recvWithFuture(channel, wrappedData.buffer());
       recvFutures.push_back(std::move(recvFuture));
     }
     for (auto& recvFuture : recvFutures) {
@@ -233,27 +209,12 @@ class SendTensorsBothWaysTest : public ClientServerChannelTestCase<TBuffer> {
     // Recv buffer.
     DataWrapper<TBuffer> wrappedRecvData(kDataSize);
 
-    std::future<Error> sendFuture;
-    std::future<Error> recvFuture;
-
     // Perform send.
-    {
-      std::future<std::tuple<Error, TDescriptor>> descriptorFuture;
-      std::tie(descriptorFuture, sendFuture) =
-          sendWithFuture(channel, wrappedSendData.buffer());
-      Error descriptorError;
-      TDescriptor descriptor;
-      std::tie(descriptorError, descriptor) = descriptorFuture.get();
-      EXPECT_FALSE(descriptorError) << descriptorError.what();
-      this->peers_->send(PeerGroup::kClient, descriptor);
-    }
-
+    std::future<Error> sendFuture =
+        sendWithFuture(channel, wrappedSendData.buffer());
     // Perform recv.
-    {
-      auto descriptor = this->peers_->recv(PeerGroup::kServer);
-      recvFuture =
-          recvWithFuture(channel, descriptor, wrappedRecvData.buffer());
-    }
+    std::future<Error> recvFuture =
+        recvWithFuture(channel, wrappedRecvData.buffer());
 
     // Wait for completion of both.
     Error sendError = sendFuture.get();
@@ -280,27 +241,12 @@ class SendTensorsBothWaysTest : public ClientServerChannelTestCase<TBuffer> {
     // Recv buffer.
     DataWrapper<TBuffer> wrappedRecvData(kDataSize);
 
-    std::future<Error> sendFuture;
-    std::future<Error> recvFuture;
-
     // Perform send.
-    {
-      std::future<std::tuple<Error, TDescriptor>> descriptorFuture;
-      std::tie(descriptorFuture, sendFuture) =
-          sendWithFuture(channel, wrappedSendData.buffer());
-      Error descriptorError;
-      TDescriptor descriptor;
-      std::tie(descriptorError, descriptor) = descriptorFuture.get();
-      EXPECT_FALSE(descriptorError) << descriptorError.what();
-      this->peers_->send(PeerGroup::kServer, descriptor);
-    }
-
+    std::future<Error> sendFuture =
+        sendWithFuture(channel, wrappedSendData.buffer());
     // Perform recv.
-    {
-      auto descriptor = this->peers_->recv(PeerGroup::kClient);
-      recvFuture =
-          recvWithFuture(channel, descriptor, wrappedRecvData.buffer());
-    }
+    std::future<Error> recvFuture =
+        recvWithFuture(channel, wrappedRecvData.buffer());
 
     // Wait for completion of both.
     Error sendError = sendFuture.get();

--- a/tensorpipe/test/channel/channel_test.h
+++ b/tensorpipe/test/channel/channel_test.h
@@ -166,7 +166,7 @@ class ChannelTestHelper {
       [promise{std::move(promise)}](const tensorpipe::Error& error) {
         promise->set_value(error);
       });
-  return std::move(future);
+  return future;
 }
 
 [[nodiscard]] inline std::future<tensorpipe::Error> recvWithFuture(

--- a/tensorpipe/test/channel/channel_test.h
+++ b/tensorpipe/test/channel/channel_test.h
@@ -151,41 +151,32 @@ class ChannelTestHelper {
       std::string id) = 0;
 };
 
-[[nodiscard]] inline std::pair<
-    std::future<
-        std::tuple<tensorpipe::Error, tensorpipe::channel::TDescriptor>>,
-    std::future<tensorpipe::Error>>
-sendWithFuture(
+[[nodiscard]] inline std::future<tensorpipe::Error> sendWithFuture(
     std::shared_ptr<tensorpipe::channel::Channel> channel,
     tensorpipe::Buffer buffer) {
-  auto descriptorPromise = std::make_shared<
-      std::promise<std::tuple<tensorpipe::Error, std::string>>>();
   auto promise = std::make_shared<std::promise<tensorpipe::Error>>();
-  auto descriptorFuture = descriptorPromise->get_future();
   auto future = promise->get_future();
 
   channel->send(
       buffer,
-      [descriptorPromise{std::move(descriptorPromise)}](
-          const tensorpipe::Error& error, std::string descriptor) {
-        descriptorPromise->set_value(
-            std::make_tuple(error, std::move(descriptor)));
+      [](const tensorpipe::Error& error, std::string descriptor) {
+        EXPECT_FALSE(error);
+        EXPECT_EQ(descriptor, "");
       },
       [promise{std::move(promise)}](const tensorpipe::Error& error) {
         promise->set_value(error);
       });
-  return {std::move(descriptorFuture), std::move(future)};
+  return std::move(future);
 }
 
 [[nodiscard]] inline std::future<tensorpipe::Error> recvWithFuture(
     std::shared_ptr<tensorpipe::channel::Channel> channel,
-    tensorpipe::channel::TDescriptor descriptor,
     tensorpipe::Buffer buffer) {
   auto promise = std::make_shared<std::promise<tensorpipe::Error>>();
   auto future = promise->get_future();
 
   channel->recv(
-      std::move(descriptor),
+      "",
       buffer,
       [promise{std::move(promise)}](const tensorpipe::Error& error) {
         promise->set_value(error);

--- a/tensorpipe/test/channel/channel_test_cpu.cc
+++ b/tensorpipe/test/channel/channel_test_cpu.cc
@@ -17,15 +17,8 @@ using namespace tensorpipe::channel;
 class NullPointerTest : public ClientServerChannelTestCase<CpuBuffer> {
   void server(std::shared_ptr<Channel> channel) override {
     // Perform send and wait for completion.
-    std::future<std::tuple<Error, TDescriptor>> descriptorFuture;
-    std::future<Error> sendFuture;
-    std::tie(descriptorFuture, sendFuture) =
+    std::future<Error> sendFuture =
         sendWithFuture(channel, CpuBuffer{nullptr, 0});
-    Error descriptorError;
-    TDescriptor descriptor;
-    std::tie(descriptorError, descriptor) = descriptorFuture.get();
-    EXPECT_FALSE(descriptorError) << descriptorError.what();
-    this->peers_->send(PeerGroup::kClient, descriptor);
     Error sendError = sendFuture.get();
     EXPECT_FALSE(sendError) << sendError.what();
 
@@ -35,9 +28,8 @@ class NullPointerTest : public ClientServerChannelTestCase<CpuBuffer> {
 
   void client(std::shared_ptr<Channel> channel) override {
     // Perform recv and wait for completion.
-    auto descriptor = this->peers_->recv(PeerGroup::kClient);
     std::future<Error> recvFuture =
-        recvWithFuture(channel, descriptor, CpuBuffer{nullptr, 0});
+        recvWithFuture(channel, CpuBuffer{nullptr, 0});
     Error recvError = recvFuture.get();
     EXPECT_FALSE(recvError) << recvError.what();
 
@@ -58,14 +50,7 @@ class EmptyTensorTest : public ClientServerChannelTestCase<CpuBuffer> {
     buffer.unwrap<CpuBuffer>().length = 0;
 
     // Perform send and wait for completion.
-    std::future<std::tuple<Error, TDescriptor>> descriptorFuture;
-    std::future<Error> sendFuture;
-    std::tie(descriptorFuture, sendFuture) = sendWithFuture(channel, buffer);
-    Error descriptorError;
-    TDescriptor descriptor;
-    std::tie(descriptorError, descriptor) = descriptorFuture.get();
-    EXPECT_FALSE(descriptorError) << descriptorError.what();
-    this->peers_->send(PeerGroup::kClient, descriptor);
+    std::future<Error> sendFuture = sendWithFuture(channel, buffer);
     Error sendError = sendFuture.get();
     EXPECT_FALSE(sendError) << sendError.what();
 
@@ -80,8 +65,7 @@ class EmptyTensorTest : public ClientServerChannelTestCase<CpuBuffer> {
     buffer.unwrap<CpuBuffer>().length = 0;
 
     // Perform recv and wait for completion.
-    auto descriptor = this->peers_->recv(PeerGroup::kClient);
-    std::future<Error> recvFuture = recvWithFuture(channel, descriptor, buffer);
+    std::future<Error> recvFuture = recvWithFuture(channel, buffer);
     Error recvError = recvFuture.get();
     EXPECT_FALSE(recvError) << recvError.what();
 
@@ -108,27 +92,20 @@ class CallbacksAreDeferredTest : public ClientServerChannelTestCase<CpuBuffer> {
     std::iota(data.begin(), data.end(), 0);
 
     // Perform send and wait for completion.
-    std::promise<std::tuple<Error, TDescriptor>> descriptorPromise;
     std::promise<Error> sendPromise;
     auto mutex = std::make_shared<std::mutex>();
     std::unique_lock<std::mutex> callerLock(*mutex);
     channel->send(
         CpuBuffer{data.data(), kDataSize},
-        [&descriptorPromise](const Error& error, TDescriptor descriptor) {
-          descriptorPromise.set_value(
-              std::make_tuple(error, std::move(descriptor)));
+        [](const Error& error, TDescriptor descriptor) {
+          EXPECT_FALSE(error);
+          EXPECT_EQ(descriptor, "");
         },
         [&sendPromise, mutex](const Error& error) {
           std::unique_lock<std::mutex> calleeLock(*mutex);
           sendPromise.set_value(error);
         });
     callerLock.unlock();
-    Error descriptorError;
-    TDescriptor descriptor;
-    std::tie(descriptorError, descriptor) =
-        descriptorPromise.get_future().get();
-    EXPECT_FALSE(descriptorError) << descriptorError.what();
-    this->peers_->send(PeerGroup::kClient, descriptor);
     Error sendError = sendPromise.get_future().get();
     EXPECT_FALSE(sendError) << sendError.what();
 
@@ -145,9 +122,8 @@ class CallbacksAreDeferredTest : public ClientServerChannelTestCase<CpuBuffer> {
     std::promise<Error> recvPromise;
     std::mutex mutex;
     std::unique_lock<std::mutex> callerLock(mutex);
-    auto descriptor = this->peers_->recv(PeerGroup::kClient);
     channel->recv(
-        descriptor,
+        "",
         CpuBuffer{data.data(), kDataSize},
         [&recvPromise, &mutex](const Error& error) {
           std::unique_lock<std::mutex> calleeLock(mutex);

--- a/tensorpipe/test/channel/channel_test_cuda.cc
+++ b/tensorpipe/test/channel/channel_test_cuda.cc
@@ -35,10 +35,7 @@ class ReceiverWaitsForStartEventTest
     TP_CUDA_CHECK(cudaMemsetAsync(ptr, 0x42, kSize, sendStream));
 
     // Perform send and wait for completion.
-    auto descriptorPromise = std::make_shared<
-        std::promise<std::tuple<tensorpipe::Error, std::string>>>();
     auto sendPromise = std::make_shared<std::promise<tensorpipe::Error>>();
-    auto descriptorFuture = descriptorPromise->get_future();
     auto sendFuture = sendPromise->get_future();
 
     channel->send(
@@ -47,21 +44,14 @@ class ReceiverWaitsForStartEventTest
             .length = kSize,
             .stream = sendStream,
         },
-        [descriptorPromise{std::move(descriptorPromise)}](
-            const tensorpipe::Error& error, std::string descriptor) {
-          descriptorPromise->set_value(
-              std::make_tuple(error, std::move(descriptor)));
+        [](const tensorpipe::Error& error, std::string descriptor) {
+          EXPECT_FALSE(error);
+          EXPECT_EQ(descriptor, "");
         },
         [sendPromise{std::move(sendPromise)}](const tensorpipe::Error& error) {
           sendPromise->set_value(error);
         });
 
-    Error descriptorError;
-    TDescriptor descriptor;
-    std::tie(descriptorError, descriptor) = descriptorFuture.get();
-
-    EXPECT_FALSE(descriptorError) << descriptorError.what();
-    this->peers_->send(PeerGroup::kClient, descriptor);
     Error sendError = sendFuture.get();
     EXPECT_FALSE(sendError) << sendError.what();
     TP_CUDA_CHECK(cudaFree(ptr));
@@ -78,14 +68,12 @@ class ReceiverWaitsForStartEventTest
     void* ptr;
     TP_CUDA_CHECK(cudaMalloc(&ptr, kSize));
 
-    auto descriptor = this->peers_->recv(PeerGroup::kClient);
-
     // Perform recv and wait for completion.
     auto recvPromise = std::make_shared<std::promise<tensorpipe::Error>>();
     auto recvFuture = recvPromise->get_future();
 
     channel->recv(
-        std::move(descriptor),
+        "",
         CudaBuffer{
             .ptr = ptr,
             .length = kSize,
@@ -127,15 +115,8 @@ class SendOffsetAllocationTest
         cudaMemset(static_cast<uint8_t*>(ptr) + kOffset, 0x42, kDataSize));
 
     // Perform send and wait for completion.
-    std::future<std::tuple<Error, TDescriptor>> descriptorFuture;
-    std::future<Error> sendFuture;
-    std::tie(descriptorFuture, sendFuture) = sendWithFuture(
+    std::future<Error> sendFuture = sendWithFuture(
         channel, CudaBuffer{static_cast<uint8_t*>(ptr) + kOffset, kDataSize});
-    Error descriptorError;
-    TDescriptor descriptor;
-    std::tie(descriptorError, descriptor) = descriptorFuture.get();
-    EXPECT_FALSE(descriptorError) << descriptorError.what();
-    this->peers_->send(PeerGroup::kClient, descriptor);
     Error sendError = sendFuture.get();
     EXPECT_FALSE(sendError) << sendError.what();
 
@@ -147,9 +128,8 @@ class SendOffsetAllocationTest
     DataWrapper<CudaBuffer> wrappedData(kDataSize);
 
     // Perform recv and wait for completion.
-    auto descriptor = this->peers_->recv(PeerGroup::kClient);
     std::future<Error> recvFuture =
-        recvWithFuture(channel, descriptor, wrappedData.buffer());
+        recvWithFuture(channel, wrappedData.buffer());
     Error recvError = recvFuture.get();
     EXPECT_FALSE(recvError) << recvError.what();
 

--- a/tensorpipe/test/channel/channel_test_cuda_multi_gpu.cc
+++ b/tensorpipe/test/channel/channel_test_cuda_multi_gpu.cc
@@ -45,10 +45,7 @@ class SendAcrossDevicesTest : public ClientServerChannelTestCase<CudaBuffer> {
     }
 
     // Perform send and wait for completion.
-    auto descriptorPromise = std::make_shared<
-        std::promise<std::tuple<tensorpipe::Error, std::string>>>();
     auto sendPromise = std::make_shared<std::promise<tensorpipe::Error>>();
-    auto descriptorFuture = descriptorPromise->get_future();
     auto sendFuture = sendPromise->get_future();
 
     channel->send(
@@ -57,21 +54,14 @@ class SendAcrossDevicesTest : public ClientServerChannelTestCase<CudaBuffer> {
             .length = kSize,
             .stream = sendStream,
         },
-        [descriptorPromise{std::move(descriptorPromise)}](
-            const tensorpipe::Error& error, std::string descriptor) {
-          descriptorPromise->set_value(
-              std::make_tuple(error, std::move(descriptor)));
+        [](const tensorpipe::Error& error, std::string descriptor) {
+          EXPECT_FALSE(error);
+          EXPECT_EQ(descriptor);
         },
         [sendPromise{std::move(sendPromise)}](const tensorpipe::Error& error) {
           sendPromise->set_value(error);
         });
 
-    Error descriptorError;
-    TDescriptor descriptor;
-    std::tie(descriptorError, descriptor) = descriptorFuture.get();
-
-    EXPECT_FALSE(descriptorError) << descriptorError.what();
-    this->peers_->send(PeerGroup::kClient, descriptor);
     Error sendError = sendFuture.get();
     EXPECT_FALSE(sendError) << sendError.what();
 
@@ -104,14 +94,12 @@ class SendAcrossDevicesTest : public ClientServerChannelTestCase<CudaBuffer> {
       TP_CUDA_CHECK(cudaMalloc(&ptr, kSize));
     }
 
-    auto descriptor = this->peers_->recv(PeerGroup::kClient);
-
     // Perform recv and wait for completion.
     auto recvPromise = std::make_shared<std::promise<tensorpipe::Error>>();
     auto recvFuture = recvPromise->get_future();
 
     channel->recv(
-        std::move(descriptor),
+        "",
         CudaBuffer{
             .ptr = ptr,
             .length = kSize,
@@ -178,10 +166,7 @@ class SendReverseAcrossDevicesTest
     }
 
     // Perform send and wait for completion.
-    auto descriptorPromise = std::make_shared<
-        std::promise<std::tuple<tensorpipe::Error, std::string>>>();
     auto sendPromise = std::make_shared<std::promise<tensorpipe::Error>>();
-    auto descriptorFuture = descriptorPromise->get_future();
     auto sendFuture = sendPromise->get_future();
 
     channel->send(
@@ -190,21 +175,14 @@ class SendReverseAcrossDevicesTest
             .length = kSize,
             .stream = sendStream,
         },
-        [descriptorPromise{std::move(descriptorPromise)}](
-            const tensorpipe::Error& error, std::string descriptor) {
-          descriptorPromise->set_value(
-              std::make_tuple(error, std::move(descriptor)));
+        [](const tensorpipe::Error& error, std::string descriptor) {
+          EXPECT_FALSE(error);
+          EXPECT_EQ(descriptor, "");
         },
         [sendPromise{std::move(sendPromise)}](const tensorpipe::Error& error) {
           sendPromise->set_value(error);
         });
 
-    Error descriptorError;
-    TDescriptor descriptor;
-    std::tie(descriptorError, descriptor) = descriptorFuture.get();
-
-    EXPECT_FALSE(descriptorError) << descriptorError.what();
-    this->peers_->send(PeerGroup::kClient, descriptor);
     Error sendError = sendFuture.get();
     EXPECT_FALSE(sendError) << sendError.what();
 
@@ -237,14 +215,12 @@ class SendReverseAcrossDevicesTest
       TP_CUDA_CHECK(cudaMalloc(&ptr, kSize));
     }
 
-    auto descriptor = this->peers_->recv(PeerGroup::kClient);
-
     // Perform recv and wait for completion.
     auto recvPromise = std::make_shared<std::promise<tensorpipe::Error>>();
     auto recvFuture = recvPromise->get_future();
 
     channel->recv(
-        std::move(descriptor),
+        "",
         CudaBuffer{
             .ptr = ptr,
             .length = kSize,
@@ -311,10 +287,7 @@ class SendAcrossNonDefaultDevicesTest
     }
 
     // Perform send and wait for completion.
-    auto descriptorPromise = std::make_shared<
-        std::promise<std::tuple<tensorpipe::Error, std::string>>>();
     auto sendPromise = std::make_shared<std::promise<tensorpipe::Error>>();
-    auto descriptorFuture = descriptorPromise->get_future();
     auto sendFuture = sendPromise->get_future();
 
     channel->send(
@@ -323,21 +296,14 @@ class SendAcrossNonDefaultDevicesTest
             .length = kSize,
             .stream = sendStream,
         },
-        [descriptorPromise{std::move(descriptorPromise)}](
-            const tensorpipe::Error& error, std::string descriptor) {
-          descriptorPromise->set_value(
-              std::make_tuple(error, std::move(descriptor)));
+        [](const tensorpipe::Error& error, std::string descriptor) {
+          EXPECT_FALSE(error);
+          EXPECT_EQ(descriptor, "");
         },
         [sendPromise{std::move(sendPromise)}](const tensorpipe::Error& error) {
           sendPromise->set_value(error);
         });
 
-    Error descriptorError;
-    TDescriptor descriptor;
-    std::tie(descriptorError, descriptor) = descriptorFuture.get();
-
-    EXPECT_FALSE(descriptorError) << descriptorError.what();
-    this->peers_->send(PeerGroup::kClient, descriptor);
     Error sendError = sendFuture.get();
     EXPECT_FALSE(sendError) << sendError.what();
 
@@ -366,14 +332,12 @@ class SendAcrossNonDefaultDevicesTest
       TP_CUDA_CHECK(cudaMalloc(&ptr, kSize));
     }
 
-    auto descriptor = this->peers_->recv(PeerGroup::kClient);
-
     // Perform recv and wait for completion.
     auto recvPromise = std::make_shared<std::promise<tensorpipe::Error>>();
     auto recvFuture = recvPromise->get_future();
 
     channel->recv(
-        std::move(descriptor),
+        "",
         CudaBuffer{
             .ptr = ptr,
             .length = kSize,

--- a/tensorpipe/test/channel/channel_test_cuda_multi_gpu.cc
+++ b/tensorpipe/test/channel/channel_test_cuda_multi_gpu.cc
@@ -56,7 +56,7 @@ class SendAcrossDevicesTest : public ClientServerChannelTestCase<CudaBuffer> {
         },
         [](const tensorpipe::Error& error, std::string descriptor) {
           EXPECT_FALSE(error);
-          EXPECT_EQ(descriptor);
+          EXPECT_EQ(descriptor, "");
         },
         [sendPromise{std::move(sendPromise)}](const tensorpipe::Error& error) {
           sendPromise->set_value(error);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #335 Remove descriptor/descriptorCallback from Channel interface.
* **#340 Avoid collecting channel descriptors in channel tests.**
* #339 Avoid collecting channel descriptors in the Pipe.
* #336 In-channel descriptor exchanges for CudaBasic.
* #334 In-channel descriptor exchanges for CudaGdr.
* #333 In-channel descriptor exchanges for CudaXth.
* #332 In-channel descriptor exchanges for Xth.
* #331 In-channel descriptor exchanges for Cma.

Differential Revision: [D27434728](https://our.internmc.facebook.com/intern/diff/D27434728)