### PR TITLE
Remove unnecessary copy of Message to heap in the Pipe.

### DIFF
--- a/tensorpipe/core/message.h
+++ b/tensorpipe/core/message.h
@@ -25,16 +25,6 @@ namespace tensorpipe {
 //
 class Message final {
  public:
-  Message() = default;
-
-  // Messages are movable.
-  Message(Message&&) = default;
-  Message& operator=(Message&&) = default;
-
-  // But they are not copyable.
-  Message(const Message&) = delete;
-  Message& operator=(const Message&) = delete;
-
   std::string metadata;
 
   struct Payload {

--- a/tensorpipe/core/pipe_impl.cc
+++ b/tensorpipe/core/pipe_impl.cc
@@ -415,13 +415,10 @@ void PipeImpl::readDescriptorFromLoop(read_descriptor_callback_fn fn) {
 }
 
 void PipeImpl::read(Message message, read_callback_fn fn) {
-  // Messages aren't copyable and thus if a lambda captures them it cannot be
-  // wrapped in a std::function. Therefore we wrap Messages in shared_ptrs.
-  auto sharedMessage = std::make_shared<Message>(std::move(message));
   context_->deferToLoop([impl{this->shared_from_this()},
-                         sharedMessage{std::move(sharedMessage)},
+                         message{std::move(message)},
                          fn{std::move(fn)}]() mutable {
-    impl->readFromLoop(std::move(*sharedMessage), std::move(fn));
+    impl->readFromLoop(std::move(message), std::move(fn));
   });
 }
 
@@ -516,13 +513,10 @@ void PipeImpl::readPayloadsAndReceiveTensorsOfMessage(ReadOpIter opIter) {
 }
 
 void PipeImpl::write(Message message, write_callback_fn fn) {
-  // Messages aren't copyable and thus if a lambda captures them it cannot be
-  // wrapped in a std::function. Therefore we wrap Messages in shared_ptrs.
-  auto sharedMessage = std::make_shared<Message>(std::move(message));
   context_->deferToLoop([impl{this->shared_from_this()},
-                         sharedMessage{std::move(sharedMessage)},
+                         message{std::move(message)},
                          fn{std::move(fn)}]() mutable {
-    impl->writeFromLoop(std::move(*sharedMessage), std::move(fn));
+    impl->writeFromLoop(std::move(message), std::move(fn));
   });
 }
 


### PR DESCRIPTION
Summary: This was a remnant of the time when `Message`s were not copiable.

Reviewed By: lw

Differential Revision: D27620188

