### PR TITLE
Avoid installing GoogleTest on make install.

### DIFF
--- a/tensorpipe/test/CMakeLists.txt
+++ b/tensorpipe/test/CMakeLists.txt
@@ -88,7 +88,7 @@ endif()
 
 
 add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/googletest
-  ${PROJECT_BINARY_DIR}/third_party/googletest)
+  ${PROJECT_BINARY_DIR}/third_party/googletest EXCLUDE_FROM_ALL)
 
 target_link_libraries(tensorpipe_test PRIVATE
   tensorpipe


### PR DESCRIPTION
By calling `add_subdirectory()` on GoogleTest, it gets registered for
installation upon `make install` of TensorPipe. This PR prevents that.