### PR TITLE
Introduce Message::Tensor::targetDevice.

### DIFF
--- a/tensorpipe/common/device.h
+++ b/tensorpipe/common/device.h
@@ -26,6 +26,13 @@ struct Device {
   std::string type;
   int index;
 
+  // This pointless constructor is needed to work around a bug in GCC 5.5 (and
+  // possibly other versions). It appears to be needed in the nop types that
+  // are used inside nop::Optional.
+  Device() {}
+
+  Device(std::string type, int index) : type(std::move(type)), index(index) {}
+
   // FIXME: This method will disappear once XDTT channel selection is
   // implemented.
   DeviceType deviceType() const {

--- a/tensorpipe/core/message.h
+++ b/tensorpipe/core/message.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include <tensorpipe/common/buffer.h>
+#include <tensorpipe/common/optional.h>
 
 namespace tensorpipe {
 
@@ -44,6 +45,11 @@ class Message final {
     size_t length{0};
 
     Device sourceDevice;
+
+    // Users may optionally specify the target device, on which the receiver
+    // should allocate memory for this tensor. If left unset, the receiver will
+    // choose one at their convenience.
+    optional<Device> targetDevice;
 
     // Users may include arbitrary metadata in the following field.
     // This may contain allocation hints for the receiver, for example.

--- a/tensorpipe/core/message.h
+++ b/tensorpipe/core/message.h
@@ -43,6 +43,8 @@ class Message final {
     tensorpipe::Buffer buffer;
     size_t length{0};
 
+    Device sourceDevice;
+
     // Users may include arbitrary metadata in the following field.
     // This may contain allocation hints for the receiver, for example.
     std::string metadata;

--- a/tensorpipe/core/message.h
+++ b/tensorpipe/core/message.h
@@ -25,16 +25,6 @@ namespace tensorpipe {
 //
 class Message final {
  public:
-  Message() = default;
-
-  // Messages are movable.
-  Message(Message&&) = default;
-  Message& operator=(Message&&) = default;
-
-  // But they are not copyable.
-  Message(const Message&) = delete;
-  Message& operator=(const Message&) = delete;
-
   std::string metadata;
 
   struct Payload {

--- a/tensorpipe/core/message.h
+++ b/tensorpipe/core/message.h
@@ -52,4 +52,8 @@ class Message final {
   std::vector<Tensor> tensors;
 };
 
+// FIXME: Remove once we introduce the proper Descriptor/Allocation structs.
+using Descriptor = Message;
+using Allocation = Message;
+
 } // namespace tensorpipe

--- a/tensorpipe/core/nop_types.h
+++ b/tensorpipe/core/nop_types.h
@@ -94,12 +94,14 @@ struct MessageDescriptor {
     std::string metadata;
 
     Device sourceDevice;
+    nop::Optional<Device> targetDevice;
     std::string channelName;
     NOP_STRUCTURE(
         TensorDescriptor,
         sizeInBytes,
         metadata,
         sourceDevice,
+        targetDevice,
         channelName);
   };
 

--- a/tensorpipe/core/nop_types.h
+++ b/tensorpipe/core/nop_types.h
@@ -14,6 +14,7 @@
 
 #include <nop/serializer.h>
 #include <nop/structure.h>
+#include <nop/types/optional.h>
 #include <nop/types/variant.h>
 
 #include <tensorpipe/common/buffer.h>
@@ -92,13 +93,13 @@ struct MessageDescriptor {
     int64_t sizeInBytes;
     std::string metadata;
 
-    DeviceType deviceType;
+    Device sourceDevice;
     std::string channelName;
     NOP_STRUCTURE(
         TensorDescriptor,
         sizeInBytes,
         metadata,
-        deviceType,
+        sourceDevice,
         channelName);
   };
 

--- a/tensorpipe/core/pipe.cc
+++ b/tensorpipe/core/pipe.cc
@@ -49,8 +49,16 @@ void Pipe::readDescriptor(read_descriptor_callback_fn fn) {
   impl_->readDescriptor(std::move(fn));
 }
 
+void Pipe::read(Allocation allocation, read_callback_deprecated_fn fn) {
+  impl_->read(std::move(allocation), std::move(fn));
+}
+
 void Pipe::read(Allocation allocation, read_callback_fn fn) {
   impl_->read(std::move(allocation), std::move(fn));
+}
+
+void Pipe::write(Message message, write_callback_deprecated_fn fn) {
+  impl_->write(std::move(message), std::move(fn));
 }
 
 void Pipe::write(Message message, write_callback_fn fn) {

--- a/tensorpipe/core/pipe.cc
+++ b/tensorpipe/core/pipe.cc
@@ -49,8 +49,8 @@ void Pipe::readDescriptor(read_descriptor_callback_fn fn) {
   impl_->readDescriptor(std::move(fn));
 }
 
-void Pipe::read(Message message, read_callback_fn fn) {
-  impl_->read(std::move(message), std::move(fn));
+void Pipe::read(Allocation allocation, read_callback_fn fn) {
+  impl_->read(std::move(allocation), std::move(fn));
 }
 
 void Pipe::write(Message message, write_callback_fn fn) {

--- a/tensorpipe/core/pipe.h
+++ b/tensorpipe/core/pipe.h
@@ -64,12 +64,18 @@ class Pipe final {
 
   void readDescriptor(read_descriptor_callback_fn fn);
 
-  using read_callback_fn = std::function<void(const Error&, Message)>;
+  using read_callback_deprecated_fn =
+      std::function<void(const Error&, Message)>;
+  using read_callback_fn = std::function<void(const Error&)>;
 
+  void read(Allocation allocation, read_callback_deprecated_fn fn);
   void read(Allocation allocation, read_callback_fn fn);
 
-  using write_callback_fn = std::function<void(const Error&, Message)>;
+  using write_callback_deprecated_fn =
+      std::function<void(const Error&, Message)>;
+  using write_callback_fn = std::function<void(const Error&)>;
 
+  void write(Message message, write_callback_deprecated_fn fn);
   void write(Message message, write_callback_fn fn);
 
   // Retrieve the user-defined name that was given to the constructor of the

--- a/tensorpipe/core/pipe.h
+++ b/tensorpipe/core/pipe.h
@@ -60,13 +60,13 @@ class Pipe final {
   //
 
   using read_descriptor_callback_fn =
-      std::function<void(const Error&, Message)>;
+      std::function<void(const Error&, Descriptor)>;
 
   void readDescriptor(read_descriptor_callback_fn fn);
 
   using read_callback_fn = std::function<void(const Error&, Message)>;
 
-  void read(Message message, read_callback_fn fn);
+  void read(Allocation allocation, read_callback_fn fn);
 
   using write_callback_fn = std::function<void(const Error&, Message)>;
 

--- a/tensorpipe/core/pipe_impl.cc
+++ b/tensorpipe/core/pipe_impl.cc
@@ -415,13 +415,10 @@ void PipeImpl::readDescriptorFromLoop(read_descriptor_callback_fn fn) {
 }
 
 void PipeImpl::read(Message message, read_callback_fn fn) {
-  // Messages aren't copyable and thus if a lambda captures them it cannot be
-  // wrapped in a std::function. Therefore we wrap Messages in shared_ptrs.
-  auto sharedMessage = std::make_shared<Message>(std::move(message));
   context_->deferToLoop([impl{this->shared_from_this()},
-                         sharedMessage{std::move(sharedMessage)},
+                         message{std::move(message)},
                          fn{std::move(fn)}]() mutable {
-    impl->readFromLoop(std::move(*sharedMessage), std::move(fn));
+    impl->readFromLoop(std::move(message), std::move(fn));
   });
 }
 
@@ -516,13 +513,10 @@ void PipeImpl::readPayloadsAndReceiveTensorsOfMessage(ReadOpIter opIter) {
 }
 
 void PipeImpl::write(Message message, write_callback_fn fn) {
-  // Messages aren't copyable and thus if a lambda captures them it cannot be
-  // wrapped in a std::function. Therefore we wrap Messages in shared_ptrs.
-  auto sharedMessage = std::make_shared<Message>(std::move(message));
   context_->deferToLoop([impl{this->shared_from_this()},
-                         sharedMessage{std::move(sharedMessage)},
+                         message{std::move(message)},
                          fn{std::move(fn)}]() mutable {
-    impl->writeFromLoop(std::move(*sharedMessage), std::move(fn));
+    impl->writeFromLoop(std::move(message), std::move(fn));
   });
 }
 

--- a/tensorpipe/core/pipe_impl.h
+++ b/tensorpipe/core/pipe_impl.h
@@ -64,7 +64,6 @@ struct ReadOperation {
   Pipe::read_callback_deprecated_fn readCallback;
 
   struct Tensor {
-    DeviceType type;
     std::string channelName;
   };
   std::vector<Tensor> tensors;
@@ -93,7 +92,6 @@ struct WriteOperation {
 
   // Tensor descriptors collected from the channels.
   struct Tensor {
-    DeviceType type;
     std::string channelName;
   };
   std::vector<Tensor> tensors;

--- a/tensorpipe/core/pipe_impl.h
+++ b/tensorpipe/core/pipe_impl.h
@@ -61,7 +61,7 @@ struct ReadOperation {
 
   // Callbacks.
   Pipe::read_descriptor_callback_fn readDescriptorCallback;
-  Pipe::read_callback_fn readCallback;
+  Pipe::read_callback_deprecated_fn readCallback;
 
   struct Tensor {
     DeviceType type;
@@ -86,7 +86,7 @@ struct WriteOperation {
   uint64_t numTensorsBeingSent{0};
 
   // Callbacks.
-  Pipe::write_callback_fn writeCallback;
+  Pipe::write_callback_deprecated_fn writeCallback;
 
   // Buffers provided by the user.
   Message message;
@@ -119,11 +119,15 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
   void init();
 
   using read_descriptor_callback_fn = Pipe::read_descriptor_callback_fn;
+  using read_callback_deprecated_fn = Pipe::read_callback_deprecated_fn;
   using read_callback_fn = Pipe::read_callback_fn;
+  using write_callback_deprecated_fn = Pipe::write_callback_deprecated_fn;
   using write_callback_fn = Pipe::write_callback_fn;
 
   void readDescriptor(read_descriptor_callback_fn fn);
+  void read(Allocation allocation, read_callback_deprecated_fn fn);
   void read(Allocation allocation, read_callback_fn fn);
+  void write(Message message, write_callback_deprecated_fn fn);
   void write(Message message, write_callback_fn fn);
 
   const std::string& getRemoteName();
@@ -135,9 +139,9 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
 
   void readDescriptorFromLoop(read_descriptor_callback_fn fn);
 
-  void readFromLoop(Allocation allocation, read_callback_fn fn);
+  void readFromLoop(Allocation allocation, read_callback_deprecated_fn fn);
 
-  void writeFromLoop(Message message, write_callback_fn fn);
+  void writeFromLoop(Message message, write_callback_deprecated_fn fn);
 
   void closeFromLoop();
 

--- a/tensorpipe/core/pipe_impl.h
+++ b/tensorpipe/core/pipe_impl.h
@@ -63,20 +63,15 @@ struct ReadOperation {
   Pipe::read_descriptor_callback_fn readDescriptorCallback;
   Pipe::read_callback_fn readCallback;
 
-  // Metadata found in the descriptor read from the connection.
-  struct Payload {
-    ssize_t length{-1};
-  };
-  std::vector<Payload> payloads;
   struct Tensor {
     DeviceType type;
-    ssize_t length{-1};
     std::string channelName;
   };
   std::vector<Tensor> tensors;
 
+  Descriptor descriptor;
   // Buffers allocated by the user.
-  Message message;
+  Allocation allocation;
 };
 
 struct WriteOperation {
@@ -128,7 +123,7 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
   using write_callback_fn = Pipe::write_callback_fn;
 
   void readDescriptor(read_descriptor_callback_fn fn);
-  void read(Message message, read_callback_fn fn);
+  void read(Allocation allocation, read_callback_fn fn);
   void write(Message message, write_callback_fn fn);
 
   const std::string& getRemoteName();
@@ -140,7 +135,7 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
 
   void readDescriptorFromLoop(read_descriptor_callback_fn fn);
 
-  void readFromLoop(Message message, read_callback_fn fn);
+  void readFromLoop(Allocation allocation, read_callback_fn fn);
 
   void writeFromLoop(Message message, write_callback_fn fn);
 


### PR DESCRIPTION
Summary:
This field will remain in Message and Descriptor. It is meant for the
user to specify a target device on which a given tensor must be received.

Differential Revision: D27691722

