### PR TITLE
Remove length member from concrete Buffer types.

### DIFF
--- a/tensorpipe/benchmark/benchmark_pipe.cc
+++ b/tensorpipe/benchmark/benchmark_pipe.cc
@@ -461,7 +461,6 @@ static void clientPingPongNonBlock(
       } else if (data.tensorType == TensorType::kCuda) {
         tensor.buffer = CudaBuffer{
             .ptr = data.expectedCudaTensor[tensorIdx].get(),
-            .length = data.tensorSize,
             .stream = data.cudaStream.get(),
         };
       } else {

--- a/tensorpipe/common/buffer.h
+++ b/tensorpipe/common/buffer.h
@@ -22,7 +22,6 @@ class Buffer {
   class AbstractBufferWrapper {
    public:
     virtual DeviceType deviceType() const = 0;
-    virtual size_t length() const = 0;
     virtual void copyConstructInto(void* ptr) const = 0;
     virtual void moveConstructInto(void* ptr) = 0;
     virtual ~AbstractBufferWrapper() = default;
@@ -41,10 +40,6 @@ class Buffer {
 
     DeviceType deviceType() const override {
       return buffer.deviceType();
-    }
-
-    size_t length() const override {
-      return buffer.length;
     }
 
     void copyConstructInto(void* ptr) const override {
@@ -119,10 +114,6 @@ class Buffer {
 
   DeviceType deviceType() const {
     return ptr()->deviceType();
-  }
-
-  size_t length() const {
-    return ptr()->length();
   }
 
  private:

--- a/tensorpipe/common/cpu_buffer.h
+++ b/tensorpipe/common/cpu_buffer.h
@@ -8,15 +8,12 @@
 
 #pragma once
 
-#include <cstddef>
-
 #include <tensorpipe/common/device.h>
 
 namespace tensorpipe {
 
 struct CpuBuffer {
   void* ptr{nullptr};
-  size_t length{0};
 
   DeviceType deviceType() const {
     return DeviceType::kCpu;

--- a/tensorpipe/common/cuda_buffer.h
+++ b/tensorpipe/common/cuda_buffer.h
@@ -16,7 +16,6 @@ namespace tensorpipe {
 
 struct CudaBuffer {
   void* ptr{nullptr};
-  size_t length{0};
   cudaStream_t stream{cudaStreamDefault};
 
   DeviceType deviceType() const {

--- a/tensorpipe/core/message.h
+++ b/tensorpipe/core/message.h
@@ -51,8 +51,7 @@ class Message final {
 
   struct Tensor {
     tensorpipe::Buffer buffer;
-    // FIXME: Default to 0 once we fully move to the new length API.
-    size_t length{static_cast<size_t>(-1)};
+    size_t length{0};
 
     // Users may include arbitrary metadata in the following field.
     // This may contain allocation hints for the receiver, for example.

--- a/tensorpipe/test/channel/channel_test_cuda.cc
+++ b/tensorpipe/test/channel/channel_test_cuda.cc
@@ -40,7 +40,6 @@ class ReceiverWaitsForStartEventTest : public ClientServerChannelTestCase {
     channel->send(
         CudaBuffer{
             .ptr = ptr,
-            .length = 0,
             .stream = sendStream,
         },
         kSize,
@@ -71,7 +70,6 @@ class ReceiverWaitsForStartEventTest : public ClientServerChannelTestCase {
     channel->recv(
         CudaBuffer{
             .ptr = ptr,
-            .length = 0,
             .stream = recvStream,
         },
         kSize,

--- a/tensorpipe/test/channel/channel_test_cuda.h
+++ b/tensorpipe/test/channel/channel_test_cuda.h
@@ -43,7 +43,6 @@ class CudaDataWrapper : public DataWrapper {
   tensorpipe::Buffer buffer() const override {
     return tensorpipe::CudaBuffer{
         .ptr = cudaPtr_,
-        .length = length_,
         .stream = stream_,
     };
   }

--- a/tensorpipe/test/channel/channel_test_cuda_multi_gpu.cc
+++ b/tensorpipe/test/channel/channel_test_cuda_multi_gpu.cc
@@ -50,7 +50,6 @@ class SendAcrossDevicesTest : public ClientServerChannelTestCase {
     channel->send(
         CudaBuffer{
             .ptr = ptr,
-            .length = 0,
             .stream = sendStream,
         },
         kSize,
@@ -97,7 +96,6 @@ class SendAcrossDevicesTest : public ClientServerChannelTestCase {
     channel->recv(
         CudaBuffer{
             .ptr = ptr,
-            .length = 0,
             .stream = recvStream,
         },
         kSize,
@@ -167,7 +165,6 @@ class SendReverseAcrossDevicesTest : public ClientServerChannelTestCase {
     channel->send(
         CudaBuffer{
             .ptr = ptr,
-            .length = 0,
             .stream = sendStream,
         },
         kSize,
@@ -214,7 +211,6 @@ class SendReverseAcrossDevicesTest : public ClientServerChannelTestCase {
     channel->recv(
         CudaBuffer{
             .ptr = ptr,
-            .length = 0,
             .stream = recvStream,
         },
         kSize,
@@ -284,7 +280,6 @@ class SendAcrossNonDefaultDevicesTest : public ClientServerChannelTestCase {
     channel->send(
         CudaBuffer{
             .ptr = ptr,
-            .length = 0,
             .stream = sendStream,
         },
         kSize,
@@ -327,7 +322,6 @@ class SendAcrossNonDefaultDevicesTest : public ClientServerChannelTestCase {
     channel->recv(
         CudaBuffer{
             .ptr = ptr,
-            .length = 0,
             .stream = recvStream,
         },
         kSize,


### PR DESCRIPTION
Summary:
This diff removes the `length` member from the `CpuBuffer`/`CudaBuffer`
classes (and therefore the `length()` method from the `Buffer` class). The goal
is to 1. enable receiver-selected target device in the Pipe, and 2. make the
Pipe fully device-agnostic.

Reviewed By: lw

Differential Revision: D27223197

