### PR TITLE
New Pipe API.

### DIFF
--- a/tensorpipe/core/message.h
+++ b/tensorpipe/core/message.h
@@ -44,8 +44,6 @@ class Message final {
     tensorpipe::Buffer buffer;
     size_t length{0};
 
-    Device sourceDevice;
-
     // Users may optionally specify the target device, on which the receiver
     // should allocate memory for this tensor. If left unset, the receiver will
     // choose one at their convenience.
@@ -60,8 +58,47 @@ class Message final {
   std::vector<Tensor> tensors;
 };
 
-// FIXME: Remove once we introduce the proper Descriptor/Allocation structs.
-using Descriptor = Message;
-using Allocation = Message;
+// Descriptors consist of metadata required by the receiver to allocate memory
+// for an incoming message.
+class Descriptor final {
+ public:
+  std::string metadata;
+
+  struct Payload {
+    size_t length{0};
+    std::string metadata;
+  };
+  std::vector<Payload> payloads;
+
+  struct Tensor {
+    size_t length{0};
+
+    // This is the sender-side device from which this tensor is being sent.
+    Device sourceDevice;
+
+    // The sender may optionally specify a target device, in which case the
+    // receiver must allocate memory for this tensor on the specified device.
+    optional<Device> targetDevice;
+
+    std::string metadata;
+  };
+  std::vector<Tensor> tensors;
+};
+
+// Allocations consist of actual memory allocations provided by the receiver for
+// an incoming message. They must match the length and target devices specified
+// in the corresponding Descriptor.
+class Allocation final {
+ public:
+  struct Payload {
+    void* data{nullptr};
+  };
+  std::vector<Payload> payloads;
+
+  struct Tensor {
+    tensorpipe::Buffer buffer;
+  };
+  std::vector<Tensor> tensors;
+};
 
 } // namespace tensorpipe

--- a/tensorpipe/core/nop_types.h
+++ b/tensorpipe/core/nop_types.h
@@ -95,6 +95,8 @@ struct MessageDescriptor {
 
     Device sourceDevice;
     nop::Optional<Device> targetDevice;
+    // FIXME: Once we get rid of channelName, we can merge Descriptor and
+    // MessageDescriptor.
     std::string channelName;
     NOP_STRUCTURE(
         TensorDescriptor,

--- a/tensorpipe/core/pipe_impl.cc
+++ b/tensorpipe/core/pipe_impl.cc
@@ -59,15 +59,6 @@ void parseDescriptorOfMessage(ReadOperation& op, const Packet& nopPacketIn) {
     if (!nopTensorDescriptor.targetDevice.empty()) {
       tensor.targetDevice = nopTensorDescriptor.targetDevice.get();
     }
-    if (tensor.sourceDevice.type == kCpuDeviceType) {
-      tensor.buffer = CpuBuffer{};
-#if TENSORPIPE_SUPPORTS_CUDA
-    } else if (tensor.sourceDevice.type == kCudaDeviceType) {
-      tensor.buffer = CudaBuffer{};
-#endif // TENSORPIPE_SUPPORTS_CUDA
-    } else {
-      TP_THROW_ASSERT() << "Unexpected device type.";
-    };
   }
 }
 
@@ -591,7 +582,6 @@ void PipeImpl::callReadCallback(ReadOpIter opIter) {
   for (int i = 0; i < op.descriptor.tensors.size(); ++i) {
     message.tensors[i].metadata = op.descriptor.tensors[i].metadata;
     message.tensors[i].length = op.descriptor.tensors[i].length;
-    message.tensors[i].sourceDevice = op.descriptor.tensors[i].sourceDevice;
     message.tensors[i].buffer = op.allocation.tensors[i].buffer;
   }
 


### PR DESCRIPTION
Summary:
In order to prevent future backwards-breaking changes to our API, we
make all the changes we will need in the foreseeable future in this diff. In
practice, we introduce distinct structs `Descriptor` and `Allocation` for
`readDescriptor()`/`read()` respectively, since the fields in `Message` were
starting to diverge.

Reviewed By: lw

Differential Revision: D27365176

