### PR TITLE
Get rid of MessageDescriptor.

### DIFF
--- a/tensorpipe/core/nop_types.h
+++ b/tensorpipe/core/nop_types.h
@@ -107,11 +107,6 @@ struct MessageDescriptorReply {
   NOP_STRUCTURE(MessageDescriptorReply, targetDevices);
 };
 
-using Packet = nop::Variant<
-    SpontaneousConnection,
-    RequestedConnection,
-    Brochure,
-    BrochureAnswer,
-    MessageDescriptor>;
+using Packet = nop::Variant<SpontaneousConnection, RequestedConnection>;
 
 } // namespace tensorpipe

--- a/tensorpipe/core/nop_types.h
+++ b/tensorpipe/core/nop_types.h
@@ -43,7 +43,7 @@ struct Brochure {
 struct BrochureAnswer {
   std::string transport;
   std::string address;
-  uint64_t transportRegistrationId;
+  std::unordered_map<uint64_t, uint64_t> transportRegistrationIds;
   std::string transportDomainDescriptor;
   std::unordered_map<std::string, std::vector<uint64_t>> channelRegistrationIds;
   std::unordered_map<std::string, std::unordered_map<Device, std::string>>
@@ -54,7 +54,7 @@ struct BrochureAnswer {
       BrochureAnswer,
       transport,
       address,
-      transportRegistrationId,
+      transportRegistrationIds,
       transportDomainDescriptor,
       channelRegistrationIds,
       channelDeviceDescriptors,

--- a/tensorpipe/core/nop_types.h
+++ b/tensorpipe/core/nop_types.h
@@ -18,6 +18,8 @@
 #include <nop/types/variant.h>
 
 #include <tensorpipe/common/device.h>
+#include <tensorpipe/common/optional.h>
+#include <tensorpipe/core/message.h>
 
 namespace tensorpipe {
 
@@ -61,50 +63,18 @@ struct BrochureAnswer {
       channelForDevicePair);
 };
 
-struct MessageDescriptor {
-  struct PayloadDescriptor {
-    // This pointless constructor is needed to work around a bug in GCC 5.5 (and
-    // possibly other versions). It appears to be needed in the nop types that
-    // are used inside std::vectors.
-    PayloadDescriptor() {}
+NOP_EXTERNAL_STRUCTURE(Descriptor::Payload, length, metadata);
+NOP_EXTERNAL_STRUCTURE(
+    Descriptor::Tensor,
+    length,
+    sourceDevice,
+    targetDevice,
+    metadata);
+NOP_EXTERNAL_STRUCTURE(Descriptor, metadata, payloads, tensors);
 
-    int64_t sizeInBytes;
-    std::string metadata;
-    NOP_STRUCTURE(PayloadDescriptor, sizeInBytes, metadata);
-  };
-
-  struct TensorDescriptor {
-    // This pointless constructor is needed to work around a bug in GCC 5.5 (and
-    // possibly other versions). It appears to be needed in the nop types that
-    // are used inside std::vectors.
-    TensorDescriptor() {}
-
-    int64_t sizeInBytes;
-    std::string metadata;
-
-    Device sourceDevice;
-    nop::Optional<Device> targetDevice;
-    NOP_STRUCTURE(
-        TensorDescriptor,
-        sizeInBytes,
-        metadata,
-        sourceDevice,
-        targetDevice);
-  };
-
-  std::string metadata;
-  std::vector<PayloadDescriptor> payloadDescriptors;
-  std::vector<TensorDescriptor> tensorDescriptors;
-  NOP_STRUCTURE(
-      MessageDescriptor,
-      metadata,
-      payloadDescriptors,
-      tensorDescriptors);
-};
-
-struct MessageDescriptorReply {
+struct DescriptorReply {
   std::vector<Device> targetDevices;
-  NOP_STRUCTURE(MessageDescriptorReply, targetDevices);
+  NOP_STRUCTURE(DescriptorReply, targetDevices);
 };
 
 using Packet = nop::Variant<SpontaneousConnection, RequestedConnection>;

--- a/tensorpipe/core/nop_types.h
+++ b/tensorpipe/core/nop_types.h
@@ -102,6 +102,11 @@ struct MessageDescriptor {
       tensorDescriptors);
 };
 
+struct MessageDescriptorReply {
+  std::vector<Device> targetDevices;
+  NOP_STRUCTURE(MessageDescriptorReply, targetDevices);
+};
+
 using Packet = nop::Variant<
     SpontaneousConnection,
     RequestedConnection,

--- a/tensorpipe/core/pipe_impl.h
+++ b/tensorpipe/core/pipe_impl.h
@@ -157,6 +157,7 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
   std::string remoteName_;
 
   std::string transport_;
+  enum ConnectionId { DESCRIPTOR };
   std::shared_ptr<transport::Connection> descriptorConnection_;
 
   std::unordered_map<std::string, std::shared_ptr<channel::Channel>> channels_;
@@ -165,7 +166,7 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
 
   // The server will set this up when it tell the client to switch to a
   // different connection or to open some channels.
-  optional<uint64_t> registrationId_;
+  std::unordered_map<uint64_t, uint64_t> registrationIds_;
 
   std::unordered_map<std::string, std::vector<uint64_t>>
       channelRegistrationIds_;
@@ -240,6 +241,7 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
   // On the server side:
   void onReadWhileServerWaitingForBrochure(const Packet& nopPacketIn);
   void onAcceptWhileServerWaitingForConnection(
+      ConnectionId connId,
       std::string receivedTransport,
       std::shared_ptr<transport::Connection> receivedConnection);
   void onAcceptWhileServerWaitingForChannel(
@@ -275,7 +277,7 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
   //
 
   void initConnection(transport::Connection& connection, uint64_t token);
-  uint64_t registerTransport();
+  uint64_t registerTransport(ConnectionId connId);
   std::vector<uint64_t>& registerChannel(const std::string& channelName);
 
   bool pendingRegistrations();

--- a/tensorpipe/core/pipe_impl.h
+++ b/tensorpipe/core/pipe_impl.h
@@ -157,8 +157,9 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
   std::string remoteName_;
 
   std::string transport_;
-  enum ConnectionId { DESCRIPTOR };
+  enum ConnectionId { DESCRIPTOR, DESCRIPTOR_REPLY };
   std::shared_ptr<transport::Connection> descriptorConnection_;
+  std::shared_ptr<transport::Connection> descriptorReplyConnection_;
 
   std::unordered_map<std::string, std::shared_ptr<channel::Channel>> channels_;
   std::unordered_map<std::pair<Device, Device>, std::string>

--- a/tensorpipe/core/pipe_impl.h
+++ b/tensorpipe/core/pipe_impl.h
@@ -251,9 +251,10 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
 
   // Transitions for the pipe's initial handshake.
   // On the client side:
-  void onReadWhileClientWaitingForBrochureAnswer(const Packet& nopPacketIn);
+  void onReadWhileClientWaitingForBrochureAnswer(
+      const BrochureAnswer& nopBrochureAnswer);
   // On the server side:
-  void onReadWhileServerWaitingForBrochure(const Packet& nopPacketIn);
+  void onReadWhileServerWaitingForBrochure(const Brochure& nopBrochure);
   void onAcceptWhileServerWaitingForConnection(
       ConnectionId connId,
       std::string receivedTransport,

--- a/tensorpipe/core/pipe_impl.h
+++ b/tensorpipe/core/pipe_impl.h
@@ -157,7 +157,7 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
   std::string remoteName_;
 
   std::string transport_;
-  std::shared_ptr<transport::Connection> connection_;
+  std::shared_ptr<transport::Connection> descriptorConnection_;
 
   std::unordered_map<std::string, std::shared_ptr<channel::Channel>> channels_;
   std::unordered_map<std::pair<Device, Device>, std::string>

--- a/tensorpipe/core/pipe_impl.h
+++ b/tensorpipe/core/pipe_impl.h
@@ -274,6 +274,7 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
   // Everything else
   //
 
+  void initConnection(transport::Connection& connection, uint64_t token);
   uint64_t registerTransport();
   std::vector<uint64_t>& registerChannel(const std::string& channelName);
 


### PR DESCRIPTION
Summary:
Now that `Descriptor` and `MessageDescriptor` have converged, we can
finally merge the two, and simply send the `Descriptor` over the wire. The main
hurdle is to serialize `tensorpipe::optional<tensorpipe::Device> targetDevice`.

Reviewed By: lw

Differential Revision: D27702214

