### PR TITLE
Refactor Pipe for multiple connections.

### DIFF
--- a/tensorpipe/core/nop_types.h
+++ b/tensorpipe/core/nop_types.h
@@ -43,7 +43,7 @@ struct Brochure {
 struct BrochureAnswer {
   std::string transport;
   std::string address;
-  uint64_t transportRegistrationId;
+  std::unordered_map<uint64_t, uint64_t> transportRegistrationIds;
   std::string transportDomainDescriptor;
   std::unordered_map<std::string, std::vector<uint64_t>> channelRegistrationIds;
   std::unordered_map<std::string, std::unordered_map<Device, std::string>>
@@ -54,7 +54,7 @@ struct BrochureAnswer {
       BrochureAnswer,
       transport,
       address,
-      transportRegistrationId,
+      transportRegistrationIds,
       transportDomainDescriptor,
       channelRegistrationIds,
       channelDeviceDescriptors,

--- a/tensorpipe/core/pipe_impl.h
+++ b/tensorpipe/core/pipe_impl.h
@@ -157,6 +157,7 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
   std::string remoteName_;
 
   std::string transport_;
+  enum ConnectionId { DESCRIPTOR };
   std::shared_ptr<transport::Connection> descriptorConnection_;
 
   std::unordered_map<std::string, std::shared_ptr<channel::Channel>> channels_;
@@ -165,7 +166,7 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
 
   // The server will set this up when it tell the client to switch to a
   // different connection or to open some channels.
-  optional<uint64_t> registrationId_;
+  std::unordered_map<uint64_t, uint64_t> registrationIds_;
 
   std::unordered_map<std::string, std::vector<uint64_t>>
       channelRegistrationIds_;
@@ -240,6 +241,7 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
   // On the server side:
   void onReadWhileServerWaitingForBrochure(const Packet& nopPacketIn);
   void onAcceptWhileServerWaitingForConnection(
+      ConnectionId connId,
       std::string receivedTransport,
       std::shared_ptr<transport::Connection> receivedConnection);
   void onAcceptWhileServerWaitingForChannel(
@@ -275,7 +277,7 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
   //
 
   void initConnection(transport::Connection& connection, uint64_t token);
-  uint64_t registerTransport();
+  uint64_t registerTransport(ConnectionId connId);
   std::vector<uint64_t>& registerChannel(const std::string& channelName);
 
   bool pendingRegistrations();

--- a/tensorpipe/core/pipe_impl.h
+++ b/tensorpipe/core/pipe_impl.h
@@ -157,7 +157,7 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
   std::string remoteName_;
 
   std::string transport_;
-  std::shared_ptr<transport::Connection> connection_;
+  std::shared_ptr<transport::Connection> descriptorConnection_;
 
   std::unordered_map<std::string, std::shared_ptr<channel::Channel>> channels_;
   std::unordered_map<std::pair<Device, Device>, std::string>

--- a/tensorpipe/core/pipe_impl.h
+++ b/tensorpipe/core/pipe_impl.h
@@ -274,6 +274,7 @@ class PipeImpl final : public std::enable_shared_from_this<PipeImpl> {
   // Everything else
   //
 
+  void initConnection(transport::Connection& connection, uint64_t token);
   uint64_t registerTransport();
   std::vector<uint64_t>& registerChannel(const std::string& channelName);
 


### PR DESCRIPTION
Summary:
This will be necessary for XDTT, where an extra connection will be used
for message descriptor replies containing the missing target devices.

Reviewed By: lw

Differential Revision: D27701990

