### PR TITLE
Factor out channel selection.

### DIFF
--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(tensorpipe
   common/fd.cc
   common/socket.cc
   common/system.cc
+  core/channel_selection.cc
   core/context.cc
   core/context_impl.cc
   core/error.cc

--- a/tensorpipe/core/channel_selection.cc
+++ b/tensorpipe/core/channel_selection.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/core/channel_selection.h>
+
+namespace tensorpipe {
+
+ChannelSelection selectChannels(
+    const ContextImpl::TOrderedChannels& orderedChannels,
+    const std::unordered_map<
+        std::string,
+        std::unordered_map<Device, std::string>>& remoteDescriptorsMap) {
+  ChannelSelection result;
+
+  for (const auto& channelIter : orderedChannels) {
+    const std::string& channelName = std::get<0>(channelIter.second);
+    const channel::Context& channelContext = *std::get<1>(channelIter.second);
+
+    const auto& remoteDescriptorsMapIter =
+        remoteDescriptorsMap.find(channelName);
+    if (remoteDescriptorsMapIter == remoteDescriptorsMap.end()) {
+      continue;
+    }
+
+    const std::unordered_map<Device, std::string>& localDeviceDescriptors =
+        channelContext.deviceDescriptors();
+    const std::unordered_map<Device, std::string>& remoteDeviceDescriptors =
+        remoteDescriptorsMapIter->second;
+
+    bool selected = false;
+    for (const auto& localDescIter : localDeviceDescriptors) {
+      const Device& localDevice = localDescIter.first;
+      const std::string& localDeviceDescriptor = localDescIter.second;
+      for (const auto& remoteDescIter : remoteDeviceDescriptors) {
+        const Device& remoteDevice = remoteDescIter.first;
+        const std::string& remoteDeviceDescriptor = remoteDescIter.second;
+
+        if (!channelContext.canCommunicateWithRemote(
+                localDeviceDescriptor, remoteDeviceDescriptor)) {
+          continue;
+        }
+
+        if (result.channelForDevicePair.count({localDevice, remoteDevice}) !=
+            0) {
+          // A channel with higher priority has already been selected for this
+          // device pair.
+          continue;
+        }
+
+        selected = true;
+        result.channelForDevicePair[{localDevice, remoteDevice}] = channelName;
+      }
+    }
+
+    if (selected) {
+      result.descriptorsMap[channelName] = localDeviceDescriptors;
+    }
+  }
+
+  return result;
+}
+
+} // namespace tensorpipe

--- a/tensorpipe/core/channel_selection.h
+++ b/tensorpipe/core/channel_selection.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <unordered_map>
+#include <utility>
+
+#include <tensorpipe/common/device.h>
+#include <tensorpipe/core/context_impl.h>
+
+namespace tensorpipe {
+
+struct ChannelSelection {
+  std::unordered_map<std::string, std::unordered_map<Device, std::string>>
+      descriptorsMap;
+  std::unordered_map<std::pair<Device, Device>, std::string>
+      channelForDevicePair;
+};
+
+ChannelSelection selectChannels(
+    const ContextImpl::TOrderedChannels& orderedChannels,
+    const std::unordered_map<
+        std::string,
+        std::unordered_map<Device, std::string>>& remoteDescriptorsMap);
+
+} // namespace tensorpipe

--- a/tensorpipe/test/CMakeLists.txt
+++ b/tensorpipe/test/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(tensorpipe_test
   transport/uv/connection_test.cc
   transport/uv/sockaddr_test.cc
   transport/listener_test.cc
+  core/channel_selection_test.cc
   core/context_test.cc
   channel/basic/basic_test.cc
   channel/xth/xth_test.cc

--- a/tensorpipe/test/core/channel_selection_test.cc
+++ b/tensorpipe/test/core/channel_selection_test.cc
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/core/channel_selection.h>
+
+#include <gtest/gtest.h>
+
+using namespace tensorpipe;
+
+namespace {
+
+class MockChannelContext : public channel::Context {
+ public:
+  static std::shared_ptr<channel::Context> create(
+      std::unordered_map<Device, std::string> deviceDescriptors) {
+    return std::make_shared<MockChannelContext>(std::move(deviceDescriptors));
+  }
+
+  explicit MockChannelContext(
+      std::unordered_map<Device, std::string> deviceDescriptors)
+      : deviceDescriptors_(std::move(deviceDescriptors)) {}
+
+  bool isViable() const override {
+    return true;
+  }
+
+  size_t numConnectionsNeeded() const override {
+    return 1;
+  }
+
+  const std::unordered_map<Device, std::string>& deviceDescriptors()
+      const override {
+    return deviceDescriptors_;
+  }
+
+  bool canCommunicateWithRemote(
+      const std::string& localDeviceDescriptor,
+      const std::string& remoteDeviceDescriptor) const override {
+    return localDeviceDescriptor == remoteDeviceDescriptor;
+  }
+
+  std::shared_ptr<channel::Channel> createChannel(
+      std::vector<std::shared_ptr<transport::Connection>> /* unused */,
+      channel::Endpoint /* unused */) override {
+    return nullptr;
+  }
+
+  void setId(std::string /* unused */) override {}
+
+  void close() override {}
+
+  void join() override {}
+
+ private:
+  std::unordered_map<Device, std::string> deviceDescriptors_;
+};
+
+} // namespace
+
+TEST(ChannelSelection, NoCompatibleChannel) {
+  auto channelContext = MockChannelContext::create({
+      {Device{kCpuDeviceType, 0}, "any"},
+  });
+
+  ChannelSelection channelSelection = selectChannels(
+      {
+          {0, std::make_tuple("foo_channel", channelContext)},
+      },
+      {
+          {
+              "bar_channel",
+              {
+                  {Device{kCpuDeviceType, 0}, "any"},
+              },
+          },
+      });
+
+  auto it = channelSelection.channelForDevicePair.find(
+      {Device{kCpuDeviceType, 0}, Device{kCpuDeviceType, 0}});
+  EXPECT_EQ(it, channelSelection.channelForDevicePair.end());
+  EXPECT_TRUE(channelSelection.descriptorsMap.empty());
+}
+
+TEST(ChannelSelection, OneCompatibleChannel) {
+  auto channelContext = MockChannelContext::create({
+      {Device{kCpuDeviceType, 0}, "any"},
+  });
+
+  ChannelSelection channelSelection = selectChannels(
+      {
+          {0, std::make_tuple("foo_channel", channelContext)},
+      },
+      {
+          {
+              "foo_channel",
+              {
+                  {Device{kCpuDeviceType, 0}, "any"},
+              },
+          },
+      });
+
+  auto it = channelSelection.channelForDevicePair.find(
+      {Device{kCpuDeviceType, 0}, Device{kCpuDeviceType, 0}});
+  EXPECT_NE(it, channelSelection.channelForDevicePair.end());
+  EXPECT_EQ(it->second, "foo_channel");
+  EXPECT_EQ(
+      channelSelection.descriptorsMap["foo_channel"],
+      channelContext->deviceDescriptors());
+}
+
+TEST(ChannelSelection, SelectsHighestPriorityChannel) {
+  auto fooChannelContext = MockChannelContext::create({
+      {Device{kCpuDeviceType, 0}, "any"},
+  });
+  auto barChannelContext = MockChannelContext::create({
+      {Device{kCpuDeviceType, 0}, "any"},
+  });
+
+  ChannelSelection channelSelection = selectChannels(
+      {
+          {0, std::make_tuple("foo_channel", fooChannelContext)},
+          {-100, std::make_tuple("bar_channel", barChannelContext)},
+      },
+      {
+          {
+              "foo_channel",
+              {
+                  {Device{kCpuDeviceType, 0}, "any"},
+              },
+          },
+          {
+              "bar_channel",
+              {
+                  {Device{kCpuDeviceType, 0}, "any"},
+              },
+          },
+      });
+
+  auto it = channelSelection.channelForDevicePair.find(
+      {Device{kCpuDeviceType, 0}, Device{kCpuDeviceType, 0}});
+  EXPECT_NE(it, channelSelection.channelForDevicePair.end());
+  EXPECT_EQ(it->second, "bar_channel");
+  EXPECT_EQ(
+      channelSelection.descriptorsMap["bar_channel"],
+      barChannelContext->deviceDescriptors());
+}


### PR DESCRIPTION
In order to make channel selection testable, we need to move it out of
the anonymous namespace in which it is currently being declared.

The `SelectedChannels` struct is being renamed to `ChannelSelection`, otherwise the code is simply moved from `core/pipe_impl.cc` to `core/channel_selection.cc`.