### PR TITLE
Rework channel tests to remove template and unify test suite

### DIFF
--- a/tensorpipe/test/channel/basic/basic_test.cc
+++ b/tensorpipe/test/channel/basic/basic_test.cc
@@ -7,11 +7,11 @@
  */
 
 #include <tensorpipe/channel/basic/factory.h>
-#include <tensorpipe/test/channel/channel_test.h>
+#include <tensorpipe/test/channel/channel_test_cpu.h>
 
 namespace {
 
-class BasicChannelTestHelper : public ChannelTestHelper<tensorpipe::CpuBuffer> {
+class BasicChannelTestHelper : public CpuChannelTestHelper {
  protected:
   std::shared_ptr<tensorpipe::channel::Context> makeContextInternal(
       std::string id) override {
@@ -24,5 +24,7 @@ class BasicChannelTestHelper : public ChannelTestHelper<tensorpipe::CpuBuffer> {
 BasicChannelTestHelper helper;
 
 } // namespace
+
+INSTANTIATE_TEST_CASE_P(Basic, ChannelTestSuite, ::testing::Values(&helper));
 
 INSTANTIATE_TEST_CASE_P(Basic, CpuChannelTestSuite, ::testing::Values(&helper));

--- a/tensorpipe/test/channel/channel_test.h
+++ b/tensorpipe/test/channel/channel_test.h
@@ -22,111 +22,20 @@
 #include <tensorpipe/channel/context.h>
 #include <tensorpipe/common/buffer.h>
 #include <tensorpipe/common/cpu_buffer.h>
-#include <tensorpipe/config.h>
 #include <tensorpipe/test/peer_group.h>
 #include <tensorpipe/transport/connection.h>
 #include <tensorpipe/transport/listener.h>
 #include <tensorpipe/transport/uv/factory.h>
 
-#if TENSORPIPE_SUPPORTS_CUDA
-#include <tensorpipe/common/cuda.h>
-#include <tensorpipe/common/cuda_buffer.h>
-#endif
-
-template <typename TBuffer>
-class DataWrapper {};
-
-template <>
-class DataWrapper<tensorpipe::CpuBuffer> {
+class DataWrapper {
  public:
-  explicit DataWrapper(size_t length) : vector_(length) {}
+  virtual tensorpipe::Buffer buffer() const = 0;
 
-  explicit DataWrapper(std::vector<uint8_t> v) : vector_(v) {}
+  virtual std::vector<uint8_t> unwrap() = 0;
 
-  tensorpipe::Buffer buffer() const {
-    return tensorpipe::CpuBuffer{
-        const_cast<uint8_t*>(vector_.data()), vector_.size()};
-  }
-
-  const std::vector<uint8_t>& unwrap() {
-    return vector_;
-  }
-
- private:
-  std::vector<uint8_t> vector_;
+  virtual ~DataWrapper() = default;
 };
 
-#if TENSORPIPE_SUPPORTS_CUDA
-
-template <>
-class DataWrapper<tensorpipe::CudaBuffer> {
- public:
-  // Non-copyable.
-  DataWrapper(const DataWrapper&) = delete;
-  DataWrapper& operator=(const DataWrapper&) = delete;
-
-  explicit DataWrapper(size_t length) : length_(length) {
-    if (length_ > 0) {
-      TP_CUDA_CHECK(cudaSetDevice(0));
-      TP_CUDA_CHECK(cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking));
-      TP_CUDA_CHECK(cudaMalloc(&cudaPtr_, length_));
-    }
-  }
-
-  explicit DataWrapper(std::vector<uint8_t> v) : DataWrapper(v.size()) {
-    if (length_ > 0) {
-      TP_CUDA_CHECK(cudaMemcpyAsync(
-          cudaPtr_, v.data(), length_, cudaMemcpyDefault, stream_));
-    }
-  }
-
-  explicit DataWrapper(DataWrapper&& other) noexcept
-      : cudaPtr_(other.cudaPtr_),
-        length_(other.length_),
-        stream_(other.stream_) {
-    other.cudaPtr_ = nullptr;
-    other.length_ = 0;
-    other.stream_ = cudaStreamDefault;
-  }
-
-  DataWrapper& operator=(DataWrapper&& other) {
-    std::swap(cudaPtr_, other.cudaPtr_);
-    std::swap(length_, other.length_);
-    std::swap(stream_, other.stream_);
-
-    return *this;
-  }
-
-  tensorpipe::Buffer buffer() const {
-    return tensorpipe::CudaBuffer{cudaPtr_, length_, stream_};
-  }
-
-  std::vector<uint8_t> unwrap() {
-    std::vector<uint8_t> v(length_);
-    if (length_ > 0) {
-      TP_CUDA_CHECK(cudaStreamSynchronize(stream_));
-      TP_CUDA_CHECK(cudaMemcpy(v.data(), cudaPtr_, length_, cudaMemcpyDefault));
-    }
-
-    return v;
-  }
-
-  ~DataWrapper() {
-    if (length_ > 0) {
-      TP_CUDA_CHECK(cudaFree(cudaPtr_));
-      TP_CUDA_CHECK(cudaStreamDestroy(stream_));
-    }
-  }
-
- private:
-  void* cudaPtr_{nullptr};
-  size_t length_{0};
-  cudaStream_t stream_{cudaStreamDefault};
-};
-
-#endif // TENSORPIPE_SUPPORTS_CUDA
-
-template <typename TBuffer>
 class ChannelTestHelper {
  public:
   virtual ~ChannelTestHelper() = default;
@@ -145,6 +54,10 @@ class ChannelTestHelper {
   virtual std::shared_ptr<PeerGroup> makePeerGroup() {
     return std::make_shared<ThreadPeerGroup>();
   }
+
+  virtual std::unique_ptr<DataWrapper> makeDataWrapper(size_t length) = 0;
+  virtual std::unique_ptr<DataWrapper> makeDataWrapper(
+      std::vector<uint8_t> v) = 0;
 
  protected:
   virtual std::shared_ptr<tensorpipe::channel::Context> makeContextInternal(
@@ -193,16 +106,14 @@ sendWithFuture(
   return future;
 }
 
-template <typename TBuffer>
 class ChannelTestCase {
  public:
-  virtual void run(ChannelTestHelper<TBuffer>* helper) = 0;
+  virtual void run(ChannelTestHelper* helper) = 0;
 
   virtual ~ChannelTestCase() = default;
 };
 
-template <typename TBuffer>
-class ClientServerChannelTestCase : public ChannelTestCase<TBuffer> {
+class ClientServerChannelTestCase : public ChannelTestCase {
   using MultiAcceptResult = std::pair<
       tensorpipe::Error,
       std::vector<std::shared_ptr<tensorpipe::transport::Connection>>>;
@@ -303,7 +214,7 @@ class ClientServerChannelTestCase : public ChannelTestCase<TBuffer> {
   }
 
  public:
-  void run(ChannelTestHelper<TBuffer>* helper) override {
+  void run(ChannelTestHelper* helper) override {
     auto addr = "127.0.0.1";
 
     helper_ = helper;
@@ -367,40 +278,13 @@ class ClientServerChannelTestCase : public ChannelTestCase<TBuffer> {
   virtual void afterClient() {}
 
  protected:
-  ChannelTestHelper<TBuffer>* helper_;
+  ChannelTestHelper* helper_;
   std::shared_ptr<PeerGroup> peers_;
 };
 
-class CpuChannelTestSuite : public ::testing::TestWithParam<
-                                ChannelTestHelper<tensorpipe::CpuBuffer>*> {};
-#if TENSORPIPE_SUPPORTS_CUDA
-class CudaChannelTestSuite : public ::testing::TestWithParam<
-                                 ChannelTestHelper<tensorpipe::CudaBuffer>*> {};
-class CudaMultiGPUChannelTestSuite
-    : public ::testing::TestWithParam<
-          ChannelTestHelper<tensorpipe::CudaBuffer>*> {};
-#endif // TENSORPIPE_SUPPORTS_CUDA
+class ChannelTestSuite : public ::testing::TestWithParam<ChannelTestHelper*> {};
 
-#define _CHANNEL_TEST(type, suite, name)    \
-  TEST_P(suite, name) {                     \
-    name##Test<tensorpipe::type##Buffer> t; \
-    t.run(GetParam());                      \
-  }
-
-#define _CHANNEL_TEST_CPU(name) _CHANNEL_TEST(Cpu, CpuChannelTestSuite, name)
-
-#if TENSORPIPE_SUPPORTS_CUDA
-#define _CHANNEL_TEST_CUDA(name) _CHANNEL_TEST(Cuda, CudaChannelTestSuite, name)
-#else // TENSORPIPE_SUPPORTS_CUDA
-#define _CHANNEL_TEST_CUDA(name)
-#endif // TENSORPIPE_SUPPORTS_CUDA
-
-// Register a generic (template) channel test.
-#define CHANNEL_TEST_GENERIC(name) \
-  _CHANNEL_TEST_CPU(name);         \
-  _CHANNEL_TEST_CUDA(name);
-
-// Register a (non-template) channel test.
+// Register a channel test.
 #define CHANNEL_TEST(suite, name) \
   TEST_P(suite, name) {           \
     name##Test t;                 \

--- a/tensorpipe/test/channel/channel_test_cpu.h
+++ b/tensorpipe/test/channel/channel_test_cpu.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <tensorpipe/common/cpu_buffer.h>
+#include <tensorpipe/test/channel/channel_test.h>
+
+class CpuDataWrapper : public DataWrapper {
+ public:
+  explicit CpuDataWrapper(size_t length) : vector_(length) {}
+
+  explicit CpuDataWrapper(std::vector<uint8_t> v) : vector_(v) {}
+
+  tensorpipe::Buffer buffer() const override {
+    return tensorpipe::CpuBuffer{
+        const_cast<uint8_t*>(vector_.data()), vector_.size()};
+  }
+
+  std::vector<uint8_t> unwrap() override {
+    return vector_;
+  }
+
+ private:
+  std::vector<uint8_t> vector_;
+};
+
+class CpuChannelTestHelper : public ChannelTestHelper {
+ public:
+  std::unique_ptr<DataWrapper> makeDataWrapper(size_t length) override {
+    return std::make_unique<CpuDataWrapper>(length);
+  }
+
+  std::unique_ptr<DataWrapper> makeDataWrapper(
+      std::vector<uint8_t> v) override {
+    return std::make_unique<CpuDataWrapper>(std::move(v));
+  }
+};
+
+class CpuChannelTestSuite
+    : public ::testing::TestWithParam<CpuChannelTestHelper*> {};

--- a/tensorpipe/test/channel/channel_test_cuda.h
+++ b/tensorpipe/test/channel/channel_test_cuda.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <tensorpipe/common/cuda.h>
+#include <tensorpipe/common/cuda_buffer.h>
+#include <tensorpipe/test/channel/channel_test.h>
+
+class CudaDataWrapper : public DataWrapper {
+ public:
+  // Non-copyable.
+  CudaDataWrapper(const CudaDataWrapper&) = delete;
+  CudaDataWrapper& operator=(const CudaDataWrapper&) = delete;
+  // Non-movable.
+  CudaDataWrapper(CudaDataWrapper&& other) = delete;
+  CudaDataWrapper& operator=(CudaDataWrapper&& other) = delete;
+
+  explicit CudaDataWrapper(size_t length) : length_(length) {
+    if (length_ > 0) {
+      TP_CUDA_CHECK(cudaSetDevice(0));
+      TP_CUDA_CHECK(cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking));
+      TP_CUDA_CHECK(cudaMalloc(&cudaPtr_, length_));
+    }
+  }
+
+  explicit CudaDataWrapper(std::vector<uint8_t> v) : CudaDataWrapper(v.size()) {
+    if (length_ > 0) {
+      TP_CUDA_CHECK(cudaMemcpyAsync(
+          cudaPtr_, v.data(), length_, cudaMemcpyDefault, stream_));
+    }
+  }
+
+  tensorpipe::Buffer buffer() const override {
+    return tensorpipe::CudaBuffer{cudaPtr_, length_, stream_};
+  }
+
+  std::vector<uint8_t> unwrap() override {
+    std::vector<uint8_t> v(length_);
+    if (length_ > 0) {
+      TP_CUDA_CHECK(cudaStreamSynchronize(stream_));
+      TP_CUDA_CHECK(cudaMemcpy(v.data(), cudaPtr_, length_, cudaMemcpyDefault));
+    }
+    return v;
+  }
+
+  ~CudaDataWrapper() override {
+    if (length_ > 0) {
+      TP_CUDA_CHECK(cudaFree(cudaPtr_));
+      TP_CUDA_CHECK(cudaStreamDestroy(stream_));
+    }
+  }
+
+ private:
+  void* cudaPtr_{nullptr};
+  size_t length_{0};
+  cudaStream_t stream_{cudaStreamDefault};
+};
+
+class CudaChannelTestHelper : public ChannelTestHelper {
+ public:
+  std::unique_ptr<DataWrapper> makeDataWrapper(size_t length) override {
+    return std::make_unique<CudaDataWrapper>(length);
+  }
+
+  std::unique_ptr<DataWrapper> makeDataWrapper(
+      std::vector<uint8_t> v) override {
+    return std::make_unique<CudaDataWrapper>(std::move(v));
+  }
+};
+
+class CudaChannelTestSuite
+    : public ::testing::TestWithParam<CudaChannelTestHelper*> {};
+
+class CudaMultiGPUChannelTestSuite
+    : public ::testing::TestWithParam<CudaChannelTestHelper*> {};

--- a/tensorpipe/test/channel/channel_test_cuda_multi_gpu.cc
+++ b/tensorpipe/test/channel/channel_test_cuda_multi_gpu.cc
@@ -9,24 +9,23 @@
 #include <cuda_runtime.h>
 #include <gmock/gmock.h>
 
-#include <tensorpipe/common/cuda.h>
-#include <tensorpipe/test/channel/channel_test.h>
+#include <tensorpipe/test/channel/channel_test_cuda.h>
 #include <tensorpipe/test/channel/cuda_helpers.h>
 #include <tensorpipe/test/test_environment.h>
 
 using namespace tensorpipe;
 using namespace tensorpipe::channel;
 
-class SendAcrossDevicesTest : public ClientServerChannelTestCase<CudaBuffer> {
+class SendAcrossDevicesTest : public ClientServerChannelTestCase {
   static constexpr size_t kSize = 1024;
 
  public:
-  void run(ChannelTestHelper<CudaBuffer>* helper) override {
+  void run(ChannelTestHelper* helper) override {
     if (TestEnvironment::numCudaDevices() < 2) {
       GTEST_SKIP() << "Skipping test requiring >=2 CUDA devices.";
     }
 
-    ClientServerChannelTestCase<CudaBuffer>::run(helper);
+    ClientServerChannelTestCase::run(helper);
   }
 
  private:
@@ -149,17 +148,16 @@ class SendAcrossDevicesTest : public ClientServerChannelTestCase<CudaBuffer> {
 
 CHANNEL_TEST(CudaMultiGPUChannelTestSuite, SendAcrossDevices);
 
-class SendReverseAcrossDevicesTest
-    : public ClientServerChannelTestCase<CudaBuffer> {
+class SendReverseAcrossDevicesTest : public ClientServerChannelTestCase {
   static constexpr size_t kSize = 1024;
 
  public:
-  void run(ChannelTestHelper<CudaBuffer>* helper) override {
+  void run(ChannelTestHelper* helper) override {
     if (TestEnvironment::numCudaDevices() < 2) {
       GTEST_SKIP() << "Skipping test requiring >=2 CUDA devices.";
     }
 
-    ClientServerChannelTestCase<CudaBuffer>::run(helper);
+    ClientServerChannelTestCase::run(helper);
   }
 
  private:
@@ -282,17 +280,16 @@ class SendReverseAcrossDevicesTest
 
 CHANNEL_TEST(CudaMultiGPUChannelTestSuite, SendReverseAcrossDevices);
 
-class SendAcrossNonDefaultDevicesTest
-    : public ClientServerChannelTestCase<CudaBuffer> {
+class SendAcrossNonDefaultDevicesTest : public ClientServerChannelTestCase {
   static constexpr size_t kSize = 1024;
 
  public:
-  void run(ChannelTestHelper<CudaBuffer>* helper) override {
+  void run(ChannelTestHelper* helper) override {
     if (TestEnvironment::numCudaDevices() < 2) {
       GTEST_SKIP() << "Skipping test requiring >=2 CUDA devices.";
     }
 
-    ClientServerChannelTestCase<CudaBuffer>::run(helper);
+    ClientServerChannelTestCase::run(helper);
   }
 
  private:

--- a/tensorpipe/test/channel/cma/cma_test.cc
+++ b/tensorpipe/test/channel/cma/cma_test.cc
@@ -7,11 +7,11 @@
  */
 
 #include <tensorpipe/channel/cma/factory.h>
-#include <tensorpipe/test/channel/channel_test.h>
+#include <tensorpipe/test/channel/channel_test_cpu.h>
 
 namespace {
 
-class CmaChannelTestHelper : public ChannelTestHelper<tensorpipe::CpuBuffer> {
+class CmaChannelTestHelper : public CpuChannelTestHelper {
  protected:
   std::shared_ptr<tensorpipe::channel::Context> makeContextInternal(
       std::string id) override {
@@ -24,5 +24,7 @@ class CmaChannelTestHelper : public ChannelTestHelper<tensorpipe::CpuBuffer> {
 CmaChannelTestHelper helper;
 
 } // namespace
+
+INSTANTIATE_TEST_CASE_P(Cma, ChannelTestSuite, ::testing::Values(&helper));
 
 INSTANTIATE_TEST_CASE_P(Cma, CpuChannelTestSuite, ::testing::Values(&helper));

--- a/tensorpipe/test/channel/cuda_basic/cuda_basic_test.cc
+++ b/tensorpipe/test/channel/cuda_basic/cuda_basic_test.cc
@@ -10,12 +10,11 @@
 
 #include <tensorpipe/channel/basic/factory.h>
 #include <tensorpipe/channel/cuda_basic/factory.h>
-#include <tensorpipe/test/channel/channel_test.h>
+#include <tensorpipe/test/channel/channel_test_cuda.h>
 
 namespace {
 
-class CudaBasicChannelTestHelper
-    : public ChannelTestHelper<tensorpipe::CudaBuffer> {
+class CudaBasicChannelTestHelper : public CudaChannelTestHelper {
  protected:
   std::shared_ptr<tensorpipe::channel::Context> makeContextInternal(
       std::string id) override {
@@ -35,6 +34,11 @@ class CudaBasicChannelTestHelper
 CudaBasicChannelTestHelper helper;
 
 } // namespace
+
+INSTANTIATE_TEST_CASE_P(
+    CudaBasic,
+    ChannelTestSuite,
+    ::testing::Values(&helper));
 
 INSTANTIATE_TEST_CASE_P(
     CudaBasic,

--- a/tensorpipe/test/channel/cuda_gdr/cuda_gdr_test.cc
+++ b/tensorpipe/test/channel/cuda_gdr/cuda_gdr_test.cc
@@ -9,12 +9,11 @@
 #include <numeric>
 
 #include <tensorpipe/channel/cuda_gdr/factory.h>
-#include <tensorpipe/test/channel/channel_test.h>
+#include <tensorpipe/test/channel/channel_test_cuda.h>
 
 namespace {
 
-class CudaGdrChannelTestHelper
-    : public ChannelTestHelper<tensorpipe::CudaBuffer> {
+class CudaGdrChannelTestHelper : public CudaChannelTestHelper {
  protected:
   std::shared_ptr<tensorpipe::channel::Context> makeContextInternal(
       std::string id) override {
@@ -32,6 +31,8 @@ class CudaGdrChannelTestHelper
 CudaGdrChannelTestHelper helper;
 
 } // namespace
+
+INSTANTIATE_TEST_CASE_P(CudaGdr, ChannelTestSuite, ::testing::Values(&helper));
 
 INSTANTIATE_TEST_CASE_P(
     CudaGdr,

--- a/tensorpipe/test/channel/cuda_ipc/cuda_ipc_test.cc
+++ b/tensorpipe/test/channel/cuda_ipc/cuda_ipc_test.cc
@@ -9,12 +9,11 @@
 #include <numeric>
 
 #include <tensorpipe/channel/cuda_ipc/factory.h>
-#include <tensorpipe/test/channel/channel_test.h>
+#include <tensorpipe/test/channel/channel_test_cuda.h>
 
 namespace {
 
-class CudaIpcChannelTestHelper
-    : public ChannelTestHelper<tensorpipe::CudaBuffer> {
+class CudaIpcChannelTestHelper : public CudaChannelTestHelper {
  protected:
   std::shared_ptr<tensorpipe::channel::Context> makeContextInternal(
       std::string id) override {
@@ -32,6 +31,8 @@ class CudaIpcChannelTestHelper
 CudaIpcChannelTestHelper helper;
 
 } // namespace
+
+INSTANTIATE_TEST_CASE_P(CudaIpc, ChannelTestSuite, ::testing::Values(&helper));
 
 INSTANTIATE_TEST_CASE_P(
     CudaIpc,

--- a/tensorpipe/test/channel/cuda_xth/cuda_xth_test.cc
+++ b/tensorpipe/test/channel/cuda_xth/cuda_xth_test.cc
@@ -9,12 +9,11 @@
 #include <numeric>
 
 #include <tensorpipe/channel/cuda_xth/factory.h>
-#include <tensorpipe/test/channel/channel_test.h>
+#include <tensorpipe/test/channel/channel_test_cuda.h>
 
 namespace {
 
-class CudaXthChannelTestHelper
-    : public ChannelTestHelper<tensorpipe::CudaBuffer> {
+class CudaXthChannelTestHelper : public CudaChannelTestHelper {
  protected:
   std::shared_ptr<tensorpipe::channel::Context> makeContextInternal(
       std::string id) override {
@@ -32,6 +31,8 @@ class CudaXthChannelTestHelper
 CudaXthChannelTestHelper helper;
 
 } // namespace
+
+INSTANTIATE_TEST_CASE_P(CudaXth, ChannelTestSuite, ::testing::Values(&helper));
 
 INSTANTIATE_TEST_CASE_P(
     CudaXth,

--- a/tensorpipe/test/channel/mpt/mpt_test.cc
+++ b/tensorpipe/test/channel/mpt/mpt_test.cc
@@ -9,12 +9,12 @@
 #include <tensorpipe/channel/context.h>
 #include <tensorpipe/channel/mpt/factory.h>
 #include <tensorpipe/common/cpu_buffer.h>
-#include <tensorpipe/test/channel/channel_test.h>
+#include <tensorpipe/test/channel/channel_test_cpu.h>
 #include <tensorpipe/transport/connection.h>
 
 namespace {
 
-class MptChannelTestHelper : public ChannelTestHelper<tensorpipe::CpuBuffer> {
+class MptChannelTestHelper : public CpuChannelTestHelper {
  protected:
   std::shared_ptr<tensorpipe::channel::Context> makeContextInternal(
       std::string id) override {
@@ -35,17 +35,17 @@ class MptChannelTestHelper : public ChannelTestHelper<tensorpipe::CpuBuffer> {
 
 MptChannelTestHelper helper;
 
-class MptChannelTestSuite : public CpuChannelTestSuite {};
+class MptChannelTestSuite : public ChannelTestSuite {};
 
 } // namespace
 
-class ContextIsNotJoinedTest : public ChannelTestCase<tensorpipe::CpuBuffer> {
+class ContextIsNotJoinedTest : public ChannelTestCase {
   // Because it's static we must define it out-of-line (until C++-17, where we
   // can mark this inline).
   static const std::string kReady;
 
  public:
-  void run(ChannelTestHelper<tensorpipe::CpuBuffer>* helper) override {
+  void run(ChannelTestHelper* helper) override {
     auto addr = "127.0.0.1";
 
     helper_ = helper;
@@ -100,13 +100,15 @@ class ContextIsNotJoinedTest : public ChannelTestCase<tensorpipe::CpuBuffer> {
   }
 
  protected:
-  ChannelTestHelper<tensorpipe::CpuBuffer>* helper_;
+  ChannelTestHelper* helper_;
   std::shared_ptr<PeerGroup> peers_;
 };
 
 const std::string ContextIsNotJoinedTest::kReady = "ready";
 
 CHANNEL_TEST(MptChannelTestSuite, ContextIsNotJoined);
+
+INSTANTIATE_TEST_CASE_P(Mpt, ChannelTestSuite, ::testing::Values(&helper));
 
 INSTANTIATE_TEST_CASE_P(Mpt, CpuChannelTestSuite, ::testing::Values(&helper));
 

--- a/tensorpipe/test/channel/xth/xth_test.cc
+++ b/tensorpipe/test/channel/xth/xth_test.cc
@@ -7,11 +7,11 @@
  */
 
 #include <tensorpipe/channel/xth/factory.h>
-#include <tensorpipe/test/channel/channel_test.h>
+#include <tensorpipe/test/channel/channel_test_cpu.h>
 
 namespace {
 
-class XthChannelTestHelper : public ChannelTestHelper<tensorpipe::CpuBuffer> {
+class XthChannelTestHelper : public CpuChannelTestHelper {
  protected:
   std::shared_ptr<tensorpipe::channel::Context> makeContextInternal(
       std::string id) override {
@@ -24,5 +24,7 @@ class XthChannelTestHelper : public ChannelTestHelper<tensorpipe::CpuBuffer> {
 XthChannelTestHelper helper;
 
 } // namespace
+
+INSTANTIATE_TEST_CASE_P(Xth, ChannelTestSuite, ::testing::Values(&helper));
 
 INSTANTIATE_TEST_CASE_P(Xth, CpuChannelTestSuite, ::testing::Values(&helper));


### PR DESCRIPTION
Summary: The `TBuffer` template parameter that we were passing around everywhere was in the end only used when instantiating a `DataWrapper<TBuffer>`. If, instead, we made DataWrapper an abstract class and added virtual functions on the test helper to construct the right subclass, we could get rid of templates entirely across all our channel tests!

Differential Revision: D27435634

