### PR TITLE
Add XDTT support to CudaBasic.

### DIFF
--- a/tensorpipe/channel/cuda_basic/channel_impl.h
+++ b/tensorpipe/channel/cuda_basic/channel_impl.h
@@ -41,13 +41,16 @@ struct ChunkSendOperation {
 
   // Arguments at creation
   uint64_t bufferSequenceNumber{0};
+  bool isCpuBuffer{false};
+  void* devicePtr{nullptr};
   size_t chunkId{0};
   size_t numChunks{0};
-  cudaStream_t stream{cudaStreamDefault};
-  int deviceIdx{0};
-  void* cudaPtr{nullptr};
   size_t length{0};
   std::function<void(const Error&)> callback;
+
+  // For CUDA buffers
+  cudaStream_t stream{cudaStreamDefault};
+  int deviceIdx{0};
 
   // Data collected during processing
   std::shared_ptr<uint8_t> tmpBuffer;
@@ -75,13 +78,16 @@ struct ChunkRecvOperation {
 
   // Arguments at creation
   uint64_t bufferSequenceNumber{0};
+  bool isCpuBuffer{false};
+  void* devicePtr{nullptr};
   size_t chunkId{0};
   size_t numChunks{0};
-  cudaStream_t stream{cudaStreamDefault};
-  int deviceIdx{0};
-  void* cudaPtr{nullptr};
   size_t length{0};
   std::function<void(const Error&)> callback;
+
+  // For CUDA buffers
+  cudaStream_t stream{cudaStreamDefault};
+  int deviceIdx{0};
 
   // Data collected during processing
   std::shared_ptr<uint8_t> tmpBuffer;

--- a/tensorpipe/channel/cuda_basic/context_impl.cc
+++ b/tensorpipe/channel/cuda_basic/context_impl.cc
@@ -48,6 +48,7 @@ std::shared_ptr<ContextImpl> ContextImpl::create(
       cpuContext->deviceDescriptors().count(Device{kCpuDeviceType, 0}), 1);
   const auto cpuDeviceDescriptor =
       cpuContext->deviceDescriptors().begin()->second;
+  deviceDescriptors[Device{kCpuDeviceType, 0}] = cpuDeviceDescriptor;
   for (const auto& device : getCudaDevices(cudaLib)) {
     deviceDescriptors[device] = cpuDeviceDescriptor;
   }

--- a/tensorpipe/test/CMakeLists.txt
+++ b/tensorpipe/test/CMakeLists.txt
@@ -63,6 +63,7 @@ if(TP_USE_CUDA)
   target_sources(tensorpipe_test PRIVATE
     channel/channel_test_cuda.cc
     channel/channel_test_cuda_multi_gpu.cc
+    channel/channel_test_cuda_xdtt.cc
     common/cuda_test.cc
     )
 

--- a/tensorpipe/test/channel/channel_test_cuda.h
+++ b/tensorpipe/test/channel/channel_test_cuda.h
@@ -90,3 +90,6 @@ class CudaChannelTestSuite
 
 class CudaMultiGPUChannelTestSuite
     : public ::testing::TestWithParam<CudaChannelTestHelper*> {};
+
+class CudaXDTTChannelTestSuite
+    : public ::testing::TestWithParam<CudaChannelTestHelper*> {};

--- a/tensorpipe/test/channel/channel_test_cuda_xdtt.cc
+++ b/tensorpipe/test/channel/channel_test_cuda_xdtt.cc
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/test/channel/channel_test_cuda.h>
+
+#include <cuda_runtime.h>
+#include <gmock/gmock.h>
+
+#include <tensorpipe/test/channel/kernel.cuh>
+
+using namespace tensorpipe;
+using namespace tensorpipe::channel;
+
+class SendFromCpuToGpuTest : public ClientServerChannelTestCase {
+  static constexpr size_t kSize = 1024;
+
+  void server(std::shared_ptr<Channel> channel) override {
+    // Perform send and wait for completion.
+    auto sendPromise = std::make_shared<std::promise<tensorpipe::Error>>();
+    auto sendFuture = sendPromise->get_future();
+
+    std::vector<uint8_t> data(kSize, 0x42);
+    channel->send(
+        CpuBuffer{
+            .ptr = data.data(),
+        },
+        kSize,
+        [sendPromise{std::move(sendPromise)}](const tensorpipe::Error& error) {
+          sendPromise->set_value(error);
+        });
+
+    Error sendError = sendFuture.get();
+    EXPECT_FALSE(sendError) << sendError.what();
+
+    this->peers_->done(PeerGroup::kServer);
+    this->peers_->join(PeerGroup::kServer);
+  }
+
+  void client(std::shared_ptr<Channel> channel) override {
+    TP_CUDA_CHECK(cudaSetDevice(0));
+    cudaStream_t recvStream;
+    TP_CUDA_CHECK(
+        cudaStreamCreateWithFlags(&recvStream, cudaStreamNonBlocking));
+    void* ptr;
+    TP_CUDA_CHECK(cudaMalloc(&ptr, kSize));
+
+    // Perform recv and wait for completion.
+    auto recvPromise = std::make_shared<std::promise<tensorpipe::Error>>();
+    auto recvFuture = recvPromise->get_future();
+
+    channel->recv(
+        CudaBuffer{
+            .ptr = ptr,
+            .stream = recvStream,
+        },
+        kSize,
+        [recvPromise{std::move(recvPromise)}](const tensorpipe::Error& error) {
+          recvPromise->set_value(error);
+        });
+
+    Error recvError = recvFuture.get();
+    EXPECT_FALSE(recvError) << recvError.what();
+
+    std::array<uint8_t, kSize> data;
+    TP_CUDA_CHECK(cudaStreamSynchronize(recvStream));
+    TP_CUDA_CHECK(cudaMemcpy(data.data(), ptr, kSize, cudaMemcpyDefault));
+    EXPECT_THAT(data, ::testing::Each(0x42));
+    TP_CUDA_CHECK(cudaFree(ptr));
+
+    this->peers_->done(PeerGroup::kClient);
+    this->peers_->join(PeerGroup::kClient);
+  }
+};
+
+CHANNEL_TEST(CudaXDTTChannelTestSuite, SendFromCpuToGpu);
+
+class SendFromGpuToCpuTest : public ClientServerChannelTestCase {
+  static constexpr size_t kSize = 1024;
+
+  void server(std::shared_ptr<Channel> channel) override {
+    TP_CUDA_CHECK(cudaSetDevice(0));
+    cudaStream_t sendStream;
+    TP_CUDA_CHECK(
+        cudaStreamCreateWithFlags(&sendStream, cudaStreamNonBlocking));
+    void* ptr;
+    TP_CUDA_CHECK(cudaMalloc(&ptr, kSize));
+
+    // Set buffer to target value.
+    TP_CUDA_CHECK(cudaMemsetAsync(ptr, 0x42, kSize, sendStream));
+
+    // Perform send and wait for completion.
+    auto sendPromise = std::make_shared<std::promise<tensorpipe::Error>>();
+    auto sendFuture = sendPromise->get_future();
+
+    channel->send(
+        CudaBuffer{
+            .ptr = ptr,
+            .stream = sendStream,
+        },
+        kSize,
+        [sendPromise{std::move(sendPromise)}](const tensorpipe::Error& error) {
+          sendPromise->set_value(error);
+        });
+
+    Error sendError = sendFuture.get();
+    EXPECT_FALSE(sendError) << sendError.what();
+    TP_CUDA_CHECK(cudaFree(ptr));
+
+    this->peers_->done(PeerGroup::kServer);
+    this->peers_->join(PeerGroup::kServer);
+  }
+
+  void client(std::shared_ptr<Channel> channel) override {
+    // Perform recv and wait for completion.
+    auto recvPromise = std::make_shared<std::promise<tensorpipe::Error>>();
+    auto recvFuture = recvPromise->get_future();
+
+    std::vector<uint8_t> data(kSize);
+    channel->recv(
+        CpuBuffer{
+            .ptr = data.data(),
+        },
+        kSize,
+        [recvPromise{std::move(recvPromise)}](const tensorpipe::Error& error) {
+          recvPromise->set_value(error);
+        });
+
+    Error recvError = recvFuture.get();
+    EXPECT_FALSE(recvError) << recvError.what();
+
+    EXPECT_THAT(data, ::testing::Each(0x42));
+
+    this->peers_->done(PeerGroup::kClient);
+    this->peers_->join(PeerGroup::kClient);
+  }
+};
+
+CHANNEL_TEST(CudaXDTTChannelTestSuite, SendFromGpuToCpu);
+
+class SendFromCpuToCpuTest : public ClientServerChannelTestCase {
+  static constexpr size_t kSize = 1024;
+
+  void server(std::shared_ptr<Channel> channel) override {
+    // Perform send and wait for completion.
+    auto sendPromise = std::make_shared<std::promise<tensorpipe::Error>>();
+    auto sendFuture = sendPromise->get_future();
+
+    std::vector<uint8_t> data(kSize, 0x42);
+    channel->send(
+        CpuBuffer{
+            .ptr = data.data(),
+        },
+        kSize,
+        [sendPromise{std::move(sendPromise)}](const tensorpipe::Error& error) {
+          sendPromise->set_value(error);
+        });
+
+    Error sendError = sendFuture.get();
+    EXPECT_FALSE(sendError) << sendError.what();
+
+    this->peers_->done(PeerGroup::kServer);
+    this->peers_->join(PeerGroup::kServer);
+  }
+
+  void client(std::shared_ptr<Channel> channel) override {
+    // Perform recv and wait for completion.
+    auto recvPromise = std::make_shared<std::promise<tensorpipe::Error>>();
+    auto recvFuture = recvPromise->get_future();
+
+    std::vector<uint8_t> data(kSize);
+    channel->recv(
+        CpuBuffer{
+            .ptr = data.data(),
+        },
+        kSize,
+        [recvPromise{std::move(recvPromise)}](const tensorpipe::Error& error) {
+          recvPromise->set_value(error);
+        });
+
+    Error recvError = recvFuture.get();
+    EXPECT_FALSE(recvError) << recvError.what();
+
+    EXPECT_THAT(data, ::testing::Each(0x42));
+
+    this->peers_->done(PeerGroup::kClient);
+    this->peers_->join(PeerGroup::kClient);
+  }
+};
+
+CHANNEL_TEST(CudaXDTTChannelTestSuite, SendFromCpuToCpu);

--- a/tensorpipe/test/channel/cuda_basic/cuda_basic_test.cc
+++ b/tensorpipe/test/channel/cuda_basic/cuda_basic_test.cc
@@ -49,3 +49,8 @@ INSTANTIATE_TEST_CASE_P(
     CudaBasic,
     CudaMultiGPUChannelTestSuite,
     ::testing::Values(&helper));
+
+INSTANTIATE_TEST_CASE_P(
+    CudaBasic,
+    CudaXDTTChannelTestSuite,
+    ::testing::Values(&helper));


### PR DESCRIPTION
Summary:
In this diff, we add support for XDTT in CudaBasic. This is done by
adding an `isCpuBuffer` boolean flag to the `Chunk{Send,Recv}Operation`s, which
triggers shortcutting allocation/copy to staging memory.

Differential Revision: D27785209

