### PR TITLE
Transition to new Message::Tensor length API.

### DIFF
--- a/tensorpipe/benchmark/benchmark_pipe.cc
+++ b/tensorpipe/benchmark/benchmark_pipe.cc
@@ -225,8 +225,7 @@ static void serverPongPingNonBlock(
         TP_DCHECK_EQ(
             message.tensors[tensorIdx].metadata,
             data.expectedTensorMetadata[tensorIdx]);
-        TP_DCHECK_EQ(
-            message.tensors[tensorIdx].buffer.length(), data.tensorSize);
+        TP_DCHECK_EQ(message.tensors[tensorIdx].length, data.tensorSize);
         if (data.tensorType == TensorType::kCpu) {
           message.tensors[tensorIdx].buffer.unwrap<CpuBuffer>().ptr =
               data.temporaryCpuTensor[tensorIdx].get();
@@ -267,8 +266,7 @@ static void serverPongPingNonBlock(
             TP_DCHECK_EQ(message.tensors.size(), data.numTensors);
             for (size_t tensorIdx = 0; tensorIdx < data.numTensors;
                  tensorIdx++) {
-              TP_DCHECK_EQ(
-                  message.tensors[tensorIdx].buffer.length(), data.tensorSize);
+              TP_DCHECK_EQ(message.tensors[tensorIdx].length, data.tensorSize);
               if (data.tensorType == TensorType::kCpu) {
                 TP_DCHECK_EQ(
                     memcmp(
@@ -276,9 +274,7 @@ static void serverPongPingNonBlock(
                             .buffer.unwrap<CpuBuffer>()
                             .ptr,
                         data.expectedCpuTensor[tensorIdx].get(),
-                        message.tensors[tensorIdx]
-                            .buffer.unwrap<CpuBuffer>()
-                            .length),
+                        message.tensors[tensorIdx].length),
                     0);
               } else if (data.tensorType == TensorType::kCuda) {
                 // No (easy) way to do a memcmp with CUDA, I believe...
@@ -458,11 +454,10 @@ static void clientPingPongNonBlock(
   if (data.tensorSize > 0) {
     for (size_t tensorIdx = 0; tensorIdx < data.numTensors; tensorIdx++) {
       Message::Tensor tensor;
+      tensor.length = data.tensorSize;
       if (data.tensorType == TensorType::kCpu) {
-        tensor.buffer = CpuBuffer{
-            .ptr = data.expectedCpuTensor[tensorIdx].get(),
-            .length = data.tensorSize,
-        };
+        tensor.buffer =
+            CpuBuffer{.ptr = data.expectedCpuTensor[tensorIdx].get()};
       } else if (data.tensorType == TensorType::kCuda) {
         tensor.buffer = CudaBuffer{
             .ptr = data.expectedCudaTensor[tensorIdx].get(),
@@ -513,8 +508,7 @@ static void clientPingPongNonBlock(
               TP_DCHECK_EQ(
                   message.tensors[tensorIdx].metadata,
                   data.expectedTensorMetadata[tensorIdx]);
-              TP_DCHECK_EQ(
-                  message.tensors[tensorIdx].buffer.length(), data.tensorSize);
+              TP_DCHECK_EQ(message.tensors[tensorIdx].length, data.tensorSize);
               if (data.tensorType == TensorType::kCpu) {
                 message.tensors[tensorIdx].buffer.unwrap<CpuBuffer>().ptr =
                     data.temporaryCpuTensor[tensorIdx].get();
@@ -571,9 +565,7 @@ static void clientPingPongNonBlock(
                                   .buffer.unwrap<CpuBuffer>()
                                   .ptr,
                               data.expectedCpuTensor[tensorIdx].get(),
-                              message.tensors[tensorIdx]
-                                  .buffer.unwrap<CpuBuffer>()
-                                  .length),
+                              message.tensors[tensorIdx].length),
                           0);
                     } else if (data.tensorType == TensorType::kCuda) {
                       // No (easy) way to do a memcmp with CUDA, I

--- a/tensorpipe/python/tensorpipe.cc
+++ b/tensorpipe/python/tensorpipe.cc
@@ -118,11 +118,8 @@ tensorpipe::Message prepareToWrite(std::shared_ptr<OutgoingMessage> pyMessage) {
   tpMessage.tensors.reserve(pyMessage->tensors.size());
   for (const auto& pyTensor : pyMessage->tensors) {
     tensorpipe::Message::Tensor tpTensor{
-        .buffer =
-            tensorpipe::CpuBuffer{
-                .ptr = pyTensor->buffer.ptr(),
-                .length = pyTensor->buffer.length(),
-            },
+        .buffer = tensorpipe::CpuBuffer{.ptr = pyTensor->buffer.ptr()},
+        .length = pyTensor->buffer.length(),
         .metadata =
             {reinterpret_cast<char*>(pyTensor->metadata.ptr()),
              pyTensor->metadata.length()},
@@ -196,9 +193,8 @@ std::shared_ptr<IncomingMessage> prepareToAllocate(
   pyTensors.reserve(tpMessage.tensors.size());
   for (const auto& tpTensor : tpMessage.tensors) {
     TP_DCHECK(tpTensor.buffer.unwrap<tensorpipe::CpuBuffer>().ptr == nullptr);
-    pyTensors.push_back(std::make_shared<IncomingTensor>(
-        tpTensor.buffer.unwrap<tensorpipe::CpuBuffer>().length,
-        tpTensor.metadata));
+    pyTensors.push_back(
+        std::make_shared<IncomingTensor>(tpTensor.length, tpTensor.metadata));
   }
   auto pyMessage = std::make_shared<IncomingMessage>(
       tpMessage.metadata, std::move(pyPayloads), std::move(pyTensors));
@@ -220,10 +216,9 @@ tensorpipe::Message prepareToRead(std::shared_ptr<IncomingMessage> pyMessage) {
   for (const auto& pyTensor : pyMessage->tensors) {
     TP_THROW_ASSERT_IF(!pyTensor->buffer.has_value()) << "No buffer";
     tensorpipe::Message::Tensor tpTensor{
-        .buffer = tensorpipe::CpuBuffer{
-            .ptr = pyTensor->buffer.value().ptr(),
-            .length = pyTensor->buffer.value().length(),
-        }};
+        .buffer = tensorpipe::CpuBuffer{.ptr = pyTensor->buffer.value().ptr()},
+        .length = pyTensor->buffer.value().length(),
+    };
     tpMessage.tensors.push_back(std::move(tpTensor));
   }
   return tpMessage;

--- a/tensorpipe/test/channel/channel_test_cpu.h
+++ b/tensorpipe/test/channel/channel_test_cpu.h
@@ -22,10 +22,7 @@ class CpuDataWrapper : public DataWrapper {
   explicit CpuDataWrapper(std::vector<uint8_t> v) : vector_(v) {}
 
   tensorpipe::Buffer buffer() const override {
-    return tensorpipe::CpuBuffer{
-        .ptr = const_cast<uint8_t*>(vector_.data()),
-        .length = vector_.size(),
-    };
+    return tensorpipe::CpuBuffer{.ptr = const_cast<uint8_t*>(vector_.data())};
   }
 
   size_t bufferLength() const override {

--- a/tensorpipe/test/core/context_test.cc
+++ b/tensorpipe/test/core/context_test.cc
@@ -79,9 +79,9 @@ namespace {
   for (size_t idx = 0; idx < m1.tensors.size(); idx++) {
     EXPECT_TRUE(buffersAreEqual(
         m1.tensors[idx].buffer.unwrap<CpuBuffer>().ptr,
-        m1.tensors[idx].buffer.unwrap<CpuBuffer>().length,
+        m1.tensors[idx].length,
         m2.tensors[idx].buffer.unwrap<CpuBuffer>().ptr,
-        m2.tensors[idx].buffer.unwrap<CpuBuffer>().length));
+        m2.tensors[idx].length));
   }
   return ::testing::AssertionSuccess();
 }
@@ -100,11 +100,10 @@ Message makeMessage(int numPayloads, int numTensors) {
   }
   for (int i = 0; i < numTensors; i++) {
     Message::Tensor tensor{
-        .buffer = CpuBuffer{
-            .ptr =
-                reinterpret_cast<void*>(const_cast<char*>(kTensorData.data())),
-            .length = kTensorData.length(),
-        }};
+        .buffer = CpuBuffer{reinterpret_cast<void*>(
+            const_cast<char*>(kTensorData.data()))},
+        .length = kTensorData.length(),
+    };
     message.tensors.push_back(std::move(tensor));
   }
   return message;
@@ -190,8 +189,7 @@ TEST(Context, ClientPingSerial) {
     buffers.push_back(std::move(payloadData));
   }
   for (auto& tensor : message.tensors) {
-    auto tensorData =
-        std::make_unique<uint8_t[]>(tensor.buffer.unwrap<CpuBuffer>().length);
+    auto tensorData = std::make_unique<uint8_t[]>(tensor.length);
     tensor.buffer.unwrap<CpuBuffer>().ptr = tensorData.get();
     buffers.push_back(std::move(tensorData));
   }
@@ -257,8 +255,7 @@ TEST(Context, ClientPingInline) {
         buffers.push_back(std::move(payloadData));
       }
       for (auto& tensor : message.tensors) {
-        auto tensorData = std::make_unique<uint8_t[]>(
-            tensor.buffer.unwrap<CpuBuffer>().length);
+        auto tensorData = std::make_unique<uint8_t[]>(tensor.length);
         tensor.buffer.unwrap<CpuBuffer>().ptr = tensorData.get();
         buffers.push_back(std::move(tensorData));
       }
@@ -354,8 +351,7 @@ TEST(Context, ServerPingPongTwice) {
                 buffers.push_back(std::move(payloadData));
               }
               for (auto& tensor : message.tensors) {
-                auto tensorData = std::make_unique<uint8_t[]>(
-                    tensor.buffer.unwrap<CpuBuffer>().length);
+                auto tensorData = std::make_unique<uint8_t[]>(tensor.length);
                 tensor.buffer.unwrap<CpuBuffer>().ptr = tensorData.get();
                 buffers.push_back(std::move(tensorData));
               }
@@ -397,8 +393,7 @@ TEST(Context, ServerPingPongTwice) {
             buffers.push_back(std::move(payloadData));
           }
           for (auto& tensor : message.tensors) {
-            auto tensorData = std::make_unique<uint8_t[]>(
-                tensor.buffer.unwrap<CpuBuffer>().length);
+            auto tensorData = std::make_unique<uint8_t[]>(tensor.length);
             tensor.buffer.unwrap<CpuBuffer>().ptr = tensorData.get();
             buffers.push_back(std::move(tensorData));
           }
@@ -452,8 +447,7 @@ static void pipeRead(
       buffers.push_back(std::move(payloadData));
     }
     for (auto& tensor : message.tensors) {
-      auto tensorData =
-          std::make_unique<uint8_t[]>(tensor.buffer.unwrap<CpuBuffer>().length);
+      auto tensorData = std::make_unique<uint8_t[]>(tensor.length);
       tensor.buffer.unwrap<CpuBuffer>().ptr = tensorData.get();
       buffers.push_back(std::move(tensorData));
     }


### PR DESCRIPTION
Summary: Use the new `Message::Tensor::length` API.

Reviewed By: lw

Differential Revision: D27282343

