### PR TITLE
Add test for client and server sending message at the same time.

### DIFF
--- a/tensorpipe/channel/basic/context_impl.cc
+++ b/tensorpipe/channel/basic/context_impl.cc
@@ -35,10 +35,6 @@ std::shared_ptr<Channel> ContextImpl::createChannel(
   return createChannelInternal(std::move(connections[0]));
 }
 
-bool ContextImpl::supportsDeviceType(DeviceType type) const {
-  return (DeviceType::kCpu == type);
-}
-
 void ContextImpl::handleErrorImpl() {}
 
 void ContextImpl::joinImpl() {}

--- a/tensorpipe/channel/basic/context_impl.h
+++ b/tensorpipe/channel/basic/context_impl.h
@@ -32,8 +32,6 @@ class ContextImpl final
       std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint);
 
-  bool supportsDeviceType(DeviceType type) const override;
-
   // Implement the DeferredExecutor interface.
   bool inLoop() const override;
   void deferToLoop(std::function<void()> fn) override;

--- a/tensorpipe/channel/cma/context_impl.cc
+++ b/tensorpipe/channel/cma/context_impl.cc
@@ -260,10 +260,6 @@ size_t ContextImpl::numConnectionsNeeded() const {
   return 2;
 }
 
-bool ContextImpl::supportsDeviceType(DeviceType type) const {
-  return (DeviceType::kCpu == type);
-}
-
 void ContextImpl::handleErrorImpl() {
   requests_.push(nullopt);
 }

--- a/tensorpipe/channel/cma/context_impl.h
+++ b/tensorpipe/channel/cma/context_impl.h
@@ -39,8 +39,6 @@ class ContextImpl final
 
   size_t numConnectionsNeeded() const override;
 
-  bool supportsDeviceType(DeviceType type) const override;
-
   // Implement the DeferredExecutor interface.
   bool inLoop() const override;
   void deferToLoop(std::function<void()> fn) override;

--- a/tensorpipe/channel/context.h
+++ b/tensorpipe/channel/context.h
@@ -100,11 +100,6 @@ class Context {
 
   virtual ~Context() = default;
 
-  // FIXME: This is a private, temporary, API. It will be removed once
-  // TensorPipe supports cross-device type transfers.
-  // DO NOT USE IT.
-  virtual bool supportsDeviceType(DeviceType type) const = 0;
-
  private:
   std::string name_;
 };

--- a/tensorpipe/channel/context_boilerplate.h
+++ b/tensorpipe/channel/context_boilerplate.h
@@ -54,9 +54,6 @@ class ContextBoilerplate : public Context {
 
   ~ContextBoilerplate() override;
 
-  // FIXME: Private, temporary API.
-  bool supportsDeviceType(DeviceType type) const override;
-
  protected:
   // The implementation is managed by a shared_ptr because each child object
   // will also hold a shared_ptr to it. However, its lifetime is tied to the one
@@ -149,16 +146,6 @@ void ContextBoilerplate<TCtx, TChan>::join() {
 template <typename TCtx, typename TChan>
 ContextBoilerplate<TCtx, TChan>::~ContextBoilerplate() {
   join();
-}
-
-// FIXME
-template <typename TCtx, typename TChan>
-bool ContextBoilerplate<TCtx, TChan>::supportsDeviceType(
-    DeviceType type) const {
-  if (unlikely(!impl_)) {
-    return false;
-  }
-  return impl_->supportsDeviceType(type);
 }
 
 } // namespace channel

--- a/tensorpipe/channel/context_impl_boilerplate.h
+++ b/tensorpipe/channel/context_impl_boilerplate.h
@@ -66,9 +66,6 @@ class ContextImplBoilerplate : public virtual DeferredExecutor,
 
   virtual ~ContextImplBoilerplate() = default;
 
-  // FIXME: Private, temporary API.
-  virtual bool supportsDeviceType(DeviceType type) const = 0;
-
  protected:
   virtual void initImplFromLoop() {}
   virtual void handleErrorImpl() = 0;

--- a/tensorpipe/channel/cuda_basic/context_impl.cc
+++ b/tensorpipe/channel/cuda_basic/context_impl.cc
@@ -32,9 +32,9 @@ std::shared_ptr<ContextImpl> ContextImpl::create(
     return nullptr;
   }
 
-  if (!cpuContext->supportsDeviceType(DeviceType::kCpu)) {
-    TP_VLOG(5) << "CUDA basic channel is not viable because the provided CPU"
-                  "channel does not support CPU buffers";
+  if (cpuContext->deviceDescriptors().count(Device{kCpuDeviceType, 0}) == 0) {
+    TP_THROW_ASSERT() << "CUDA basic channel needs a CPU channel";
+
     return nullptr;
   }
 
@@ -79,10 +79,6 @@ std::shared_ptr<Channel> ContextImpl::createChannel(
 
 size_t ContextImpl::numConnectionsNeeded() const {
   return 1 + cpuContext_->numConnectionsNeeded();
-}
-
-bool ContextImpl::supportsDeviceType(DeviceType type) const {
-  return (DeviceType::kCuda == type);
 }
 
 const CudaLib& ContextImpl::getCudaLib() {

--- a/tensorpipe/channel/cuda_basic/context_impl.h
+++ b/tensorpipe/channel/cuda_basic/context_impl.h
@@ -41,8 +41,6 @@ class ContextImpl final
 
   size_t numConnectionsNeeded() const override;
 
-  bool supportsDeviceType(DeviceType type) const override;
-
   const CudaLib& getCudaLib();
   Allocator& getCudaHostSendAllocator(int deviceIdx);
   Allocator& getCudaHostRecvAllocator(int deviceIdx);

--- a/tensorpipe/channel/cuda_gdr/context_impl.cc
+++ b/tensorpipe/channel/cuda_gdr/context_impl.cc
@@ -652,10 +652,6 @@ size_t ContextImpl::numConnectionsNeeded() const {
   return 2;
 }
 
-bool ContextImpl::supportsDeviceType(DeviceType type) const {
-  return (DeviceType::kCuda == type);
-}
-
 } // namespace cuda_gdr
 } // namespace channel
 } // namespace tensorpipe

--- a/tensorpipe/channel/cuda_gdr/context_impl.h
+++ b/tensorpipe/channel/cuda_gdr/context_impl.h
@@ -139,8 +139,6 @@ class ContextImpl final
 
   size_t numConnectionsNeeded() const override;
 
-  bool supportsDeviceType(DeviceType type) const override;
-
   const CudaLib& getCudaLib();
 
   const std::vector<size_t>& getGpuToNicMapping();

--- a/tensorpipe/channel/cuda_ipc/context_impl.cc
+++ b/tensorpipe/channel/cuda_ipc/context_impl.cc
@@ -301,10 +301,6 @@ size_t ContextImpl::numConnectionsNeeded() const {
   return 2;
 }
 
-bool ContextImpl::supportsDeviceType(DeviceType type) const {
-  return (DeviceType::kCuda == type);
-}
-
 bool ContextImpl::canCommunicateWithRemote(
     const std::string& localDeviceDescriptor,
     const std::string& remoteDeviceDescriptor) const {

--- a/tensorpipe/channel/cuda_ipc/context_impl.h
+++ b/tensorpipe/channel/cuda_ipc/context_impl.h
@@ -46,8 +46,6 @@ class ContextImpl final
 
   size_t numConnectionsNeeded() const override;
 
-  bool supportsDeviceType(DeviceType type) const override;
-
   bool canCommunicateWithRemote(
       const std::string& localDeviceDescriptor,
       const std::string& remoteDeviceDescriptor) const override;

--- a/tensorpipe/channel/cuda_xth/context_impl.cc
+++ b/tensorpipe/channel/cuda_xth/context_impl.cc
@@ -100,10 +100,6 @@ size_t ContextImpl::numConnectionsNeeded() const {
   return 2;
 }
 
-bool ContextImpl::supportsDeviceType(DeviceType type) const {
-  return (DeviceType::kCuda == type);
-}
-
 const CudaLib& ContextImpl::getCudaLib() {
   return cudaLib_;
 }

--- a/tensorpipe/channel/cuda_xth/context_impl.h
+++ b/tensorpipe/channel/cuda_xth/context_impl.h
@@ -34,8 +34,6 @@ class ContextImpl final
 
   size_t numConnectionsNeeded() const override;
 
-  bool supportsDeviceType(DeviceType type) const override;
-
   const CudaLib& getCudaLib();
 
   // Implement the DeferredExecutor interface.

--- a/tensorpipe/channel/mpt/context_impl.cc
+++ b/tensorpipe/channel/mpt/context_impl.cc
@@ -88,10 +88,6 @@ std::shared_ptr<Channel> ContextImpl::createChannel(
   return createChannelInternal(std::move(connections[0]), endpoint, numLanes_);
 }
 
-bool ContextImpl::supportsDeviceType(DeviceType type) const {
-  return (DeviceType::kCpu == type);
-}
-
 const std::vector<std::string>& ContextImpl::addresses() const {
   // As this is an immutable member (after it has been initialized in
   // the constructor), we'll access it without deferring to the loop.

--- a/tensorpipe/channel/mpt/context_impl.h
+++ b/tensorpipe/channel/mpt/context_impl.h
@@ -45,8 +45,6 @@ class ContextImpl final
       std::vector<std::shared_ptr<transport::Connection>> connections,
       Endpoint endpoint);
 
-  bool supportsDeviceType(DeviceType type) const override;
-
   // Implement the DeferredExecutor interface.
   bool inLoop() const override;
   void deferToLoop(std::function<void()> fn) override;

--- a/tensorpipe/channel/xth/context_impl.cc
+++ b/tensorpipe/channel/xth/context_impl.cc
@@ -72,10 +72,6 @@ size_t ContextImpl::numConnectionsNeeded() const {
   return 2;
 }
 
-bool ContextImpl::supportsDeviceType(DeviceType type) const {
-  return (DeviceType::kCpu == type);
-}
-
 void ContextImpl::handleErrorImpl() {
   requests_.push(nullopt);
 }

--- a/tensorpipe/channel/xth/context_impl.h
+++ b/tensorpipe/channel/xth/context_impl.h
@@ -39,8 +39,6 @@ class ContextImpl final
 
   size_t numConnectionsNeeded() const override;
 
-  bool supportsDeviceType(DeviceType type) const override;
-
   // Implement the DeferredExecutor interface.
   bool inLoop() const override;
   void deferToLoop(std::function<void()> fn) override;

--- a/tensorpipe/common/buffer.h
+++ b/tensorpipe/common/buffer.h
@@ -21,7 +21,6 @@ namespace tensorpipe {
 class Buffer {
   class AbstractBufferWrapper {
    public:
-    virtual DeviceType deviceType() const = 0;
     virtual Device device() const = 0;
     virtual void copyConstructInto(void* ptr) const = 0;
     virtual void moveConstructInto(void* ptr) = 0;
@@ -38,10 +37,6 @@ class Buffer {
     TBuffer buffer;
 
     explicit BufferWrapper(TBuffer buffer) : buffer(std::move(buffer)) {}
-
-    DeviceType deviceType() const override {
-      return buffer.deviceType();
-    }
 
     Device device() const override {
       return buffer.getDevice();
@@ -115,10 +110,6 @@ class Buffer {
       throw std::runtime_error("Invalid unwrapping of tensorpipe::Buffer");
     }
     return wrapperPtr->buffer;
-  }
-
-  DeviceType deviceType() const {
-    return ptr()->deviceType();
   }
 
   Device device() const {

--- a/tensorpipe/common/cpu_buffer.h
+++ b/tensorpipe/common/cpu_buffer.h
@@ -18,10 +18,6 @@ struct CpuBuffer {
   Device getDevice() const {
     return Device{kCpuDeviceType, 0};
   }
-
-  DeviceType deviceType() const {
-    return DeviceType::kCpu;
-  }
 };
 
 } // namespace tensorpipe

--- a/tensorpipe/common/cuda_buffer.h
+++ b/tensorpipe/common/cuda_buffer.h
@@ -19,10 +19,6 @@ struct CudaBuffer {
   cudaStream_t stream{cudaStreamDefault};
 
   Device getDevice() const;
-
-  DeviceType deviceType() const {
-    return DeviceType::kCuda;
-  }
 };
 
 } // namespace tensorpipe

--- a/tensorpipe/common/device.h
+++ b/tensorpipe/common/device.h
@@ -14,11 +14,6 @@
 
 namespace tensorpipe {
 
-enum class DeviceType {
-  kCpu,
-  kCuda,
-};
-
 const std::string kCpuDeviceType{"cpu"};
 const std::string kCudaDeviceType{"cuda"};
 
@@ -32,18 +27,6 @@ struct Device {
   Device() {}
 
   Device(std::string type, int index) : type(std::move(type)), index(index) {}
-
-  // FIXME: This method will disappear once XDTT channel selection is
-  // implemented.
-  DeviceType deviceType() const {
-    if (type == "cpu") {
-      return DeviceType::kCpu;
-    } else if (type == "cuda") {
-      return DeviceType::kCuda;
-    } else {
-      throw std::runtime_error("Invalid device type " + type);
-    }
-  }
 
   std::string toString() const {
     std::stringstream ss;

--- a/tensorpipe/common/device.h
+++ b/tensorpipe/common/device.h
@@ -67,4 +67,15 @@ struct hash<::tensorpipe::Device> {
   }
 };
 
+template <>
+struct hash<std::pair<::tensorpipe::Device, ::tensorpipe::Device>> {
+  size_t operator()(const std::pair<::tensorpipe::Device, ::tensorpipe::Device>&
+                        p) const noexcept {
+    size_t h1 = std::hash<::tensorpipe::Device>{}(p.first);
+    size_t h2 = std::hash<::tensorpipe::Device>{}(p.second);
+    // Shifting one hash to avoid collisions between (a, b) and (b, a).
+    return h1 ^ (h2 << 1);
+  }
+};
+
 } // namespace std

--- a/tensorpipe/core/nop_types.h
+++ b/tensorpipe/core/nop_types.h
@@ -17,7 +17,6 @@
 #include <nop/types/optional.h>
 #include <nop/types/variant.h>
 
-#include <tensorpipe/common/buffer.h>
 #include <tensorpipe/common/device.h>
 
 namespace tensorpipe {
@@ -32,29 +31,13 @@ struct RequestedConnection {
   NOP_STRUCTURE(RequestedConnection, registrationId);
 };
 
-struct TransportAdvertisement {
-  std::string domainDescriptor;
-  NOP_STRUCTURE(TransportAdvertisement, domainDescriptor);
-};
-
 NOP_EXTERNAL_STRUCTURE(Device, type, index);
 
-struct ChannelAdvertisement {
-  std::unordered_map<Device, std::string> deviceDescriptors;
-  NOP_STRUCTURE(ChannelAdvertisement, deviceDescriptors);
-};
-
 struct Brochure {
-  std::unordered_map<std::string, TransportAdvertisement>
-      transportAdvertisement;
-  std::unordered_map<std::string, ChannelAdvertisement> channelAdvertisement;
-  NOP_STRUCTURE(Brochure, transportAdvertisement, channelAdvertisement);
-};
-
-struct ChannelSelection {
-  std::vector<uint64_t> registrationIds;
-  std::unordered_map<Device, std::string> deviceDescriptors;
-  NOP_STRUCTURE(ChannelSelection, registrationIds, deviceDescriptors);
+  std::unordered_map<std::string, std::string> transportDomainDescriptors;
+  std::unordered_map<std::string, std::unordered_map<Device, std::string>>
+      channelDeviceDescriptors;
+  NOP_STRUCTURE(Brochure, transportDomainDescriptors, channelDeviceDescriptors);
 };
 
 struct BrochureAnswer {
@@ -62,14 +45,20 @@ struct BrochureAnswer {
   std::string address;
   uint64_t transportRegistrationId;
   std::string transportDomainDescriptor;
-  std::unordered_map<std::string, ChannelSelection> channelSelection;
+  std::unordered_map<std::string, std::vector<uint64_t>> channelRegistrationIds;
+  std::unordered_map<std::string, std::unordered_map<Device, std::string>>
+      channelDeviceDescriptors;
+  std::unordered_map<std::pair<Device, Device>, std::string>
+      channelForDevicePair;
   NOP_STRUCTURE(
       BrochureAnswer,
       transport,
       address,
       transportRegistrationId,
       transportDomainDescriptor,
-      channelSelection);
+      channelRegistrationIds,
+      channelDeviceDescriptors,
+      channelForDevicePair);
 };
 
 struct MessageDescriptor {
@@ -95,16 +84,12 @@ struct MessageDescriptor {
 
     Device sourceDevice;
     nop::Optional<Device> targetDevice;
-    // FIXME: Once we get rid of channelName, we can merge Descriptor and
-    // MessageDescriptor.
-    std::string channelName;
     NOP_STRUCTURE(
         TensorDescriptor,
         sizeInBytes,
         metadata,
         sourceDevice,
-        targetDevice,
-        channelName);
+        targetDevice);
   };
 
   std::string metadata;

--- a/tensorpipe/core/pipe.cc
+++ b/tensorpipe/core/pipe.cc
@@ -49,16 +49,8 @@ void Pipe::readDescriptor(read_descriptor_callback_fn fn) {
   impl_->readDescriptor(std::move(fn));
 }
 
-void Pipe::read(Allocation allocation, read_callback_deprecated_fn fn) {
-  impl_->read(std::move(allocation), std::move(fn));
-}
-
 void Pipe::read(Allocation allocation, read_callback_fn fn) {
   impl_->read(std::move(allocation), std::move(fn));
-}
-
-void Pipe::write(Message message, write_callback_deprecated_fn fn) {
-  impl_->write(std::move(message), std::move(fn));
 }
 
 void Pipe::write(Message message, write_callback_fn fn) {

--- a/tensorpipe/core/pipe.h
+++ b/tensorpipe/core/pipe.h
@@ -64,18 +64,12 @@ class Pipe final {
 
   void readDescriptor(read_descriptor_callback_fn fn);
 
-  using read_callback_deprecated_fn =
-      std::function<void(const Error&, Message)>;
   using read_callback_fn = std::function<void(const Error&)>;
 
-  void read(Allocation allocation, read_callback_deprecated_fn fn);
   void read(Allocation allocation, read_callback_fn fn);
 
-  using write_callback_deprecated_fn =
-      std::function<void(const Error&, Message)>;
   using write_callback_fn = std::function<void(const Error&)>;
 
-  void write(Message message, write_callback_deprecated_fn fn);
   void write(Message message, write_callback_fn fn);
 
   // Retrieve the user-defined name that was given to the constructor of the

--- a/tensorpipe/core/pipe_impl.h
+++ b/tensorpipe/core/pipe_impl.h
@@ -261,11 +261,13 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
   void readDescriptorOfMessage(ReadOpIter opIter);
   void callReadDescriptorCallback(ReadOpIter opIter);
   void expectReadCall(ReadOpIter opIter);
-  void readPayloadsAndReceiveTensorsOfMessage(ReadOpIter opIter);
+  void readPayloadsOfMessage(ReadOpIter opIter);
+  void receiveTensorsOfMessage(ReadOpIter opIter);
   void callReadCallback(ReadOpIter opIter);
   // For write operations:
+  void writeDescriptorOfMessage(WriteOpIter opIter);
+  void writePayloadsOfMessage(WriteOpIter opIter);
   void sendTensorsOfMessage(WriteOpIter opIter);
-  void writeDescriptorAndPayloadsOfMessage(WriteOpIter opIter);
   void callWriteCallback(WriteOpIter opIter);
 
   //

--- a/tensorpipe/core/pipe_impl.h
+++ b/tensorpipe/core/pipe_impl.h
@@ -63,11 +63,6 @@ struct ReadOperation {
   Pipe::read_descriptor_callback_fn readDescriptorCallback;
   Pipe::read_callback_fn readCallback;
 
-  struct Tensor {
-    std::string channelName;
-  };
-  std::vector<Tensor> tensors;
-
   Descriptor descriptor;
   // Buffers allocated by the user.
   Allocation allocation;
@@ -90,10 +85,8 @@ struct WriteOperation {
   // Buffers provided by the user.
   Message message;
 
-  // Tensor descriptors collected from the channels.
-  struct Tensor {
-    std::string channelName;
-  };
+  // This is currently empty, but will be used again for XDTT channel selection.
+  struct Tensor {};
   std::vector<Tensor> tensors;
 };
 
@@ -167,6 +160,8 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
   std::shared_ptr<transport::Connection> connection_;
 
   std::unordered_map<std::string, std::shared_ptr<channel::Channel>> channels_;
+  std::unordered_map<std::pair<Device, Device>, std::string>
+      channelForDevicePair_;
 
   // The server will set this up when it tell the client to switch to a
   // different connection or to open some channels.

--- a/tensorpipe/core/pipe_impl.h
+++ b/tensorpipe/core/pipe_impl.h
@@ -61,7 +61,7 @@ struct ReadOperation {
 
   // Callbacks.
   Pipe::read_descriptor_callback_fn readDescriptorCallback;
-  Pipe::read_callback_deprecated_fn readCallback;
+  Pipe::read_callback_fn readCallback;
 
   struct Tensor {
     std::string channelName;
@@ -85,7 +85,7 @@ struct WriteOperation {
   uint64_t numTensorsBeingSent{0};
 
   // Callbacks.
-  Pipe::write_callback_deprecated_fn writeCallback;
+  Pipe::write_callback_fn writeCallback;
 
   // Buffers provided by the user.
   Message message;
@@ -117,15 +117,11 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
   void init();
 
   using read_descriptor_callback_fn = Pipe::read_descriptor_callback_fn;
-  using read_callback_deprecated_fn = Pipe::read_callback_deprecated_fn;
   using read_callback_fn = Pipe::read_callback_fn;
-  using write_callback_deprecated_fn = Pipe::write_callback_deprecated_fn;
   using write_callback_fn = Pipe::write_callback_fn;
 
   void readDescriptor(read_descriptor_callback_fn fn);
-  void read(Allocation allocation, read_callback_deprecated_fn fn);
   void read(Allocation allocation, read_callback_fn fn);
-  void write(Message message, write_callback_deprecated_fn fn);
   void write(Message message, write_callback_fn fn);
 
   const std::string& getRemoteName();
@@ -137,9 +133,9 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
 
   void readDescriptorFromLoop(read_descriptor_callback_fn fn);
 
-  void readFromLoop(Allocation allocation, read_callback_deprecated_fn fn);
+  void readFromLoop(Allocation allocation, read_callback_fn fn);
 
-  void writeFromLoop(Message message, write_callback_deprecated_fn fn);
+  void writeFromLoop(Message message, write_callback_fn fn);
 
   void closeFromLoop();
 


### PR DESCRIPTION
Summary: This diff adds a test that writes then reads a `Message` from each endpoint. It fails when (mistakenly) using the same control connection in the Pipe for exchanging both `Descriptor`s and `DescriptorReply`s (as the next packet type cannot be predicted).

Reviewed By: lw

Differential Revision: D27702149

