### PR TITLE
Introduce new Message::Tensor length API.

### DIFF
--- a/tensorpipe/benchmark/benchmark_pipe.cc
+++ b/tensorpipe/benchmark/benchmark_pipe.cc
@@ -459,13 +459,16 @@ static void clientPingPongNonBlock(
     for (size_t tensorIdx = 0; tensorIdx < data.numTensors; tensorIdx++) {
       Message::Tensor tensor;
       if (data.tensorType == TensorType::kCpu) {
-        tensor.buffer =
-            CpuBuffer{data.expectedCpuTensor[tensorIdx].get(), data.tensorSize};
+        tensor.buffer = CpuBuffer{
+            .ptr = data.expectedCpuTensor[tensorIdx].get(),
+            .length = data.tensorSize,
+        };
       } else if (data.tensorType == TensorType::kCuda) {
         tensor.buffer = CudaBuffer{
-            data.expectedCudaTensor[tensorIdx].get(),
-            data.tensorSize,
-            data.cudaStream.get()};
+            .ptr = data.expectedCudaTensor[tensorIdx].get(),
+            .length = data.tensorSize,
+            .stream = data.cudaStream.get(),
+        };
       } else {
         TP_THROW_ASSERT() << "Unknown tensor type";
       }

--- a/tensorpipe/channel/cuda_basic/channel_impl.cc
+++ b/tensorpipe/channel/cuda_basic/channel_impl.cc
@@ -270,7 +270,7 @@ void ChannelImpl::sendCpuBuffer(ChunkSendOpIter opIter) {
              << op.bufferSequenceNumber << " through CPU channel";
 
   cpuChannel_->send(
-      CpuBuffer{op.tmpBuffer.get()},
+      CpuBuffer{.ptr = op.tmpBuffer.get()},
       op.length,
       callbackWrapper_([opIter](ChannelImpl& impl) {
         TP_VLOG(6) << "Channel " << impl.id_ << " is done sending chunk #"
@@ -492,7 +492,7 @@ void ChannelImpl::receiveCpuBuffer(ChunkRecvOpIter opIter) {
              << " of " << op.numChunks << " for buffer #"
              << op.bufferSequenceNumber << " through CPU channel";
   cpuChannel_->recv(
-      CpuBuffer{op.tmpBuffer.get()},
+      CpuBuffer{.ptr = op.tmpBuffer.get()},
       op.length,
       callbackWrapper_([opIter](ChannelImpl& impl) {
         TP_VLOG(6) << "Channel " << impl.id_ << " is done sending chunk #"

--- a/tensorpipe/core/message.h
+++ b/tensorpipe/core/message.h
@@ -51,6 +51,8 @@ class Message final {
 
   struct Tensor {
     tensorpipe::Buffer buffer;
+    // FIXME: Default to 0 once we fully move to the new length API.
+    size_t length{static_cast<size_t>(-1)};
 
     // Users may include arbitrary metadata in the following field.
     // This may contain allocation hints for the receiver, for example.

--- a/tensorpipe/python/tensorpipe.cc
+++ b/tensorpipe/python/tensorpipe.cc
@@ -107,19 +107,26 @@ tensorpipe::Message prepareToWrite(std::shared_ptr<OutgoingMessage> pyMessage) {
   tpMessage.payloads.reserve(pyMessage->payloads.size());
   for (const auto& pyPayload : pyMessage->payloads) {
     tensorpipe::Message::Payload tpPayload{
-        pyPayload->buffer.ptr(),
-        pyPayload->buffer.length(),
-        {reinterpret_cast<char*>(pyPayload->metadata.ptr()),
-         pyPayload->metadata.length()}};
+        .data = pyPayload->buffer.ptr(),
+        .length = pyPayload->buffer.length(),
+        .metadata =
+            {reinterpret_cast<char*>(pyPayload->metadata.ptr()),
+             pyPayload->metadata.length()},
+    };
     tpMessage.payloads.push_back(std::move(tpPayload));
   }
   tpMessage.tensors.reserve(pyMessage->tensors.size());
   for (const auto& pyTensor : pyMessage->tensors) {
     tensorpipe::Message::Tensor tpTensor{
-        tensorpipe::CpuBuffer{
-            pyTensor->buffer.ptr(), pyTensor->buffer.length()},
-        {reinterpret_cast<char*>(pyTensor->metadata.ptr()),
-         pyTensor->metadata.length()}};
+        .buffer =
+            tensorpipe::CpuBuffer{
+                .ptr = pyTensor->buffer.ptr(),
+                .length = pyTensor->buffer.length(),
+            },
+        .metadata =
+            {reinterpret_cast<char*>(pyTensor->metadata.ptr()),
+             pyTensor->metadata.length()},
+    };
     tpMessage.tensors.push_back(std::move(tpTensor));
   }
   return tpMessage;
@@ -204,14 +211,19 @@ tensorpipe::Message prepareToRead(std::shared_ptr<IncomingMessage> pyMessage) {
   for (const auto& pyPayload : pyMessage->payloads) {
     TP_THROW_ASSERT_IF(!pyPayload->buffer.has_value()) << "No buffer";
     tensorpipe::Message::Payload tpPayload{
-        pyPayload->buffer.value().ptr(), pyPayload->buffer.value().length()};
+        .data = pyPayload->buffer.value().ptr(),
+        .length = pyPayload->buffer.value().length(),
+    };
     tpMessage.payloads.push_back(std::move(tpPayload));
   }
   tpMessage.tensors.reserve(pyMessage->tensors.size());
   for (const auto& pyTensor : pyMessage->tensors) {
     TP_THROW_ASSERT_IF(!pyTensor->buffer.has_value()) << "No buffer";
-    tensorpipe::Message::Tensor tpTensor{tensorpipe::CpuBuffer{
-        pyTensor->buffer.value().ptr(), pyTensor->buffer.value().length()}};
+    tensorpipe::Message::Tensor tpTensor{
+        .buffer = tensorpipe::CpuBuffer{
+            .ptr = pyTensor->buffer.value().ptr(),
+            .length = pyTensor->buffer.value().length(),
+        }};
     tpMessage.tensors.push_back(std::move(tpTensor));
   }
   return tpMessage;

--- a/tensorpipe/test/channel/channel_test_cpu.cc
+++ b/tensorpipe/test/channel/channel_test_cpu.cc
@@ -20,7 +20,7 @@ class NullPointerTest : public ClientServerChannelTestCase {
   void server(std::shared_ptr<Channel> channel) override {
     // Perform send and wait for completion.
     std::future<Error> sendFuture =
-        sendWithFuture(channel, CpuBuffer{nullptr}, 0);
+        sendWithFuture(channel, CpuBuffer{.ptr = nullptr}, 0);
     Error sendError = sendFuture.get();
     EXPECT_FALSE(sendError) << sendError.what();
 
@@ -31,7 +31,7 @@ class NullPointerTest : public ClientServerChannelTestCase {
   void client(std::shared_ptr<Channel> channel) override {
     // Perform recv and wait for completion.
     std::future<Error> recvFuture =
-        recvWithFuture(channel, CpuBuffer{nullptr}, 0);
+        recvWithFuture(channel, CpuBuffer{.ptr = nullptr}, 0);
     Error recvError = recvFuture.get();
     EXPECT_FALSE(recvError) << recvError.what();
 
@@ -96,7 +96,7 @@ class CallbacksAreDeferredTest : public ClientServerChannelTestCase {
     auto mutex = std::make_shared<std::mutex>();
     std::unique_lock<std::mutex> callerLock(*mutex);
     channel->send(
-        CpuBuffer{data.data()},
+        CpuBuffer{.ptr = data.data()},
         kDataSize,
         [&sendPromise, mutex](const Error& error) {
           std::unique_lock<std::mutex> calleeLock(*mutex);
@@ -120,7 +120,7 @@ class CallbacksAreDeferredTest : public ClientServerChannelTestCase {
     std::mutex mutex;
     std::unique_lock<std::mutex> callerLock(mutex);
     channel->recv(
-        CpuBuffer{data.data()},
+        CpuBuffer{.ptr = data.data()},
         kDataSize,
         [&recvPromise, &mutex](const Error& error) {
           std::unique_lock<std::mutex> calleeLock(mutex);

--- a/tensorpipe/test/channel/channel_test_cpu.h
+++ b/tensorpipe/test/channel/channel_test_cpu.h
@@ -23,7 +23,9 @@ class CpuDataWrapper : public DataWrapper {
 
   tensorpipe::Buffer buffer() const override {
     return tensorpipe::CpuBuffer{
-        const_cast<uint8_t*>(vector_.data()), vector_.size()};
+        .ptr = const_cast<uint8_t*>(vector_.data()),
+        .length = vector_.size(),
+    };
   }
 
   size_t bufferLength() const override {

--- a/tensorpipe/test/channel/channel_test_cuda.cc
+++ b/tensorpipe/test/channel/channel_test_cuda.cc
@@ -111,7 +111,9 @@ class SendOffsetAllocationTest : public ClientServerChannelTestCase {
 
     // Perform send and wait for completion.
     std::future<Error> sendFuture = sendWithFuture(
-        channel, CudaBuffer{static_cast<uint8_t*>(ptr) + kOffset}, kDataSize);
+        channel,
+        CudaBuffer{.ptr = static_cast<uint8_t*>(ptr) + kOffset},
+        kDataSize);
     Error sendError = sendFuture.get();
     EXPECT_FALSE(sendError) << sendError.what();
 

--- a/tensorpipe/test/channel/channel_test_cuda.h
+++ b/tensorpipe/test/channel/channel_test_cuda.h
@@ -41,7 +41,11 @@ class CudaDataWrapper : public DataWrapper {
   }
 
   tensorpipe::Buffer buffer() const override {
-    return tensorpipe::CudaBuffer{cudaPtr_, length_, stream_};
+    return tensorpipe::CudaBuffer{
+        .ptr = cudaPtr_,
+        .length = length_,
+        .stream = stream_,
+    };
   }
 
   size_t bufferLength() const override {

--- a/tensorpipe/test/core/context_test.cc
+++ b/tensorpipe/test/core/context_test.cc
@@ -99,9 +99,12 @@ Message makeMessage(int numPayloads, int numTensors) {
     message.payloads.push_back(std::move(payload));
   }
   for (int i = 0; i < numTensors; i++) {
-    Message::Tensor tensor{CpuBuffer{
-        reinterpret_cast<void*>(const_cast<char*>(kTensorData.data())),
-        kTensorData.length()}};
+    Message::Tensor tensor{
+        .buffer = CpuBuffer{
+            .ptr =
+                reinterpret_cast<void*>(const_cast<char*>(kTensorData.data())),
+            .length = kTensorData.length(),
+        }};
     message.tensors.push_back(std::move(tensor));
   }
   return message;


### PR DESCRIPTION
Summary:
So far, we have been storing the length of a tensor inside the concrete
`Buffer` class that represented it. However, the Pipe needs to access that value
in order to populate the message descriptor. Since we want the Pipe to be device
agnostic, we make the length an attribute on `Message::Tensor` directly.

Since we do not want to break backwards compatibility, we keep the `length`
fields on the `{Cpu,Cuda}Buffer` structs, and use a special default value
(`static_cast<size_t>(-1)`) for `Message::Tensor::length`, so that we can
handle `Message`s from users not populating this field, but relying on the old
API instead.

Reviewed By: lw

Differential Revision: D27282339

