### PR TITLE
Make channels take a separate length parameter.

### DIFF
--- a/tensorpipe/channel/basic/channel_impl.cc
+++ b/tensorpipe/channel/basic/channel_impl.cc
@@ -40,11 +40,12 @@ void ChannelImpl::initImplFromLoop() {
 void ChannelImpl::sendImplFromLoop(
     uint64_t sequenceNumber,
     Buffer buffer,
+    size_t length,
     TSendCallback callback) {
   SendOpIter opIter = sendOps_.emplaceBack(sequenceNumber);
   SendOperation& op = *opIter;
   op.ptr = buffer.unwrap<CpuBuffer>().ptr;
-  op.length = buffer.unwrap<CpuBuffer>().length;
+  op.length = length;
   op.callback = std::move(callback);
 
   sendOps_.advanceOperation(opIter);
@@ -106,11 +107,12 @@ void ChannelImpl::callSendCallback(SendOpIter opIter) {
 void ChannelImpl::recvImplFromLoop(
     uint64_t sequenceNumber,
     Buffer buffer,
+    size_t length,
     TRecvCallback callback) {
   RecvOpIter opIter = recvOps_.emplaceBack(sequenceNumber);
   RecvOperation& op = *opIter;
   op.ptr = buffer.unwrap<CpuBuffer>().ptr;
-  op.length = buffer.unwrap<CpuBuffer>().length;
+  op.length = length;
   op.callback = std::move(callback);
 
   recvOps_.advanceOperation(opIter);

--- a/tensorpipe/channel/basic/channel_impl.h
+++ b/tensorpipe/channel/basic/channel_impl.h
@@ -69,10 +69,12 @@ class ChannelImpl final
   void sendImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TSendCallback callback) override;
   void recvImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TRecvCallback callback) override;
   void handleErrorImpl() override;
 

--- a/tensorpipe/channel/channel.h
+++ b/tensorpipe/channel/channel.h
@@ -52,10 +52,10 @@ using TRecvCallback = std::function<void(const Error&)>;
 class Channel {
  public:
   // Send memory region to peer.
-  virtual void send(Buffer buffer, TSendCallback callback) = 0;
+  virtual void send(Buffer buffer, size_t length, TSendCallback callback) = 0;
 
   // Receive memory region from peer.
-  virtual void recv(Buffer buffer, TRecvCallback callback) = 0;
+  virtual void recv(Buffer buffer, size_t length, TRecvCallback callback) = 0;
 
   // Tell the channel what its identifier is.
   //

--- a/tensorpipe/channel/channel_boilerplate.h
+++ b/tensorpipe/channel/channel_boilerplate.h
@@ -38,10 +38,10 @@ class ChannelBoilerplate : public Channel {
   ChannelBoilerplate& operator=(ChannelBoilerplate&&) = delete;
 
   // Perform a send operation.
-  void send(Buffer buffer, TSendCallback callback) override;
+  void send(Buffer buffer, size_t length, TSendCallback callback) override;
 
   // Queue a recv operation.
-  void recv(Buffer buffer, TRecvCallback callback) override;
+  void recv(Buffer buffer, size_t length, TRecvCallback callback) override;
 
   // Tell the connection what its identifier is.
   void setId(std::string id) override;
@@ -85,6 +85,7 @@ ChannelBoilerplate<TCtx, TChan>::ChannelBoilerplate(
 template <typename TCtx, typename TChan>
 void ChannelBoilerplate<TCtx, TChan>::send(
     Buffer buffer,
+    size_t length,
     TSendCallback callback) {
   if (unlikely(!impl_)) {
     // FIXME In C++-17 perhaps a global static inline variable would be better?
@@ -92,12 +93,13 @@ void ChannelBoilerplate<TCtx, TChan>::send(
     callback(error);
     return;
   }
-  impl_->send(buffer, std::move(callback));
+  impl_->send(buffer, length, std::move(callback));
 }
 
 template <typename TCtx, typename TChan>
 void ChannelBoilerplate<TCtx, TChan>::recv(
     Buffer buffer,
+    size_t length,
     TRecvCallback callback) {
   if (unlikely(!impl_)) {
     // FIXME In C++-17 perhaps a global static inline variable would be better?
@@ -105,7 +107,7 @@ void ChannelBoilerplate<TCtx, TChan>::recv(
     callback(error);
     return;
   }
-  impl_->recv(buffer, std::move(callback));
+  impl_->recv(buffer, length, std::move(callback));
 }
 
 template <typename TCtx, typename TChan>

--- a/tensorpipe/channel/cma/channel_impl.cc
+++ b/tensorpipe/channel/cma/channel_impl.cc
@@ -55,6 +55,7 @@ void ChannelImpl::initImplFromLoop() {
 void ChannelImpl::sendImplFromLoop(
     uint64_t sequenceNumber,
     Buffer buffer,
+    size_t /* length */,
     TSendCallback callback) {
   SendOpIter opIter = sendOps_.emplaceBack(sequenceNumber);
   SendOperation& op = *opIter;
@@ -147,11 +148,12 @@ void ChannelImpl::callSendCallback(SendOpIter opIter) {
 void ChannelImpl::recvImplFromLoop(
     uint64_t sequenceNumber,
     Buffer buffer,
+    size_t length,
     TRecvCallback callback) {
   RecvOpIter opIter = recvOps_.emplaceBack(sequenceNumber);
   RecvOperation& op = *opIter;
   op.ptr = buffer.unwrap<CpuBuffer>().ptr;
-  op.length = buffer.unwrap<CpuBuffer>().length;
+  op.length = length;
   op.callback = std::move(callback);
 
   recvOps_.advanceOperation(opIter);

--- a/tensorpipe/channel/cma/channel_impl.h
+++ b/tensorpipe/channel/cma/channel_impl.h
@@ -73,10 +73,12 @@ class ChannelImpl final
   void sendImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TSendCallback callback) override;
   void recvImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TRecvCallback callback) override;
   void handleErrorImpl() override;
 

--- a/tensorpipe/channel/cuda_basic/channel_impl.h
+++ b/tensorpipe/channel/cuda_basic/channel_impl.h
@@ -110,10 +110,12 @@ class ChannelImpl final
   void sendImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TSendCallback callback) override;
   void recvImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TRecvCallback callback) override;
   void handleErrorImpl() override;
   void setIdImpl() override;

--- a/tensorpipe/channel/cuda_gdr/channel_impl.h
+++ b/tensorpipe/channel/cuda_gdr/channel_impl.h
@@ -103,10 +103,12 @@ struct SendOperation {
   // Provide a constructor so we can create the CudaEvent in-place.
   SendOperation(
       CudaBuffer buffer,
+      size_t length,
       TSendCallback callback,
       size_t localGpuIdx,
       size_t localNicIdx)
       : buffer(buffer),
+        length(length),
         callback(std::move(callback)),
         event(localGpuIdx),
         localNicIdx(localNicIdx) {}
@@ -114,6 +116,7 @@ struct SendOperation {
   size_t sequenceNumber;
   State state{UNINITIALIZED};
   CudaBuffer buffer;
+  size_t length;
   TSendCallback callback;
   CudaEvent event;
   size_t localNicIdx;
@@ -136,10 +139,12 @@ struct RecvOperation {
   // Provide a constructor so we can create the CudaEvent in-place.
   RecvOperation(
       CudaBuffer buffer,
+      size_t length,
       TSendCallback callback,
       size_t deviceIdx,
       size_t localNicIdx)
       : buffer(buffer),
+        length(length),
         callback(std::move(callback)),
         event(deviceIdx),
         localNicIdx(localNicIdx) {}
@@ -147,6 +152,7 @@ struct RecvOperation {
   size_t sequenceNumber;
   State state{UNINITIALIZED};
   CudaBuffer buffer;
+  size_t length;
   TSendCallback callback;
   CudaEvent event;
   size_t localNicIdx;
@@ -197,10 +203,12 @@ class ChannelImpl final
   void sendImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TSendCallback callback) override;
   void recvImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TRecvCallback callback) override;
   void handleErrorImpl() override;
 

--- a/tensorpipe/channel/cuda_ipc/channel_impl.h
+++ b/tensorpipe/channel/cuda_ipc/channel_impl.h
@@ -123,10 +123,12 @@ class ChannelImpl final
   void sendImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TSendCallback callback) override;
   void recvImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TRecvCallback callback) override;
   void handleErrorImpl() override;
 

--- a/tensorpipe/channel/cuda_xth/channel_impl.cc
+++ b/tensorpipe/channel/cuda_xth/channel_impl.cc
@@ -53,9 +53,10 @@ SendOperation::SendOperation(
 RecvOperation::RecvOperation(
     int deviceIdx,
     CudaBuffer buffer,
+    size_t length,
     TRecvCallback callback)
     : ptr(buffer.ptr),
-      length(buffer.length),
+      length(length),
       deviceIdx(deviceIdx),
       stream(buffer.stream),
       callback(std::move(callback)) {}
@@ -93,6 +94,7 @@ void ChannelImpl::initImplFromLoop() {
 void ChannelImpl::sendImplFromLoop(
     uint64_t sequenceNumber,
     Buffer buffer,
+    size_t /* length */,
     TSendCallback callback) {
   int deviceIdx = cudaDeviceForPointer(
       context_->getCudaLib(), buffer.unwrap<CudaBuffer>().ptr);
@@ -192,6 +194,7 @@ void ChannelImpl::callSendCallback(SendOpIter opIter) {
 void ChannelImpl::recvImplFromLoop(
     uint64_t sequenceNumber,
     Buffer buffer,
+    size_t length,
     TRecvCallback callback) {
   int deviceIdx = cudaDeviceForPointer(
       context_->getCudaLib(), buffer.unwrap<CudaBuffer>().ptr);
@@ -199,6 +202,7 @@ void ChannelImpl::recvImplFromLoop(
       sequenceNumber,
       deviceIdx,
       buffer.unwrap<CudaBuffer>(),
+      length,
       std::move(callback));
 
   recvOps_.advanceOperation(opIter);

--- a/tensorpipe/channel/cuda_xth/channel_impl.h
+++ b/tensorpipe/channel/cuda_xth/channel_impl.h
@@ -72,7 +72,11 @@ struct RecvOperation {
   int srcDeviceIdx;
   cudaStream_t srcStream;
 
-  RecvOperation(int deviceIdx, CudaBuffer buffer, TRecvCallback callback);
+  RecvOperation(
+      int deviceIdx,
+      CudaBuffer buffer,
+      size_t length,
+      TRecvCallback callback);
 
   void process();
 };
@@ -93,10 +97,12 @@ class ChannelImpl final
   void sendImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TSendCallback callback) override;
   void recvImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TRecvCallback callback) override;
   void handleErrorImpl() override;
 

--- a/tensorpipe/channel/mpt/channel_impl.cc
+++ b/tensorpipe/channel/mpt/channel_impl.cc
@@ -157,11 +157,12 @@ void ChannelImpl::onServerAcceptOfLane(
 void ChannelImpl::sendImplFromLoop(
     uint64_t sequenceNumber,
     Buffer buffer,
+    size_t length,
     TSendCallback callback) {
   SendOpIter opIter = sendOps_.emplaceBack(sequenceNumber);
   SendOperation& op = *opIter;
   op.ptr = buffer.unwrap<CpuBuffer>().ptr;
-  op.length = buffer.unwrap<CpuBuffer>().length;
+  op.length = length;
   op.callback = std::move(callback);
 
   sendOps_.advanceOperation(opIter);
@@ -237,11 +238,12 @@ void ChannelImpl::callSendCallback(SendOpIter opIter) {
 void ChannelImpl::recvImplFromLoop(
     uint64_t sequenceNumber,
     Buffer buffer,
+    size_t length,
     TRecvCallback callback) {
   RecvOpIter opIter = recvOps_.emplaceBack(sequenceNumber);
   RecvOperation& op = *opIter;
   op.ptr = buffer.unwrap<CpuBuffer>().ptr;
-  op.length = buffer.unwrap<CpuBuffer>().length;
+  op.length = length;
   op.callback = std::move(callback);
 
   recvOps_.advanceOperation(opIter);

--- a/tensorpipe/channel/mpt/channel_impl.h
+++ b/tensorpipe/channel/mpt/channel_impl.h
@@ -76,10 +76,12 @@ class ChannelImpl final
   void sendImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TSendCallback callback) override;
   void recvImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TRecvCallback callback) override;
   void handleErrorImpl() override;
 

--- a/tensorpipe/channel/xth/channel_impl.cc
+++ b/tensorpipe/channel/xth/channel_impl.cc
@@ -54,6 +54,7 @@ void ChannelImpl::initImplFromLoop() {
 void ChannelImpl::sendImplFromLoop(
     uint64_t sequenceNumber,
     Buffer buffer,
+    size_t /* length */,
     TSendCallback callback) {
   SendOpIter opIter = sendOps_.emplaceBack(sequenceNumber);
   SendOperation& op = *opIter;
@@ -144,11 +145,12 @@ void ChannelImpl::callSendCallback(SendOpIter opIter) {
 void ChannelImpl::recvImplFromLoop(
     uint64_t sequenceNumber,
     Buffer buffer,
+    size_t length,
     TRecvCallback callback) {
   RecvOpIter opIter = recvOps_.emplaceBack(sequenceNumber);
   RecvOperation& op = *opIter;
   op.ptr = buffer.unwrap<CpuBuffer>().ptr;
-  op.length = buffer.unwrap<CpuBuffer>().length;
+  op.length = length;
   op.callback = std::move(callback);
 
   recvOps_.advanceOperation(opIter);

--- a/tensorpipe/channel/xth/channel_impl.h
+++ b/tensorpipe/channel/xth/channel_impl.h
@@ -72,10 +72,12 @@ class ChannelImpl final
   void sendImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TSendCallback callback) override;
   void recvImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TRecvCallback callback) override;
   void handleErrorImpl() override;
 

--- a/tensorpipe/core/pipe_impl.cc
+++ b/tensorpipe/core/pipe_impl.cc
@@ -511,7 +511,9 @@ void PipeImpl::readPayloadsAndReceiveTensorsOfMessage(ReadOpIter opIter) {
                << op.sequenceNumber << "." << tensorIdx;
 
     channel->recv(
-        tensor.buffer, callbackWrapper_([opIter, tensorIdx](PipeImpl& impl) {
+        tensor.buffer,
+        tensor.buffer.length(),
+        callbackWrapper_([opIter, tensorIdx](PipeImpl& impl) {
           TP_VLOG(3) << "Pipe " << impl.id_ << " done receiving tensor #"
                      << opIter->sequenceNumber << "." << tensorIdx;
           impl.onRecvOfTensor(opIter);
@@ -825,7 +827,9 @@ void PipeImpl::sendTensorsOfMessage(WriteOpIter opIter) {
                  << op.sequenceNumber << "." << tensorIdx;
 
       channel.send(
-          tensor.buffer, callbackWrapper_([opIter, tensorIdx](PipeImpl& impl) {
+          tensor.buffer,
+          tensor.buffer.length(),
+          callbackWrapper_([opIter, tensorIdx](PipeImpl& impl) {
             TP_VLOG(3) << "Pipe " << impl.id_ << " done sending tensor #"
                        << opIter->sequenceNumber << "." << tensorIdx;
             impl.onSendOfTensor(opIter);

--- a/tensorpipe/test/channel/channel_test.cc
+++ b/tensorpipe/test/channel/channel_test.cc
@@ -53,8 +53,7 @@ class ClientToServerTest : public ClientServerChannelTestCase {
     std::unique_ptr<DataWrapper> wrappedData = helper_->makeDataWrapper(data);
 
     // Perform send and wait for completion.
-    std::future<Error> sendFuture =
-        sendWithFuture(channel, wrappedData->buffer());
+    std::future<Error> sendFuture = sendWithFuture(channel, *wrappedData);
     Error sendError = sendFuture.get();
     EXPECT_FALSE(sendError) << sendError.what();
 
@@ -67,8 +66,7 @@ class ClientToServerTest : public ClientServerChannelTestCase {
         helper_->makeDataWrapper(kDataSize);
 
     // Perform recv and wait for completion.
-    std::future<Error> recvFuture =
-        recvWithFuture(channel, wrappedData->buffer());
+    std::future<Error> recvFuture = recvWithFuture(channel, *wrappedData);
     Error recvError = recvFuture.get();
     EXPECT_FALSE(recvError) << recvError.what();
 
@@ -94,8 +92,7 @@ class ServerToClientTest : public ClientServerChannelTestCase {
         helper_->makeDataWrapper(kDataSize);
 
     // Perform recv and wait for completion.
-    std::future<Error> recvFuture =
-        recvWithFuture(channel, wrappedData->buffer());
+    std::future<Error> recvFuture = recvWithFuture(channel, *wrappedData);
     Error recvError = recvFuture.get();
     EXPECT_FALSE(recvError) << recvError.what();
 
@@ -116,8 +113,7 @@ class ServerToClientTest : public ClientServerChannelTestCase {
     std::unique_ptr<DataWrapper> wrappedData = helper_->makeDataWrapper(data);
 
     // Perform send and wait for completion.
-    std::future<Error> sendFuture =
-        sendWithFuture(channel, wrappedData->buffer());
+    std::future<Error> sendFuture = sendWithFuture(channel, *wrappedData);
     Error sendError = sendFuture.get();
     EXPECT_FALSE(sendError) << sendError.what();
 
@@ -146,8 +142,7 @@ class SendMultipleTensorsTest : public ClientServerChannelTestCase {
 
     // Perform send and wait for completion.
     for (int i = 0; i < kNumTensors; i++) {
-      std::future<Error> sendFuture =
-          sendWithFuture(channel, wrappedData->buffer());
+      std::future<Error> sendFuture = sendWithFuture(channel, *wrappedData);
       sendFutures.push_back(std::move(sendFuture));
     }
     for (auto& sendFuture : sendFutures) {
@@ -170,8 +165,7 @@ class SendMultipleTensorsTest : public ClientServerChannelTestCase {
 
     // Perform recv and wait for completion.
     for (auto& wrappedData : wrappedDataVec) {
-      std::future<Error> recvFuture =
-          recvWithFuture(channel, wrappedData->buffer());
+      std::future<Error> recvFuture = recvWithFuture(channel, *wrappedData);
       recvFutures.push_back(std::move(recvFuture));
     }
     for (auto& recvFuture : recvFutures) {
@@ -209,11 +203,9 @@ class SendTensorsBothWaysTest : public ClientServerChannelTestCase {
         helper_->makeDataWrapper(kDataSize);
 
     // Perform send.
-    std::future<Error> sendFuture =
-        sendWithFuture(channel, wrappedSendData->buffer());
+    std::future<Error> sendFuture = sendWithFuture(channel, *wrappedSendData);
     // Perform recv.
-    std::future<Error> recvFuture =
-        recvWithFuture(channel, wrappedRecvData->buffer());
+    std::future<Error> recvFuture = recvWithFuture(channel, *wrappedRecvData);
 
     // Wait for completion of both.
     Error sendError = sendFuture.get();
@@ -243,11 +235,9 @@ class SendTensorsBothWaysTest : public ClientServerChannelTestCase {
         helper_->makeDataWrapper(kDataSize);
 
     // Perform send.
-    std::future<Error> sendFuture =
-        sendWithFuture(channel, wrappedSendData->buffer());
+    std::future<Error> sendFuture = sendWithFuture(channel, *wrappedSendData);
     // Perform recv.
-    std::future<Error> recvFuture =
-        recvWithFuture(channel, wrappedRecvData->buffer());
+    std::future<Error> recvFuture = recvWithFuture(channel, *wrappedRecvData);
 
     // Wait for completion of both.
     Error sendError = sendFuture.get();

--- a/tensorpipe/test/channel/channel_test_cpu.h
+++ b/tensorpipe/test/channel/channel_test_cpu.h
@@ -26,6 +26,10 @@ class CpuDataWrapper : public DataWrapper {
         const_cast<uint8_t*>(vector_.data()), vector_.size()};
   }
 
+  size_t bufferLength() const override {
+    return vector_.size();
+  }
+
   std::vector<uint8_t> unwrap() override {
     return vector_;
   }

--- a/tensorpipe/test/channel/channel_test_cuda.cc
+++ b/tensorpipe/test/channel/channel_test_cuda.cc
@@ -40,9 +40,10 @@ class ReceiverWaitsForStartEventTest : public ClientServerChannelTestCase {
     channel->send(
         CudaBuffer{
             .ptr = ptr,
-            .length = kSize,
+            .length = 0,
             .stream = sendStream,
         },
+        kSize,
         [sendPromise{std::move(sendPromise)}](const tensorpipe::Error& error) {
           sendPromise->set_value(error);
         });
@@ -70,9 +71,10 @@ class ReceiverWaitsForStartEventTest : public ClientServerChannelTestCase {
     channel->recv(
         CudaBuffer{
             .ptr = ptr,
-            .length = kSize,
+            .length = 0,
             .stream = recvStream,
         },
+        kSize,
         [recvPromise{std::move(recvPromise)}](const tensorpipe::Error& error) {
           recvPromise->set_value(error);
         });
@@ -109,7 +111,7 @@ class SendOffsetAllocationTest : public ClientServerChannelTestCase {
 
     // Perform send and wait for completion.
     std::future<Error> sendFuture = sendWithFuture(
-        channel, CudaBuffer{static_cast<uint8_t*>(ptr) + kOffset, kDataSize});
+        channel, CudaBuffer{static_cast<uint8_t*>(ptr) + kOffset}, kDataSize);
     Error sendError = sendFuture.get();
     EXPECT_FALSE(sendError) << sendError.what();
 
@@ -122,8 +124,7 @@ class SendOffsetAllocationTest : public ClientServerChannelTestCase {
         helper_->makeDataWrapper(kDataSize);
 
     // Perform recv and wait for completion.
-    std::future<Error> recvFuture =
-        recvWithFuture(channel, wrappedData->buffer());
+    std::future<Error> recvFuture = recvWithFuture(channel, *wrappedData);
     Error recvError = recvFuture.get();
     EXPECT_FALSE(recvError) << recvError.what();
 

--- a/tensorpipe/test/channel/channel_test_cuda.h
+++ b/tensorpipe/test/channel/channel_test_cuda.h
@@ -44,6 +44,10 @@ class CudaDataWrapper : public DataWrapper {
     return tensorpipe::CudaBuffer{cudaPtr_, length_, stream_};
   }
 
+  size_t bufferLength() const override {
+    return length_;
+  }
+
   std::vector<uint8_t> unwrap() override {
     std::vector<uint8_t> v(length_);
     if (length_ > 0) {

--- a/tensorpipe/test/channel/channel_test_cuda_multi_gpu.cc
+++ b/tensorpipe/test/channel/channel_test_cuda_multi_gpu.cc
@@ -50,9 +50,10 @@ class SendAcrossDevicesTest : public ClientServerChannelTestCase {
     channel->send(
         CudaBuffer{
             .ptr = ptr,
-            .length = kSize,
+            .length = 0,
             .stream = sendStream,
         },
+        kSize,
         [sendPromise{std::move(sendPromise)}](const tensorpipe::Error& error) {
           sendPromise->set_value(error);
         });
@@ -96,9 +97,10 @@ class SendAcrossDevicesTest : public ClientServerChannelTestCase {
     channel->recv(
         CudaBuffer{
             .ptr = ptr,
-            .length = kSize,
+            .length = 0,
             .stream = recvStream,
         },
+        kSize,
         [recvPromise{std::move(recvPromise)}](const tensorpipe::Error& error) {
           recvPromise->set_value(error);
         });
@@ -165,9 +167,10 @@ class SendReverseAcrossDevicesTest : public ClientServerChannelTestCase {
     channel->send(
         CudaBuffer{
             .ptr = ptr,
-            .length = kSize,
+            .length = 0,
             .stream = sendStream,
         },
+        kSize,
         [sendPromise{std::move(sendPromise)}](const tensorpipe::Error& error) {
           sendPromise->set_value(error);
         });
@@ -211,9 +214,10 @@ class SendReverseAcrossDevicesTest : public ClientServerChannelTestCase {
     channel->recv(
         CudaBuffer{
             .ptr = ptr,
-            .length = kSize,
+            .length = 0,
             .stream = recvStream,
         },
+        kSize,
         [recvPromise{std::move(recvPromise)}](const tensorpipe::Error& error) {
           recvPromise->set_value(error);
         });
@@ -280,9 +284,10 @@ class SendAcrossNonDefaultDevicesTest : public ClientServerChannelTestCase {
     channel->send(
         CudaBuffer{
             .ptr = ptr,
-            .length = kSize,
+            .length = 0,
             .stream = sendStream,
         },
+        kSize,
         [sendPromise{std::move(sendPromise)}](const tensorpipe::Error& error) {
           sendPromise->set_value(error);
         });
@@ -322,9 +327,10 @@ class SendAcrossNonDefaultDevicesTest : public ClientServerChannelTestCase {
     channel->recv(
         CudaBuffer{
             .ptr = ptr,
-            .length = kSize,
+            .length = 0,
             .stream = recvStream,
         },
+        kSize,
         [recvPromise{std::move(recvPromise)}](const tensorpipe::Error& error) {
           recvPromise->set_value(error);
         });


### PR DESCRIPTION
Summary:
Change the Channel API back to the way it was initially:
`send()`/`recv()` now take a `Buffer` and a `length`.

This change will be required for making the Pipe device agnostic, and enable
sender-unspecified XDTT. The `Buffer` class still carries the length at this
point, but it is disregarded by the channel.

Reviewed By: lw

Differential Revision: D27282341

