### PR TITLE
Per-device pair channel selection.

### DIFF
--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -95,6 +95,8 @@ if(TP_USE_CUDA)
   find_package(CUDA REQUIRED)
   target_link_libraries(tensorpipe PUBLIC ${CUDA_LIBRARIES})
   target_include_directories(tensorpipe PUBLIC ${CUDA_INCLUDE_DIRS})
+  target_sources(tensorpipe PRIVATE
+    common/cuda_buffer.cc)
   set(TP_PUBLIC_HEADERS ${TP_PUBLIC_HEADERS}
     common/cuda_buffer.h)
   set(TENSORPIPE_SUPPORTS_CUDA 1)

--- a/tensorpipe/common/buffer.h
+++ b/tensorpipe/common/buffer.h
@@ -22,6 +22,7 @@ class Buffer {
   class AbstractBufferWrapper {
    public:
     virtual DeviceType deviceType() const = 0;
+    virtual Device device() const = 0;
     virtual void copyConstructInto(void* ptr) const = 0;
     virtual void moveConstructInto(void* ptr) = 0;
     virtual ~AbstractBufferWrapper() = default;
@@ -40,6 +41,10 @@ class Buffer {
 
     DeviceType deviceType() const override {
       return buffer.deviceType();
+    }
+
+    Device device() const override {
+      return buffer.getDevice();
     }
 
     void copyConstructInto(void* ptr) const override {
@@ -114,6 +119,10 @@ class Buffer {
 
   DeviceType deviceType() const {
     return ptr()->deviceType();
+  }
+
+  Device device() const {
+    return ptr()->device();
   }
 
  private:

--- a/tensorpipe/common/cpu_buffer.h
+++ b/tensorpipe/common/cpu_buffer.h
@@ -15,6 +15,10 @@ namespace tensorpipe {
 struct CpuBuffer {
   void* ptr{nullptr};
 
+  Device getDevice() const {
+    return Device{kCpuDeviceType, 0};
+  }
+
   DeviceType deviceType() const {
     return DeviceType::kCpu;
   }

--- a/tensorpipe/common/cuda_buffer.cc
+++ b/tensorpipe/common/cuda_buffer.cc
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/common/cuda_buffer.h>
+
+#include <tensorpipe/common/cuda.h>
+#include <tensorpipe/common/defs.h>
+
+namespace tensorpipe {
+
+Device CudaBuffer::getDevice() const {
+  static CudaLib cudaLib = []() {
+    Error error;
+    CudaLib lib;
+    std::tie(error, lib) = CudaLib::create();
+    TP_THROW_ASSERT_IF(error)
+        << "Cannot get CUDA device for pointer because libcuda could not be loaded: "
+        << error.what();
+    return lib;
+  }();
+
+  return Device{kCudaDeviceType, cudaDeviceForPointer(cudaLib, ptr)};
+}
+
+} // namespace tensorpipe

--- a/tensorpipe/common/cuda_buffer.h
+++ b/tensorpipe/common/cuda_buffer.h
@@ -18,6 +18,8 @@ struct CudaBuffer {
   void* ptr{nullptr};
   cudaStream_t stream{cudaStreamDefault};
 
+  Device getDevice() const;
+
   DeviceType deviceType() const {
     return DeviceType::kCuda;
   }

--- a/tensorpipe/common/device.h
+++ b/tensorpipe/common/device.h
@@ -60,4 +60,14 @@ struct hash<::tensorpipe::Device> {
   }
 };
 
+template <>
+struct hash<std::pair<::tensorpipe::Device, ::tensorpipe::Device>> {
+  size_t operator()(const std::pair<::tensorpipe::Device, ::tensorpipe::Device>&
+                        p) const noexcept {
+    size_t h1 = std::hash<::tensorpipe::Device>{}(p.first);
+    size_t h2 = std::hash<::tensorpipe::Device>{}(p.second);
+    return h1 ^ (h2 << 1);
+  }
+};
+
 } // namespace std

--- a/tensorpipe/core/nop_types.h
+++ b/tensorpipe/core/nop_types.h
@@ -16,7 +16,6 @@
 #include <nop/structure.h>
 #include <nop/types/variant.h>
 
-#include <tensorpipe/common/buffer.h>
 #include <tensorpipe/common/device.h>
 
 namespace tensorpipe {
@@ -31,29 +30,13 @@ struct RequestedConnection {
   NOP_STRUCTURE(RequestedConnection, registrationId);
 };
 
-struct TransportAdvertisement {
-  std::string domainDescriptor;
-  NOP_STRUCTURE(TransportAdvertisement, domainDescriptor);
-};
-
 NOP_EXTERNAL_STRUCTURE(Device, type, index);
 
-struct ChannelAdvertisement {
-  std::unordered_map<Device, std::string> deviceDescriptors;
-  NOP_STRUCTURE(ChannelAdvertisement, deviceDescriptors);
-};
-
 struct Brochure {
-  std::unordered_map<std::string, TransportAdvertisement>
-      transportAdvertisement;
-  std::unordered_map<std::string, ChannelAdvertisement> channelAdvertisement;
-  NOP_STRUCTURE(Brochure, transportAdvertisement, channelAdvertisement);
-};
-
-struct ChannelSelection {
-  std::vector<uint64_t> registrationIds;
-  std::unordered_map<Device, std::string> deviceDescriptors;
-  NOP_STRUCTURE(ChannelSelection, registrationIds, deviceDescriptors);
+  std::unordered_map<std::string, std::string> transportDomainDescriptors;
+  std::unordered_map<std::string, std::unordered_map<Device, std::string>>
+      channelDeviceDescriptors;
+  NOP_STRUCTURE(Brochure, transportDomainDescriptors, channelDeviceDescriptors);
 };
 
 struct BrochureAnswer {
@@ -61,14 +44,20 @@ struct BrochureAnswer {
   std::string address;
   uint64_t transportRegistrationId;
   std::string transportDomainDescriptor;
-  std::unordered_map<std::string, ChannelSelection> channelSelection;
+  std::unordered_map<std::string, std::vector<uint64_t>> channelRegistrationIds;
+  std::unordered_map<std::string, std::unordered_map<Device, std::string>>
+      channelDeviceDescriptors;
+  std::unordered_map<std::pair<Device, Device>, std::string>
+      channelForDevicePair;
   NOP_STRUCTURE(
       BrochureAnswer,
       transport,
       address,
       transportRegistrationId,
       transportDomainDescriptor,
-      channelSelection);
+      channelRegistrationIds,
+      channelDeviceDescriptors,
+      channelForDevicePair);
 };
 
 struct MessageDescriptor {
@@ -92,14 +81,8 @@ struct MessageDescriptor {
     int64_t sizeInBytes;
     std::string metadata;
 
-    DeviceType deviceType;
-    std::string channelName;
-    NOP_STRUCTURE(
-        TensorDescriptor,
-        sizeInBytes,
-        metadata,
-        deviceType,
-        channelName);
+    Device sourceDevice;
+    NOP_STRUCTURE(TensorDescriptor, sizeInBytes, metadata, sourceDevice);
   };
 
   std::string metadata;

--- a/tensorpipe/core/pipe_impl.cc
+++ b/tensorpipe/core/pipe_impl.cc
@@ -52,7 +52,7 @@ void parseDescriptorOfMessage(ReadOperation& op, const Packet& nopPacketIn) {
        nopMessageDescriptor.tensorDescriptors) {
     ReadOperation::Tensor tensorBeingAllocated;
     tensorBeingAllocated.length = nopTensorDescriptor.sizeInBytes;
-    tensorBeingAllocated.channelName = nopTensorDescriptor.channelName;
+    tensorBeingAllocated.sourceDevice = nopTensorDescriptor.sourceDevice;
 
     message.tensors.emplace_back();
     Message::Tensor& tensor = message.tensors.back();
@@ -117,8 +117,7 @@ std::shared_ptr<NopHolder<Packet>> makeDescriptorForMessage(
     MessageDescriptor::TensorDescriptor& nopTensorDescriptor =
         nopMessageDescriptor.tensorDescriptors.back();
     nopTensorDescriptor.metadata = tensor.metadata;
-    nopTensorDescriptor.channelName = otherTensor.channelName;
-    nopTensorDescriptor.deviceType = tensor.buffer.deviceType();
+    nopTensorDescriptor.sourceDevice = tensor.buffer.device();
     nopTensorDescriptor.sizeInBytes = tensor.length;
   }
 
@@ -133,8 +132,7 @@ struct SelectedTransport {
 
 SelectedTransport selectTransport(
     const ContextImpl::TOrderedTransports& orderedTransports,
-    const std::unordered_map<std::string, TransportAdvertisement>&
-        nopTransportAdvertisement,
+    const std::unordered_map<std::string, std::string>& remoteDomainDescriptors,
     const std::map<std::string, std::string>& addresses) {
   for (const auto& transportContextIter : orderedTransports) {
     const std::string& transportName = std::get<0>(transportContextIter.second);
@@ -148,16 +146,14 @@ SelectedTransport selectTransport(
     }
     const auto& address = addressIter->second;
 
-    const auto nopTransportAdvertisementIter =
-        nopTransportAdvertisement.find(transportName);
-    if (nopTransportAdvertisementIter == nopTransportAdvertisement.cend()) {
+    const auto remoteDomainDescriptorsIter =
+        remoteDomainDescriptors.find(transportName);
+    if (remoteDomainDescriptorsIter == remoteDomainDescriptors.cend()) {
       continue;
     }
-    const TransportAdvertisement& nopCurrentTransportAdvertisement =
-        nopTransportAdvertisementIter->second;
-    const std::string& domainDescriptor =
-        nopCurrentTransportAdvertisement.domainDescriptor;
-    if (!transportContext.canCommunicateWithRemote(domainDescriptor)) {
+    const std::string& remoteDomainDescriptor =
+        remoteDomainDescriptorsIter->second;
+    if (!transportContext.canCommunicateWithRemote(remoteDomainDescriptor)) {
       continue;
     }
 
@@ -169,55 +165,68 @@ SelectedTransport selectTransport(
   return {};
 }
 
-struct SelectedChannel {
-  std::string name;
-  std::unordered_map<Device, std::string> deviceDescriptors;
+struct SelectedChannels {
+  std::unordered_map<std::string, std::unordered_map<Device, std::string>>
+      descriptorsMap;
+  std::unordered_map<std::pair<Device, Device>, std::string>
+      channelForDevicePair;
 };
 
-std::vector<SelectedChannel> selectChannels(
+SelectedChannels selectChannels(
     const ContextImpl::TOrderedChannels& orderedChannels,
-    const std::unordered_map<std::string, ChannelAdvertisement>&
-        nopChannelAdvertisement) {
-  std::vector<SelectedChannel> result;
-  for (const auto& channelContextIter : orderedChannels) {
-    const std::string& channelName = std::get<0>(channelContextIter.second);
-    const channel::Context& channelContext =
-        *(std::get<1>(channelContextIter.second));
+    const std::unordered_map<
+        std::string,
+        std::unordered_map<Device, std::string>>& remoteDescriptorsMap) {
+  SelectedChannels result;
 
-    const auto nopChannelAdvertisementIter =
-        nopChannelAdvertisement.find(channelName);
-    if (nopChannelAdvertisementIter == nopChannelAdvertisement.cend()) {
+  for (const auto& channelIter : orderedChannels) {
+    const std::string& channelName = std::get<0>(channelIter.second);
+    const channel::Context& channelContext = *std::get<1>(channelIter.second);
+
+    const auto& remoteDescriptorsMapIter =
+        remoteDescriptorsMap.find(channelName);
+    if (remoteDescriptorsMapIter == remoteDescriptorsMap.end()) {
       continue;
     }
-    const ChannelAdvertisement& nopCurrentChannelAdvertisement =
-        nopChannelAdvertisementIter->second;
+
     const std::unordered_map<Device, std::string>& localDeviceDescriptors =
         channelContext.deviceDescriptors();
     const std::unordered_map<Device, std::string>& remoteDeviceDescriptors =
-        nopCurrentChannelAdvertisement.deviceDescriptors;
-
-    // Do not select channels which cannot connect anything.
-    if (localDeviceDescriptors.empty() || remoteDeviceDescriptors.empty()) {
-      continue;
-    }
+        remoteDescriptorsMapIter->second;
 
     // For now, only select a channel if it is supported by all pairs of
     // relevant devices. This will be lifted once we introduce per-device pair
     // channel selection.
-    bool selected = true;
+    bool connectsAllPairs = true;
+    std::vector<std::pair<Device, Device>> devicePairs;
     for (const auto& localDescIter : localDeviceDescriptors) {
+      const Device& localDevice = localDescIter.first;
       const std::string& localDeviceDescriptor = localDescIter.second;
       for (const auto& remoteDescIter : remoteDeviceDescriptors) {
+        const Device& remoteDevice = remoteDescIter.first;
         const std::string& remoteDeviceDescriptor = remoteDescIter.second;
         if (!channelContext.canCommunicateWithRemote(
                 localDeviceDescriptor, remoteDeviceDescriptor)) {
-          selected = false;
+          connectsAllPairs = false;
+          break;
         }
+
+        if (result.channelForDevicePair.count({localDevice, remoteDevice}) !=
+            0) {
+          // A channel with higher priority has already been selected for this
+          // device pair.
+          continue;
+        }
+
+        devicePairs.emplace_back(localDevice, remoteDevice);
       }
     }
 
-    if (selected) {
-      result.push_back({channelName, localDeviceDescriptors});
+    if (connectsAllPairs && !devicePairs.empty()) {
+      for (const auto& p : devicePairs) {
+        result.channelForDevicePair[p] = channelName;
+      }
+      result.descriptorsMap[channelName] = localDeviceDescriptors;
     }
   }
 
@@ -305,16 +314,14 @@ void PipeImpl::initFromLoop() {
           std::get<0>(transportContextIter.second);
       const transport::Context& transportContext =
           *(std::get<1>(transportContextIter.second));
-      TransportAdvertisement& nopTransportAdvertisement =
-          nopBrochure.transportAdvertisement[transportName];
-      nopTransportAdvertisement.domainDescriptor =
+      nopBrochure.transportDomainDescriptors[transportName] =
           transportContext.domainDescriptor();
     }
     for (const auto& channelContextIter : context_->getOrderedChannels()) {
       const std::string& channelName = std::get<0>(channelContextIter.second);
       const channel::Context& channelContext =
           *(std::get<1>(channelContextIter.second));
-      nopBrochure.channelAdvertisement[channelName].deviceDescriptors =
+      nopBrochure.channelDeviceDescriptors[channelName] =
           channelContext.deviceDescriptors();
     }
     TP_VLOG(3) << "Pipe " << id_ << " is writing nop object (brochure)";
@@ -483,12 +490,26 @@ void PipeImpl::readPayloadsAndReceiveTensorsOfMessage(ReadOpIter opIter) {
        tensorIdx++) {
     Message::Tensor& tensor = op.message.tensors[tensorIdx];
     ReadOperation::Tensor& tensorBeingAllocated = op.tensors[tensorIdx];
-    std::shared_ptr<channel::Channel> channel =
-        channels_.at(tensorBeingAllocated.channelName);
+
+    // FIXME: Until we have full support for XDTT, `selectChannels` ensures that
+    // a single channel is selected for a given device type. Moreover, no
+    // channel supports XDTT for now, so the device type of buffers on both ends
+    // is guaranteed to be the same. Therefore, we can pick a channel based
+    // solely on the source device's type, and we do that with this ugly hack:
+    std::string channelName;
+    for (const auto& iter : channelForDevicePair_) {
+      const std::pair<Device, Device>& p = iter.first;
+      if (p.first.type == tensorBeingAllocated.sourceDevice.type) {
+        channelName = iter.second;
+        break;
+      }
+    }
+    TP_DCHECK(channelName != "");
+    channel::Channel& channel = *channels_.at(channelName);
     TP_VLOG(3) << "Pipe " << id_ << " is receiving tensor #"
                << op.sequenceNumber << "." << tensorIdx;
 
-    channel->recv(
+    channel.recv(
         tensor.buffer,
         tensor.length,
         callbackWrapper_([opIter, tensorIdx](PipeImpl& impl) {
@@ -777,44 +798,34 @@ void PipeImpl::sendTensorsOfMessage(WriteOpIter opIter) {
   for (int tensorIdx = 0; tensorIdx < op.message.tensors.size(); ++tensorIdx) {
     const auto& tensor = op.message.tensors[tensorIdx];
 
-    bool foundAChannel = false;
-    for (const auto& channelContextIter : context_->getOrderedChannels()) {
-      const std::string& channelName = std::get<0>(channelContextIter.second);
-      auto channelIter = channels_.find(channelName);
-      if (channelIter == channels_.cend()) {
-        continue;
+    // FIXME: Until we have full support for XDTT, `selectChannels` ensures that
+    // a single channel is selected for a given device type.
+    std::string channelName;
+    for (const auto& iter : channelForDevicePair_) {
+      const std::pair<Device, Device>& p = iter.first;
+      if (p.first == tensor.buffer.device()) {
+        channelName = iter.second;
+        break;
       }
-
-      auto& channelContext = std::get<1>(channelContextIter.second);
-      // FIXME: Skip channel if it does not support current buffer type, as a
-      // temporary measure before we roll out proper channel selection for
-      // cross-device type transfers.
-      if (!channelContext->supportsDeviceType(tensor.buffer.deviceType())) {
-        continue;
-      }
-
-      auto& channel = *(channelIter->second);
-
-      TP_VLOG(3) << "Pipe " << id_ << " is sending tensor #"
-                 << op.sequenceNumber << "." << tensorIdx;
-
-      channel.send(
-          tensor.buffer,
-          tensor.length,
-          callbackWrapper_([opIter, tensorIdx](PipeImpl& impl) {
-            TP_VLOG(3) << "Pipe " << impl.id_ << " done sending tensor #"
-                       << opIter->sequenceNumber << "." << tensorIdx;
-            opIter->numTensorsBeingSent--;
-            impl.writeOps_.advanceOperation(opIter);
-          }));
-
-      op.tensors.push_back(
-          WriteOperation::Tensor{tensor.buffer.deviceType(), channelName});
-
-      foundAChannel = true;
-      break;
     }
-    TP_THROW_ASSERT_IF(!foundAChannel);
+    TP_THROW_ASSERT_IF(channelName == "") << "Could not find suitable channel";
+
+    channel::Channel& channel = *channels_[channelName];
+
+    TP_VLOG(3) << "Pipe " << id_ << " is sending tensor #" << op.sequenceNumber
+               << "." << tensorIdx;
+
+    channel.send(
+        tensor.buffer,
+        tensor.length,
+        callbackWrapper_([opIter, tensorIdx](PipeImpl& impl) {
+          TP_VLOG(3) << "Pipe " << impl.id_ << " done sending tensor #"
+                     << opIter->sequenceNumber << "." << tensorIdx;
+          opIter->numTensorsBeingSent--;
+          impl.writeOps_.advanceOperation(opIter);
+        }));
+
+    op.tensors.push_back(WriteOperation::Tensor{});
 
     ++op.numTensorsBeingSent;
   }
@@ -873,7 +884,7 @@ void PipeImpl::onReadWhileServerWaitingForBrochure(const Packet& nopPacketIn) {
 
   auto transport = selectTransport(
       context_->getOrderedTransports(),
-      nopBrochure.transportAdvertisement,
+      nopBrochure.transportDomainDescriptors,
       listener_->addresses());
 
   if (transport.name != transport_) {
@@ -885,13 +896,19 @@ void PipeImpl::onReadWhileServerWaitingForBrochure(const Packet& nopPacketIn) {
   nopBrochureAnswer.address = transport.address;
   nopBrochureAnswer.transportDomainDescriptor = transport.domainDescriptor;
 
-  const auto selectedChannels = selectChannels(
-      context_->getOrderedChannels(), nopBrochure.channelAdvertisement);
-  for (const auto& channel : selectedChannels) {
-    ChannelSelection& nopChannelSelection =
-        nopBrochureAnswer.channelSelection[channel.name];
-    nopChannelSelection.registrationIds = registerChannel(channel.name);
-    nopChannelSelection.deviceDescriptors = channel.deviceDescriptors;
+  SelectedChannels selectedChannels = selectChannels(
+      context_->getOrderedChannels(), nopBrochure.channelDeviceDescriptors);
+  channelForDevicePair_ = std::move(selectedChannels.channelForDevicePair);
+  nopBrochureAnswer.channelForDevicePair = channelForDevicePair_;
+
+  for (auto& descriptorsIter : selectedChannels.descriptorsMap) {
+    const std::string& channelName = descriptorsIter.first;
+    nopBrochureAnswer.channelRegistrationIds[channelName] =
+        registerChannel(channelName);
+    std::unordered_map<Device, std::string>& deviceDescriptors =
+        descriptorsIter.second;
+    nopBrochureAnswer.channelDeviceDescriptors[channelName] =
+        std::move(deviceDescriptors);
   }
 
   TP_VLOG(3) << "Pipe " << id_ << " is writing nop object (brochure answer)";
@@ -1003,29 +1020,43 @@ void PipeImpl::onReadWhileClientWaitingForBrochureAnswer(
     connection_ = std::move(connection);
   }
 
-  for (const auto& nopChannelSelectionIter :
-       nopBrochureAnswer.channelSelection) {
-    const std::string& channelName = nopChannelSelectionIter.first;
-    const ChannelSelection& nopChannelSelection =
-        nopChannelSelectionIter.second;
+  // Recompute the channel map based on this side's channels and priorities.
+  SelectedChannels selectedChannels = selectChannels(
+      context_->getOrderedChannels(),
+      nopBrochureAnswer.channelDeviceDescriptors);
+  channelForDevicePair_ = std::move(selectedChannels.channelForDevicePair);
 
+  // Verify that the locally and remotely computed channel maps are consistent.
+  TP_THROW_ASSERT_IF(
+      nopBrochureAnswer.channelForDevicePair.size() !=
+      channelForDevicePair_.size())
+      << "Inconsistent channel selection";
+  for (const auto& iter : channelForDevicePair_) {
+    Device localDevice;
+    Device remoteDevice;
+    std::tie(localDevice, remoteDevice) = iter.first;
+    const std::string& channelName = iter.second;
+
+    const auto& answerIter = nopBrochureAnswer.channelForDevicePair.find(
+        {remoteDevice, localDevice});
+
+    TP_THROW_ASSERT_IF(
+        answerIter == nopBrochureAnswer.channelForDevicePair.end())
+        << "Inconsistent channel selection";
+    TP_THROW_ASSERT_IF(answerIter->second != channelName)
+        << "Inconsistent channel selection";
+  }
+
+  for (const auto& channelDeviceDescriptorsIter :
+       selectedChannels.descriptorsMap) {
+    const std::string& channelName = channelDeviceDescriptorsIter.first;
     std::shared_ptr<channel::Context> channelContext =
         context_->getChannel(channelName);
 
-    for (const auto& localDescIter : channelContext->deviceDescriptors()) {
-      const std::string& localDeviceDescriptor = localDescIter.second;
-      for (const auto& remoteDescIter : nopChannelSelection.deviceDescriptors) {
-        const std::string& remoteDeviceDescriptor = remoteDescIter.second;
-        TP_DCHECK(channelContext->canCommunicateWithRemote(
-            localDeviceDescriptor, remoteDeviceDescriptor))
-            << "The two endpoints disagree on whether channel " << channelName
-            << " can be used to communicate";
-      }
-    }
-
+    const std::vector<uint64_t>& registrationIds =
+        nopBrochureAnswer.channelRegistrationIds.at(channelName);
     const size_t numConnectionsNeeded = channelContext->numConnectionsNeeded();
-    TP_DCHECK_EQ(
-        numConnectionsNeeded, nopChannelSelection.registrationIds.size());
+    TP_DCHECK_EQ(numConnectionsNeeded, registrationIds.size());
     std::vector<std::shared_ptr<transport::Connection>> connections(
         numConnectionsNeeded);
     for (size_t connId = 0; connId < numConnectionsNeeded; ++connId) {
@@ -1042,7 +1073,7 @@ void PipeImpl::onReadWhileClientWaitingForBrochureAnswer(
       nopPacketOut.Become(nopPacketOut.index_of<RequestedConnection>());
       RequestedConnection& nopRequestedConnection =
           *nopPacketOut.get<RequestedConnection>();
-      uint64_t token = nopChannelSelection.registrationIds[connId];
+      uint64_t token = registrationIds[connId];
       nopRequestedConnection.registrationId = token;
       TP_VLOG(3) << "Pipe " << id_
                  << " is writing nop object (requested connection)";

--- a/tensorpipe/core/pipe_impl.h
+++ b/tensorpipe/core/pipe_impl.h
@@ -69,9 +69,8 @@ struct ReadOperation {
   };
   std::vector<Payload> payloads;
   struct Tensor {
-    DeviceType type;
+    Device sourceDevice;
     ssize_t length{-1};
-    std::string channelName;
   };
   std::vector<Tensor> tensors;
 
@@ -96,11 +95,8 @@ struct WriteOperation {
   // Buffers provided by the user.
   Message message;
 
-  // Tensor descriptors collected from the channels.
-  struct Tensor {
-    DeviceType type;
-    std::string channelName;
-  };
+  // This is currently empty, but will be used again for XDTT channel selection.
+  struct Tensor {};
   std::vector<Tensor> tensors;
 };
 
@@ -174,6 +170,8 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
   std::shared_ptr<transport::Connection> connection_;
 
   std::unordered_map<std::string, std::shared_ptr<channel::Channel>> channels_;
+  std::unordered_map<std::pair<Device, Device>, std::string>
+      channelForDevicePair_;
 
   // The server will set this up when it tell the client to switch to a
   // different connection or to open some channels.


### PR DESCRIPTION
Summary:
This diff introduces a `channelMap_` in the Pipe which maps a device
pair to a channel. This map is computed during channel selection, and sent back
to the connecting endpoint. It is then used to pick a channel when
sending/receiving a tensor.

Currently, when the user calls `Pipe::write()`, the Pipe picks a channel _based
solely on the local device_, in order to conserve behavior until we implement
the channel negotiation roundtrip where the receiving endpoint picks the target
device (and hence the actual channel). This behavior is maintained by ensuring
that 1. a selected channel connects all pairs of devices (of its type), and 2.
exactly one channel is selected per device type.

Reviewed By: lw

Differential Revision: D27223196

