### PR TITLE
Fix data race in createContextId().

### DIFF
--- a/tensorpipe/core/context_impl.cc
+++ b/tensorpipe/core/context_impl.cc
@@ -11,6 +11,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <atomic>
 #include <memory>
 #include <string>
 #include <tuple>
@@ -33,7 +34,7 @@ namespace tensorpipe {
 
 namespace {
 
-uint64_t contextCouter{0};
+std::atomic<uint64_t> contextCouter{0};
 
 std::string createContextId() {
   // Should we use argv[0] instead of the PID? It may be more semantically


### PR DESCRIPTION
This (mostly harmless) data race has been there for quite some time, but only started manifesting itself now that we have tests creating multiple contexts from multiple threads in a same process.