### PR TITLE
Use designated initializers.

### DIFF
--- a/tensorpipe/benchmark/benchmark_pipe.cc
+++ b/tensorpipe/benchmark/benchmark_pipe.cc
@@ -459,13 +459,16 @@ static void clientPingPongNonBlock(
     for (size_t tensorIdx = 0; tensorIdx < data.numTensors; tensorIdx++) {
       Message::Tensor tensor;
       if (data.tensorType == TensorType::kCpu) {
-        tensor.buffer =
-            CpuBuffer{data.expectedCpuTensor[tensorIdx].get(), data.tensorSize};
+        tensor.buffer = CpuBuffer{
+            .ptr = data.expectedCpuTensor[tensorIdx].get(),
+            .length = data.tensorSize,
+        };
       } else if (data.tensorType == TensorType::kCuda) {
         tensor.buffer = CudaBuffer{
-            data.expectedCudaTensor[tensorIdx].get(),
-            data.tensorSize,
-            data.cudaStream.get()};
+            .ptr = data.expectedCudaTensor[tensorIdx].get(),
+            .length = data.tensorSize,
+            .stream = data.cudaStream.get(),
+        };
       } else {
         TP_THROW_ASSERT() << "Unknown tensor type";
       }

--- a/tensorpipe/channel/basic/channel_impl.cc
+++ b/tensorpipe/channel/basic/channel_impl.cc
@@ -40,11 +40,12 @@ void ChannelImpl::initImplFromLoop() {
 void ChannelImpl::sendImplFromLoop(
     uint64_t sequenceNumber,
     Buffer buffer,
+    size_t length,
     TSendCallback callback) {
   SendOpIter opIter = sendOps_.emplaceBack(sequenceNumber);
   SendOperation& op = *opIter;
   op.ptr = buffer.unwrap<CpuBuffer>().ptr;
-  op.length = buffer.unwrap<CpuBuffer>().length;
+  op.length = length;
   op.callback = std::move(callback);
 
   sendOps_.advanceOperation(opIter);
@@ -106,11 +107,12 @@ void ChannelImpl::callSendCallback(SendOpIter opIter) {
 void ChannelImpl::recvImplFromLoop(
     uint64_t sequenceNumber,
     Buffer buffer,
+    size_t length,
     TRecvCallback callback) {
   RecvOpIter opIter = recvOps_.emplaceBack(sequenceNumber);
   RecvOperation& op = *opIter;
   op.ptr = buffer.unwrap<CpuBuffer>().ptr;
-  op.length = buffer.unwrap<CpuBuffer>().length;
+  op.length = length;
   op.callback = std::move(callback);
 
   recvOps_.advanceOperation(opIter);

--- a/tensorpipe/channel/basic/channel_impl.h
+++ b/tensorpipe/channel/basic/channel_impl.h
@@ -69,10 +69,12 @@ class ChannelImpl final
   void sendImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TSendCallback callback) override;
   void recvImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TRecvCallback callback) override;
   void handleErrorImpl() override;
 

--- a/tensorpipe/channel/channel.h
+++ b/tensorpipe/channel/channel.h
@@ -52,10 +52,10 @@ using TRecvCallback = std::function<void(const Error&)>;
 class Channel {
  public:
   // Send memory region to peer.
-  virtual void send(Buffer buffer, TSendCallback callback) = 0;
+  virtual void send(Buffer buffer, size_t length, TSendCallback callback) = 0;
 
   // Receive memory region from peer.
-  virtual void recv(Buffer buffer, TRecvCallback callback) = 0;
+  virtual void recv(Buffer buffer, size_t length, TRecvCallback callback) = 0;
 
   // Tell the channel what its identifier is.
   //

--- a/tensorpipe/channel/channel_boilerplate.h
+++ b/tensorpipe/channel/channel_boilerplate.h
@@ -38,10 +38,10 @@ class ChannelBoilerplate : public Channel {
   ChannelBoilerplate& operator=(ChannelBoilerplate&&) = delete;
 
   // Perform a send operation.
-  void send(Buffer buffer, TSendCallback callback) override;
+  void send(Buffer buffer, size_t length, TSendCallback callback) override;
 
   // Queue a recv operation.
-  void recv(Buffer buffer, TRecvCallback callback) override;
+  void recv(Buffer buffer, size_t length, TRecvCallback callback) override;
 
   // Tell the connection what its identifier is.
   void setId(std::string id) override;
@@ -85,6 +85,7 @@ ChannelBoilerplate<TCtx, TChan>::ChannelBoilerplate(
 template <typename TCtx, typename TChan>
 void ChannelBoilerplate<TCtx, TChan>::send(
     Buffer buffer,
+    size_t length,
     TSendCallback callback) {
   if (unlikely(!impl_)) {
     // FIXME In C++-17 perhaps a global static inline variable would be better?
@@ -92,12 +93,13 @@ void ChannelBoilerplate<TCtx, TChan>::send(
     callback(error);
     return;
   }
-  impl_->send(buffer, std::move(callback));
+  impl_->send(buffer, length, std::move(callback));
 }
 
 template <typename TCtx, typename TChan>
 void ChannelBoilerplate<TCtx, TChan>::recv(
     Buffer buffer,
+    size_t length,
     TRecvCallback callback) {
   if (unlikely(!impl_)) {
     // FIXME In C++-17 perhaps a global static inline variable would be better?
@@ -105,7 +107,7 @@ void ChannelBoilerplate<TCtx, TChan>::recv(
     callback(error);
     return;
   }
-  impl_->recv(buffer, std::move(callback));
+  impl_->recv(buffer, length, std::move(callback));
 }
 
 template <typename TCtx, typename TChan>

--- a/tensorpipe/channel/cma/channel_impl.cc
+++ b/tensorpipe/channel/cma/channel_impl.cc
@@ -55,6 +55,7 @@ void ChannelImpl::initImplFromLoop() {
 void ChannelImpl::sendImplFromLoop(
     uint64_t sequenceNumber,
     Buffer buffer,
+    size_t /* length */,
     TSendCallback callback) {
   SendOpIter opIter = sendOps_.emplaceBack(sequenceNumber);
   SendOperation& op = *opIter;
@@ -147,11 +148,12 @@ void ChannelImpl::callSendCallback(SendOpIter opIter) {
 void ChannelImpl::recvImplFromLoop(
     uint64_t sequenceNumber,
     Buffer buffer,
+    size_t length,
     TRecvCallback callback) {
   RecvOpIter opIter = recvOps_.emplaceBack(sequenceNumber);
   RecvOperation& op = *opIter;
   op.ptr = buffer.unwrap<CpuBuffer>().ptr;
-  op.length = buffer.unwrap<CpuBuffer>().length;
+  op.length = length;
   op.callback = std::move(callback);
 
   recvOps_.advanceOperation(opIter);

--- a/tensorpipe/channel/cma/channel_impl.h
+++ b/tensorpipe/channel/cma/channel_impl.h
@@ -73,10 +73,12 @@ class ChannelImpl final
   void sendImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TSendCallback callback) override;
   void recvImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TRecvCallback callback) override;
   void handleErrorImpl() override;
 

--- a/tensorpipe/channel/cuda_basic/channel_impl.cc
+++ b/tensorpipe/channel/cuda_basic/channel_impl.cc
@@ -270,7 +270,7 @@ void ChannelImpl::sendCpuBuffer(ChunkSendOpIter opIter) {
              << op.bufferSequenceNumber << " through CPU channel";
 
   cpuChannel_->send(
-      CpuBuffer{op.tmpBuffer.get()},
+      CpuBuffer{.ptr = op.tmpBuffer.get()},
       op.length,
       callbackWrapper_([opIter](ChannelImpl& impl) {
         TP_VLOG(6) << "Channel " << impl.id_ << " is done sending chunk #"
@@ -492,7 +492,7 @@ void ChannelImpl::receiveCpuBuffer(ChunkRecvOpIter opIter) {
              << " of " << op.numChunks << " for buffer #"
              << op.bufferSequenceNumber << " through CPU channel";
   cpuChannel_->recv(
-      CpuBuffer{op.tmpBuffer.get()},
+      CpuBuffer{.ptr = op.tmpBuffer.get()},
       op.length,
       callbackWrapper_([opIter](ChannelImpl& impl) {
         TP_VLOG(6) << "Channel " << impl.id_ << " is done sending chunk #"

--- a/tensorpipe/channel/cuda_basic/channel_impl.h
+++ b/tensorpipe/channel/cuda_basic/channel_impl.h
@@ -110,10 +110,12 @@ class ChannelImpl final
   void sendImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TSendCallback callback) override;
   void recvImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TRecvCallback callback) override;
   void handleErrorImpl() override;
   void setIdImpl() override;

--- a/tensorpipe/channel/cuda_gdr/channel_impl.h
+++ b/tensorpipe/channel/cuda_gdr/channel_impl.h
@@ -103,10 +103,12 @@ struct SendOperation {
   // Provide a constructor so we can create the CudaEvent in-place.
   SendOperation(
       CudaBuffer buffer,
+      size_t length,
       TSendCallback callback,
       size_t localGpuIdx,
       size_t localNicIdx)
       : buffer(buffer),
+        length(length),
         callback(std::move(callback)),
         event(localGpuIdx),
         localNicIdx(localNicIdx) {}
@@ -114,6 +116,7 @@ struct SendOperation {
   size_t sequenceNumber;
   State state{UNINITIALIZED};
   CudaBuffer buffer;
+  size_t length;
   TSendCallback callback;
   CudaEvent event;
   size_t localNicIdx;
@@ -136,10 +139,12 @@ struct RecvOperation {
   // Provide a constructor so we can create the CudaEvent in-place.
   RecvOperation(
       CudaBuffer buffer,
+      size_t length,
       TSendCallback callback,
       size_t deviceIdx,
       size_t localNicIdx)
       : buffer(buffer),
+        length(length),
         callback(std::move(callback)),
         event(deviceIdx),
         localNicIdx(localNicIdx) {}
@@ -147,6 +152,7 @@ struct RecvOperation {
   size_t sequenceNumber;
   State state{UNINITIALIZED};
   CudaBuffer buffer;
+  size_t length;
   TSendCallback callback;
   CudaEvent event;
   size_t localNicIdx;
@@ -197,10 +203,12 @@ class ChannelImpl final
   void sendImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TSendCallback callback) override;
   void recvImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TRecvCallback callback) override;
   void handleErrorImpl() override;
 

--- a/tensorpipe/channel/cuda_ipc/channel_impl.h
+++ b/tensorpipe/channel/cuda_ipc/channel_impl.h
@@ -123,10 +123,12 @@ class ChannelImpl final
   void sendImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TSendCallback callback) override;
   void recvImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TRecvCallback callback) override;
   void handleErrorImpl() override;
 

--- a/tensorpipe/channel/cuda_xth/channel_impl.cc
+++ b/tensorpipe/channel/cuda_xth/channel_impl.cc
@@ -53,9 +53,10 @@ SendOperation::SendOperation(
 RecvOperation::RecvOperation(
     int deviceIdx,
     CudaBuffer buffer,
+    size_t length,
     TRecvCallback callback)
     : ptr(buffer.ptr),
-      length(buffer.length),
+      length(length),
       deviceIdx(deviceIdx),
       stream(buffer.stream),
       callback(std::move(callback)) {}
@@ -93,6 +94,7 @@ void ChannelImpl::initImplFromLoop() {
 void ChannelImpl::sendImplFromLoop(
     uint64_t sequenceNumber,
     Buffer buffer,
+    size_t /* length */,
     TSendCallback callback) {
   int deviceIdx = cudaDeviceForPointer(
       context_->getCudaLib(), buffer.unwrap<CudaBuffer>().ptr);
@@ -192,6 +194,7 @@ void ChannelImpl::callSendCallback(SendOpIter opIter) {
 void ChannelImpl::recvImplFromLoop(
     uint64_t sequenceNumber,
     Buffer buffer,
+    size_t length,
     TRecvCallback callback) {
   int deviceIdx = cudaDeviceForPointer(
       context_->getCudaLib(), buffer.unwrap<CudaBuffer>().ptr);
@@ -199,6 +202,7 @@ void ChannelImpl::recvImplFromLoop(
       sequenceNumber,
       deviceIdx,
       buffer.unwrap<CudaBuffer>(),
+      length,
       std::move(callback));
 
   recvOps_.advanceOperation(opIter);

--- a/tensorpipe/channel/cuda_xth/channel_impl.h
+++ b/tensorpipe/channel/cuda_xth/channel_impl.h
@@ -72,7 +72,11 @@ struct RecvOperation {
   int srcDeviceIdx;
   cudaStream_t srcStream;
 
-  RecvOperation(int deviceIdx, CudaBuffer buffer, TRecvCallback callback);
+  RecvOperation(
+      int deviceIdx,
+      CudaBuffer buffer,
+      size_t length,
+      TRecvCallback callback);
 
   void process();
 };
@@ -93,10 +97,12 @@ class ChannelImpl final
   void sendImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TSendCallback callback) override;
   void recvImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TRecvCallback callback) override;
   void handleErrorImpl() override;
 

--- a/tensorpipe/channel/mpt/channel_impl.cc
+++ b/tensorpipe/channel/mpt/channel_impl.cc
@@ -157,11 +157,12 @@ void ChannelImpl::onServerAcceptOfLane(
 void ChannelImpl::sendImplFromLoop(
     uint64_t sequenceNumber,
     Buffer buffer,
+    size_t length,
     TSendCallback callback) {
   SendOpIter opIter = sendOps_.emplaceBack(sequenceNumber);
   SendOperation& op = *opIter;
   op.ptr = buffer.unwrap<CpuBuffer>().ptr;
-  op.length = buffer.unwrap<CpuBuffer>().length;
+  op.length = length;
   op.callback = std::move(callback);
 
   sendOps_.advanceOperation(opIter);
@@ -237,11 +238,12 @@ void ChannelImpl::callSendCallback(SendOpIter opIter) {
 void ChannelImpl::recvImplFromLoop(
     uint64_t sequenceNumber,
     Buffer buffer,
+    size_t length,
     TRecvCallback callback) {
   RecvOpIter opIter = recvOps_.emplaceBack(sequenceNumber);
   RecvOperation& op = *opIter;
   op.ptr = buffer.unwrap<CpuBuffer>().ptr;
-  op.length = buffer.unwrap<CpuBuffer>().length;
+  op.length = length;
   op.callback = std::move(callback);
 
   recvOps_.advanceOperation(opIter);

--- a/tensorpipe/channel/mpt/channel_impl.h
+++ b/tensorpipe/channel/mpt/channel_impl.h
@@ -76,10 +76,12 @@ class ChannelImpl final
   void sendImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TSendCallback callback) override;
   void recvImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TRecvCallback callback) override;
   void handleErrorImpl() override;
 

--- a/tensorpipe/channel/xth/channel_impl.cc
+++ b/tensorpipe/channel/xth/channel_impl.cc
@@ -54,6 +54,7 @@ void ChannelImpl::initImplFromLoop() {
 void ChannelImpl::sendImplFromLoop(
     uint64_t sequenceNumber,
     Buffer buffer,
+    size_t /* length */,
     TSendCallback callback) {
   SendOpIter opIter = sendOps_.emplaceBack(sequenceNumber);
   SendOperation& op = *opIter;
@@ -144,11 +145,12 @@ void ChannelImpl::callSendCallback(SendOpIter opIter) {
 void ChannelImpl::recvImplFromLoop(
     uint64_t sequenceNumber,
     Buffer buffer,
+    size_t length,
     TRecvCallback callback) {
   RecvOpIter opIter = recvOps_.emplaceBack(sequenceNumber);
   RecvOperation& op = *opIter;
   op.ptr = buffer.unwrap<CpuBuffer>().ptr;
-  op.length = buffer.unwrap<CpuBuffer>().length;
+  op.length = length;
   op.callback = std::move(callback);
 
   recvOps_.advanceOperation(opIter);

--- a/tensorpipe/channel/xth/channel_impl.h
+++ b/tensorpipe/channel/xth/channel_impl.h
@@ -72,10 +72,12 @@ class ChannelImpl final
   void sendImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TSendCallback callback) override;
   void recvImplFromLoop(
       uint64_t sequenceNumber,
       Buffer buffer,
+      size_t length,
       TRecvCallback callback) override;
   void handleErrorImpl() override;
 

--- a/tensorpipe/core/pipe_impl.cc
+++ b/tensorpipe/core/pipe_impl.cc
@@ -511,7 +511,9 @@ void PipeImpl::readPayloadsAndReceiveTensorsOfMessage(ReadOpIter opIter) {
                << op.sequenceNumber << "." << tensorIdx;
 
     channel->recv(
-        tensor.buffer, callbackWrapper_([opIter, tensorIdx](PipeImpl& impl) {
+        tensor.buffer,
+        tensor.buffer.length(),
+        callbackWrapper_([opIter, tensorIdx](PipeImpl& impl) {
           TP_VLOG(3) << "Pipe " << impl.id_ << " done receiving tensor #"
                      << opIter->sequenceNumber << "." << tensorIdx;
           impl.onRecvOfTensor(opIter);
@@ -825,7 +827,9 @@ void PipeImpl::sendTensorsOfMessage(WriteOpIter opIter) {
                  << op.sequenceNumber << "." << tensorIdx;
 
       channel.send(
-          tensor.buffer, callbackWrapper_([opIter, tensorIdx](PipeImpl& impl) {
+          tensor.buffer,
+          tensor.buffer.length(),
+          callbackWrapper_([opIter, tensorIdx](PipeImpl& impl) {
             TP_VLOG(3) << "Pipe " << impl.id_ << " done sending tensor #"
                        << opIter->sequenceNumber << "." << tensorIdx;
             impl.onSendOfTensor(opIter);

--- a/tensorpipe/python/tensorpipe.cc
+++ b/tensorpipe/python/tensorpipe.cc
@@ -107,19 +107,26 @@ tensorpipe::Message prepareToWrite(std::shared_ptr<OutgoingMessage> pyMessage) {
   tpMessage.payloads.reserve(pyMessage->payloads.size());
   for (const auto& pyPayload : pyMessage->payloads) {
     tensorpipe::Message::Payload tpPayload{
-        pyPayload->buffer.ptr(),
-        pyPayload->buffer.length(),
-        {reinterpret_cast<char*>(pyPayload->metadata.ptr()),
-         pyPayload->metadata.length()}};
+        .data = pyPayload->buffer.ptr(),
+        .length = pyPayload->buffer.length(),
+        .metadata =
+            {reinterpret_cast<char*>(pyPayload->metadata.ptr()),
+             pyPayload->metadata.length()},
+    };
     tpMessage.payloads.push_back(std::move(tpPayload));
   }
   tpMessage.tensors.reserve(pyMessage->tensors.size());
   for (const auto& pyTensor : pyMessage->tensors) {
     tensorpipe::Message::Tensor tpTensor{
-        tensorpipe::CpuBuffer{
-            pyTensor->buffer.ptr(), pyTensor->buffer.length()},
-        {reinterpret_cast<char*>(pyTensor->metadata.ptr()),
-         pyTensor->metadata.length()}};
+        .buffer =
+            tensorpipe::CpuBuffer{
+                .ptr = pyTensor->buffer.ptr(),
+                .length = pyTensor->buffer.length(),
+            },
+        .metadata =
+            {reinterpret_cast<char*>(pyTensor->metadata.ptr()),
+             pyTensor->metadata.length()},
+    };
     tpMessage.tensors.push_back(std::move(tpTensor));
   }
   return tpMessage;
@@ -204,14 +211,19 @@ tensorpipe::Message prepareToRead(std::shared_ptr<IncomingMessage> pyMessage) {
   for (const auto& pyPayload : pyMessage->payloads) {
     TP_THROW_ASSERT_IF(!pyPayload->buffer.has_value()) << "No buffer";
     tensorpipe::Message::Payload tpPayload{
-        pyPayload->buffer.value().ptr(), pyPayload->buffer.value().length()};
+        .data = pyPayload->buffer.value().ptr(),
+        .length = pyPayload->buffer.value().length(),
+    };
     tpMessage.payloads.push_back(std::move(tpPayload));
   }
   tpMessage.tensors.reserve(pyMessage->tensors.size());
   for (const auto& pyTensor : pyMessage->tensors) {
     TP_THROW_ASSERT_IF(!pyTensor->buffer.has_value()) << "No buffer";
-    tensorpipe::Message::Tensor tpTensor{tensorpipe::CpuBuffer{
-        pyTensor->buffer.value().ptr(), pyTensor->buffer.value().length()}};
+    tensorpipe::Message::Tensor tpTensor{
+        .buffer = tensorpipe::CpuBuffer{
+            .ptr = pyTensor->buffer.value().ptr(),
+            .length = pyTensor->buffer.value().length(),
+        }};
     tpMessage.tensors.push_back(std::move(tpTensor));
   }
   return tpMessage;

--- a/tensorpipe/test/channel/channel_test.cc
+++ b/tensorpipe/test/channel/channel_test.cc
@@ -53,8 +53,7 @@ class ClientToServerTest : public ClientServerChannelTestCase {
     std::unique_ptr<DataWrapper> wrappedData = helper_->makeDataWrapper(data);
 
     // Perform send and wait for completion.
-    std::future<Error> sendFuture =
-        sendWithFuture(channel, wrappedData->buffer());
+    std::future<Error> sendFuture = sendWithFuture(channel, *wrappedData);
     Error sendError = sendFuture.get();
     EXPECT_FALSE(sendError) << sendError.what();
 
@@ -67,8 +66,7 @@ class ClientToServerTest : public ClientServerChannelTestCase {
         helper_->makeDataWrapper(kDataSize);
 
     // Perform recv and wait for completion.
-    std::future<Error> recvFuture =
-        recvWithFuture(channel, wrappedData->buffer());
+    std::future<Error> recvFuture = recvWithFuture(channel, *wrappedData);
     Error recvError = recvFuture.get();
     EXPECT_FALSE(recvError) << recvError.what();
 
@@ -94,8 +92,7 @@ class ServerToClientTest : public ClientServerChannelTestCase {
         helper_->makeDataWrapper(kDataSize);
 
     // Perform recv and wait for completion.
-    std::future<Error> recvFuture =
-        recvWithFuture(channel, wrappedData->buffer());
+    std::future<Error> recvFuture = recvWithFuture(channel, *wrappedData);
     Error recvError = recvFuture.get();
     EXPECT_FALSE(recvError) << recvError.what();
 
@@ -116,8 +113,7 @@ class ServerToClientTest : public ClientServerChannelTestCase {
     std::unique_ptr<DataWrapper> wrappedData = helper_->makeDataWrapper(data);
 
     // Perform send and wait for completion.
-    std::future<Error> sendFuture =
-        sendWithFuture(channel, wrappedData->buffer());
+    std::future<Error> sendFuture = sendWithFuture(channel, *wrappedData);
     Error sendError = sendFuture.get();
     EXPECT_FALSE(sendError) << sendError.what();
 
@@ -146,8 +142,7 @@ class SendMultipleTensorsTest : public ClientServerChannelTestCase {
 
     // Perform send and wait for completion.
     for (int i = 0; i < kNumTensors; i++) {
-      std::future<Error> sendFuture =
-          sendWithFuture(channel, wrappedData->buffer());
+      std::future<Error> sendFuture = sendWithFuture(channel, *wrappedData);
       sendFutures.push_back(std::move(sendFuture));
     }
     for (auto& sendFuture : sendFutures) {
@@ -170,8 +165,7 @@ class SendMultipleTensorsTest : public ClientServerChannelTestCase {
 
     // Perform recv and wait for completion.
     for (auto& wrappedData : wrappedDataVec) {
-      std::future<Error> recvFuture =
-          recvWithFuture(channel, wrappedData->buffer());
+      std::future<Error> recvFuture = recvWithFuture(channel, *wrappedData);
       recvFutures.push_back(std::move(recvFuture));
     }
     for (auto& recvFuture : recvFutures) {
@@ -209,11 +203,9 @@ class SendTensorsBothWaysTest : public ClientServerChannelTestCase {
         helper_->makeDataWrapper(kDataSize);
 
     // Perform send.
-    std::future<Error> sendFuture =
-        sendWithFuture(channel, wrappedSendData->buffer());
+    std::future<Error> sendFuture = sendWithFuture(channel, *wrappedSendData);
     // Perform recv.
-    std::future<Error> recvFuture =
-        recvWithFuture(channel, wrappedRecvData->buffer());
+    std::future<Error> recvFuture = recvWithFuture(channel, *wrappedRecvData);
 
     // Wait for completion of both.
     Error sendError = sendFuture.get();
@@ -243,11 +235,9 @@ class SendTensorsBothWaysTest : public ClientServerChannelTestCase {
         helper_->makeDataWrapper(kDataSize);
 
     // Perform send.
-    std::future<Error> sendFuture =
-        sendWithFuture(channel, wrappedSendData->buffer());
+    std::future<Error> sendFuture = sendWithFuture(channel, *wrappedSendData);
     // Perform recv.
-    std::future<Error> recvFuture =
-        recvWithFuture(channel, wrappedRecvData->buffer());
+    std::future<Error> recvFuture = recvWithFuture(channel, *wrappedRecvData);
 
     // Wait for completion of both.
     Error sendError = sendFuture.get();

--- a/tensorpipe/test/channel/channel_test_cpu.cc
+++ b/tensorpipe/test/channel/channel_test_cpu.cc
@@ -20,7 +20,7 @@ class NullPointerTest : public ClientServerChannelTestCase {
   void server(std::shared_ptr<Channel> channel) override {
     // Perform send and wait for completion.
     std::future<Error> sendFuture =
-        sendWithFuture(channel, CpuBuffer{nullptr}, 0);
+        sendWithFuture(channel, CpuBuffer{.ptr = nullptr}, 0);
     Error sendError = sendFuture.get();
     EXPECT_FALSE(sendError) << sendError.what();
 
@@ -31,7 +31,7 @@ class NullPointerTest : public ClientServerChannelTestCase {
   void client(std::shared_ptr<Channel> channel) override {
     // Perform recv and wait for completion.
     std::future<Error> recvFuture =
-        recvWithFuture(channel, CpuBuffer{nullptr}, 0);
+        recvWithFuture(channel, CpuBuffer{.ptr = nullptr}, 0);
     Error recvError = recvFuture.get();
     EXPECT_FALSE(recvError) << recvError.what();
 
@@ -96,7 +96,7 @@ class CallbacksAreDeferredTest : public ClientServerChannelTestCase {
     auto mutex = std::make_shared<std::mutex>();
     std::unique_lock<std::mutex> callerLock(*mutex);
     channel->send(
-        CpuBuffer{data.data()},
+        CpuBuffer{.ptr = data.data()},
         kDataSize,
         [&sendPromise, mutex](const Error& error) {
           std::unique_lock<std::mutex> calleeLock(*mutex);
@@ -120,7 +120,7 @@ class CallbacksAreDeferredTest : public ClientServerChannelTestCase {
     std::mutex mutex;
     std::unique_lock<std::mutex> callerLock(mutex);
     channel->recv(
-        CpuBuffer{data.data()},
+        CpuBuffer{.ptr = data.data()},
         kDataSize,
         [&recvPromise, &mutex](const Error& error) {
           std::unique_lock<std::mutex> calleeLock(mutex);

--- a/tensorpipe/test/channel/channel_test_cpu.h
+++ b/tensorpipe/test/channel/channel_test_cpu.h
@@ -26,6 +26,10 @@ class CpuDataWrapper : public DataWrapper {
         const_cast<uint8_t*>(vector_.data()), vector_.size()};
   }
 
+  size_t bufferLength() const override {
+    return vector_.size();
+  }
+
   std::vector<uint8_t> unwrap() override {
     return vector_;
   }

--- a/tensorpipe/test/channel/channel_test_cpu.h
+++ b/tensorpipe/test/channel/channel_test_cpu.h
@@ -23,7 +23,9 @@ class CpuDataWrapper : public DataWrapper {
 
   tensorpipe::Buffer buffer() const override {
     return tensorpipe::CpuBuffer{
-        const_cast<uint8_t*>(vector_.data()), vector_.size()};
+        .ptr = const_cast<uint8_t*>(vector_.data()),
+        .length = vector_.size(),
+    };
   }
 
   size_t bufferLength() const override {

--- a/tensorpipe/test/channel/channel_test_cuda.cc
+++ b/tensorpipe/test/channel/channel_test_cuda.cc
@@ -111,7 +111,9 @@ class SendOffsetAllocationTest : public ClientServerChannelTestCase {
 
     // Perform send and wait for completion.
     std::future<Error> sendFuture = sendWithFuture(
-        channel, CudaBuffer{static_cast<uint8_t*>(ptr) + kOffset}, kDataSize);
+        channel,
+        CudaBuffer{.ptr = static_cast<uint8_t*>(ptr) + kOffset},
+        kDataSize);
     Error sendError = sendFuture.get();
     EXPECT_FALSE(sendError) << sendError.what();
 

--- a/tensorpipe/test/channel/channel_test_cuda.cc
+++ b/tensorpipe/test/channel/channel_test_cuda.cc
@@ -40,9 +40,10 @@ class ReceiverWaitsForStartEventTest : public ClientServerChannelTestCase {
     channel->send(
         CudaBuffer{
             .ptr = ptr,
-            .length = kSize,
+            .length = 0,
             .stream = sendStream,
         },
+        kSize,
         [sendPromise{std::move(sendPromise)}](const tensorpipe::Error& error) {
           sendPromise->set_value(error);
         });
@@ -70,9 +71,10 @@ class ReceiverWaitsForStartEventTest : public ClientServerChannelTestCase {
     channel->recv(
         CudaBuffer{
             .ptr = ptr,
-            .length = kSize,
+            .length = 0,
             .stream = recvStream,
         },
+        kSize,
         [recvPromise{std::move(recvPromise)}](const tensorpipe::Error& error) {
           recvPromise->set_value(error);
         });
@@ -109,7 +111,7 @@ class SendOffsetAllocationTest : public ClientServerChannelTestCase {
 
     // Perform send and wait for completion.
     std::future<Error> sendFuture = sendWithFuture(
-        channel, CudaBuffer{static_cast<uint8_t*>(ptr) + kOffset, kDataSize});
+        channel, CudaBuffer{static_cast<uint8_t*>(ptr) + kOffset}, kDataSize);
     Error sendError = sendFuture.get();
     EXPECT_FALSE(sendError) << sendError.what();
 
@@ -122,8 +124,7 @@ class SendOffsetAllocationTest : public ClientServerChannelTestCase {
         helper_->makeDataWrapper(kDataSize);
 
     // Perform recv and wait for completion.
-    std::future<Error> recvFuture =
-        recvWithFuture(channel, wrappedData->buffer());
+    std::future<Error> recvFuture = recvWithFuture(channel, *wrappedData);
     Error recvError = recvFuture.get();
     EXPECT_FALSE(recvError) << recvError.what();
 

--- a/tensorpipe/test/channel/channel_test_cuda.h
+++ b/tensorpipe/test/channel/channel_test_cuda.h
@@ -44,6 +44,10 @@ class CudaDataWrapper : public DataWrapper {
     return tensorpipe::CudaBuffer{cudaPtr_, length_, stream_};
   }
 
+  size_t bufferLength() const override {
+    return length_;
+  }
+
   std::vector<uint8_t> unwrap() override {
     std::vector<uint8_t> v(length_);
     if (length_ > 0) {

--- a/tensorpipe/test/channel/channel_test_cuda.h
+++ b/tensorpipe/test/channel/channel_test_cuda.h
@@ -41,7 +41,11 @@ class CudaDataWrapper : public DataWrapper {
   }
 
   tensorpipe::Buffer buffer() const override {
-    return tensorpipe::CudaBuffer{cudaPtr_, length_, stream_};
+    return tensorpipe::CudaBuffer{
+        .ptr = cudaPtr_,
+        .length = length_,
+        .stream = stream_,
+    };
   }
 
   size_t bufferLength() const override {

--- a/tensorpipe/test/channel/channel_test_cuda_multi_gpu.cc
+++ b/tensorpipe/test/channel/channel_test_cuda_multi_gpu.cc
@@ -50,9 +50,10 @@ class SendAcrossDevicesTest : public ClientServerChannelTestCase {
     channel->send(
         CudaBuffer{
             .ptr = ptr,
-            .length = kSize,
+            .length = 0,
             .stream = sendStream,
         },
+        kSize,
         [sendPromise{std::move(sendPromise)}](const tensorpipe::Error& error) {
           sendPromise->set_value(error);
         });
@@ -96,9 +97,10 @@ class SendAcrossDevicesTest : public ClientServerChannelTestCase {
     channel->recv(
         CudaBuffer{
             .ptr = ptr,
-            .length = kSize,
+            .length = 0,
             .stream = recvStream,
         },
+        kSize,
         [recvPromise{std::move(recvPromise)}](const tensorpipe::Error& error) {
           recvPromise->set_value(error);
         });
@@ -165,9 +167,10 @@ class SendReverseAcrossDevicesTest : public ClientServerChannelTestCase {
     channel->send(
         CudaBuffer{
             .ptr = ptr,
-            .length = kSize,
+            .length = 0,
             .stream = sendStream,
         },
+        kSize,
         [sendPromise{std::move(sendPromise)}](const tensorpipe::Error& error) {
           sendPromise->set_value(error);
         });
@@ -211,9 +214,10 @@ class SendReverseAcrossDevicesTest : public ClientServerChannelTestCase {
     channel->recv(
         CudaBuffer{
             .ptr = ptr,
-            .length = kSize,
+            .length = 0,
             .stream = recvStream,
         },
+        kSize,
         [recvPromise{std::move(recvPromise)}](const tensorpipe::Error& error) {
           recvPromise->set_value(error);
         });
@@ -280,9 +284,10 @@ class SendAcrossNonDefaultDevicesTest : public ClientServerChannelTestCase {
     channel->send(
         CudaBuffer{
             .ptr = ptr,
-            .length = kSize,
+            .length = 0,
             .stream = sendStream,
         },
+        kSize,
         [sendPromise{std::move(sendPromise)}](const tensorpipe::Error& error) {
           sendPromise->set_value(error);
         });
@@ -322,9 +327,10 @@ class SendAcrossNonDefaultDevicesTest : public ClientServerChannelTestCase {
     channel->recv(
         CudaBuffer{
             .ptr = ptr,
-            .length = kSize,
+            .length = 0,
             .stream = recvStream,
         },
+        kSize,
         [recvPromise{std::move(recvPromise)}](const tensorpipe::Error& error) {
           recvPromise->set_value(error);
         });

--- a/tensorpipe/test/core/context_test.cc
+++ b/tensorpipe/test/core/context_test.cc
@@ -99,9 +99,12 @@ Message makeMessage(int numPayloads, int numTensors) {
     message.payloads.push_back(std::move(payload));
   }
   for (int i = 0; i < numTensors; i++) {
-    Message::Tensor tensor{CpuBuffer{
-        reinterpret_cast<void*>(const_cast<char*>(kTensorData.data())),
-        kTensorData.length()}};
+    Message::Tensor tensor{
+        .buffer = CpuBuffer{
+            .ptr =
+                reinterpret_cast<void*>(const_cast<char*>(kTensorData.data())),
+            .length = kTensorData.length(),
+        }};
     message.tensors.push_back(std::move(tensor));
   }
   return message;


### PR DESCRIPTION
Summary:
As discussed, using designated aggregate initializers where applicable,
in order to increase readbility and ease switching to the new Buffer API (so
that order of parameters does not matter).

Reviewed By: lw

Differential Revision: D27466386

