### PR TITLE
Add tests for channel::Context::canCommunicateWithRemote.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,32 +303,32 @@ workflows:
           cuda_version: "9.2"
           # Excluding CudaGdr for lack of InfiniBand hardware, and CudaIpc on
           # multi GPU for lack of p2p capabilities.
-          exclude_tests: "CudaGdr*:CudaIpc/CudaMultiGPUChannelTestSuite*"
+          exclude_tests: "CudaGdr*:CudaIpc/CudaMultiGPUChannelTestSuite*:*CudaIpcCanCommunicateWithRemote*"
       - build_gpu:
           name: GPU (CUDA 10.1)
           cuda_version: "10.1"
           # Excluding CudaGdr for lack of InfiniBand hardware, and CudaIpc on
           # multi GPU for lack of p2p capabilities.
-          exclude_tests: "CudaGdr*:CudaIpc/CudaMultiGPUChannelTestSuite*"
+          exclude_tests: "CudaGdr*:CudaIpc/CudaMultiGPUChannelTestSuite*:*CudaIpcCanCommunicateWithRemote*"
       - build_gpu:
           name: GPU (CUDA 10.2)
           cuda_version: "10.2"
           # Excluding CudaGdr for lack of InfiniBand hardware, and CudaIpc on
           # multi GPU for lack of p2p capabilities.
-          exclude_tests: "CudaGdr*:CudaIpc/CudaMultiGPUChannelTestSuite*"
+          exclude_tests: "CudaGdr*:CudaIpc/CudaMultiGPUChannelTestSuite*:*CudaIpcCanCommunicateWithRemote*"
       - build_gpu:
           name: GPU (CUDA 11.0)
           cuda_version: "11.0"
           # Excluding CudaGdr for lack of InfiniBand hardware, and CudaIpc on
           # multi GPU for lack of p2p capabilities.
-          exclude_tests: "CudaGdr*:CudaIpc/CudaMultiGPUChannelTestSuite*"
+          exclude_tests: "CudaGdr*:CudaIpc/CudaMultiGPUChannelTestSuite*:*CudaIpcCanCommunicateWithRemote*"
       - build_gpu:
           name: GPU (CUDA 11.1)
           cuda_version: "11.1"
           # Excluding CudaGdr for lack of InfiniBand hardware, and CudaIpc on
           # multi GPU for lack of p2p capabilities, and CudaBasic/CudaMultiGPUChannelTestSuite.SendAcrossNonDefaultDevices/0
           # because it does not work with CUDA 11.1 (cf. https://github.com/pytorch/tensorpipe/issues/368).
-          exclude_tests: "CudaGdr*:CudaIpc/CudaMultiGPUChannelTestSuite*:CudaBasic/CudaMultiGPUChannelTestSuite.SendAcrossNonDefaultDevices/0"
+          exclude_tests: "CudaGdr*:CudaIpc/CudaMultiGPUChannelTestSuite*:*CudaIpcCanCommunicateWithRemote*:CudaBasic/CudaMultiGPUChannelTestSuite.SendAcrossNonDefaultDevices/0"
       - build_osx:
           name: OSX
       - python:

--- a/tensorpipe/common/nop.h
+++ b/tensorpipe/common/nop.h
@@ -12,6 +12,8 @@
 #include <nop/status.h>
 #include <nop/utility/buffer_reader.h>
 #include <nop/utility/buffer_writer.h>
+#include <nop/utility/stream_reader.h>
+#include <nop/utility/stream_writer.h>
 
 #include <tensorpipe/common/defs.h>
 #include <tensorpipe/common/optional.h>
@@ -239,6 +241,22 @@ class NopHolder : public AbstractNopHolder {
  private:
   T object_;
 };
+
+template <typename T>
+std::string nopToString(T value) {
+  nop::Serializer<nop::StreamWriter<std::stringstream>> serializer;
+  serializer.Write(value);
+  return serializer.writer().stream().str();
+}
+
+template <typename T>
+T nopFromString(std::string serializedValue) {
+  nop::Deserializer<nop::StreamReader<std::stringstream>> serializer{
+      serializedValue};
+  T value;
+  serializer.Read(&value);
+  return value;
+}
 
 } // namespace tensorpipe
 

--- a/tensorpipe/test/channel/basic/basic_test.cc
+++ b/tensorpipe/test/channel/basic/basic_test.cc
@@ -23,8 +23,34 @@ class BasicChannelTestHelper : public CpuChannelTestHelper {
 
 BasicChannelTestHelper helper;
 
+class BasicChannelTestSuite : public ChannelTestSuite {};
+
 } // namespace
+
+class BasicCanCommunicateWithRemoteTest : public CanCommunicateWithRemoteTest {
+ public:
+  void checkDeviceDescriptors(
+      const tensorpipe::channel::Context& ctx,
+      const std::unordered_map<tensorpipe::Device, std::string>&
+          localDeviceDescriptors,
+      const std::unordered_map<tensorpipe::Device, std::string>&
+          remoteDeviceDescriptors) const override {
+    for (const auto& localIt : localDeviceDescriptors) {
+      for (const auto& remoteIt : remoteDeviceDescriptors) {
+        EXPECT_TRUE(
+            ctx.canCommunicateWithRemote(localIt.second, remoteIt.second));
+      }
+    }
+  }
+};
+
+CHANNEL_TEST(BasicChannelTestSuite, BasicCanCommunicateWithRemote);
 
 INSTANTIATE_TEST_CASE_P(Basic, ChannelTestSuite, ::testing::Values(&helper));
 
 INSTANTIATE_TEST_CASE_P(Basic, CpuChannelTestSuite, ::testing::Values(&helper));
+
+INSTANTIATE_TEST_CASE_P(
+    Basic,
+    BasicChannelTestSuite,
+    ::testing::Values(&helper));

--- a/tensorpipe/test/channel/cma/cma_test.cc
+++ b/tensorpipe/test/channel/cma/cma_test.cc
@@ -23,8 +23,31 @@ class CmaChannelTestHelper : public CpuChannelTestHelper {
 
 CmaChannelTestHelper helper;
 
+class CmaChannelTestSuite : public ChannelTestSuite {};
+
 } // namespace
+
+class CmaCanCommunicateWithRemoteTest : public CanCommunicateWithRemoteTest {
+ public:
+  void checkDeviceDescriptors(
+      const tensorpipe::channel::Context& ctx,
+      const std::unordered_map<tensorpipe::Device, std::string>&
+          localDeviceDescriptors,
+      const std::unordered_map<tensorpipe::Device, std::string>&
+          remoteDeviceDescriptors) const override {
+    for (const auto& localIt : localDeviceDescriptors) {
+      for (const auto& remoteIt : remoteDeviceDescriptors) {
+        EXPECT_TRUE(
+            ctx.canCommunicateWithRemote(localIt.second, remoteIt.second));
+      }
+    }
+  }
+};
+
+CHANNEL_TEST(CmaChannelTestSuite, CmaCanCommunicateWithRemote);
 
 INSTANTIATE_TEST_CASE_P(Cma, ChannelTestSuite, ::testing::Values(&helper));
 
 INSTANTIATE_TEST_CASE_P(Cma, CpuChannelTestSuite, ::testing::Values(&helper));
+
+INSTANTIATE_TEST_CASE_P(Cma, CmaChannelTestSuite, ::testing::Values(&helper));

--- a/tensorpipe/test/channel/cuda_gdr/cuda_gdr_test.cc
+++ b/tensorpipe/test/channel/cuda_gdr/cuda_gdr_test.cc
@@ -30,7 +30,29 @@ class CudaGdrChannelTestHelper : public CudaChannelTestHelper {
 
 CudaGdrChannelTestHelper helper;
 
+class CudaGdrChannelTestSuite : public ChannelTestSuite {};
+
 } // namespace
+
+class CudaGdrCanCommunicateWithRemoteTest
+    : public CanCommunicateWithRemoteTest {
+ public:
+  void checkDeviceDescriptors(
+      const tensorpipe::channel::Context& ctx,
+      const std::unordered_map<tensorpipe::Device, std::string>&
+          localDeviceDescriptors,
+      const std::unordered_map<tensorpipe::Device, std::string>&
+          remoteDeviceDescriptors) const override {
+    for (const auto& localIt : localDeviceDescriptors) {
+      for (const auto& remoteIt : remoteDeviceDescriptors) {
+        EXPECT_TRUE(
+            ctx.canCommunicateWithRemote(localIt.second, remoteIt.second));
+      }
+    }
+  }
+};
+
+CHANNEL_TEST(CudaGdrChannelTestSuite, CudaGdrCanCommunicateWithRemote);
 
 INSTANTIATE_TEST_CASE_P(CudaGdr, ChannelTestSuite, ::testing::Values(&helper));
 
@@ -42,4 +64,9 @@ INSTANTIATE_TEST_CASE_P(
 INSTANTIATE_TEST_CASE_P(
     CudaGdr,
     CudaMultiGPUChannelTestSuite,
+    ::testing::Values(&helper));
+
+INSTANTIATE_TEST_CASE_P(
+    CudaGdr,
+    CudaGdrChannelTestSuite,
     ::testing::Values(&helper));

--- a/tensorpipe/test/channel/cuda_ipc/cuda_ipc_test.cc
+++ b/tensorpipe/test/channel/cuda_ipc/cuda_ipc_test.cc
@@ -34,6 +34,26 @@ class CudaIpcChannelTestSuite : public ChannelTestSuite {};
 
 } // namespace
 
+class CudaIpcCanCommunicateWithRemoteTest
+    : public CanCommunicateWithRemoteTest {
+ public:
+  void checkDeviceDescriptors(
+      const tensorpipe::channel::Context& ctx,
+      const std::unordered_map<tensorpipe::Device, std::string>&
+          localDeviceDescriptors,
+      const std::unordered_map<tensorpipe::Device, std::string>&
+          remoteDeviceDescriptors) const override {
+    for (const auto& localIt : localDeviceDescriptors) {
+      for (const auto& remoteIt : remoteDeviceDescriptors) {
+        EXPECT_TRUE(
+            ctx.canCommunicateWithRemote(localIt.second, remoteIt.second));
+      }
+    }
+  }
+};
+
+CHANNEL_TEST(CudaIpcChannelTestSuite, CudaIpcCanCommunicateWithRemote);
+
 class CannotCommunicateInSameProcessTest : public ChannelTestCase {
  public:
   void run(ChannelTestHelper* /* unused */) override {

--- a/tensorpipe/test/channel/cuda_xth/cuda_xth_test.cc
+++ b/tensorpipe/test/channel/cuda_xth/cuda_xth_test.cc
@@ -30,7 +30,29 @@ class CudaXthChannelTestHelper : public CudaChannelTestHelper {
 
 CudaXthChannelTestHelper helper;
 
+class CudaXthChannelTestSuite : public ChannelTestSuite {};
+
 } // namespace
+
+class CudaXthCanCommunicateWithRemoteTest
+    : public CanCommunicateWithRemoteTest {
+ public:
+  void checkDeviceDescriptors(
+      const tensorpipe::channel::Context& ctx,
+      const std::unordered_map<tensorpipe::Device, std::string>&
+          localDeviceDescriptors,
+      const std::unordered_map<tensorpipe::Device, std::string>&
+          remoteDeviceDescriptors) const override {
+    for (const auto& localIt : localDeviceDescriptors) {
+      for (const auto& remoteIt : remoteDeviceDescriptors) {
+        EXPECT_TRUE(
+            ctx.canCommunicateWithRemote(localIt.second, remoteIt.second));
+      }
+    }
+  }
+};
+
+CHANNEL_TEST(CudaXthChannelTestSuite, CudaXthCanCommunicateWithRemote);
 
 INSTANTIATE_TEST_CASE_P(CudaXth, ChannelTestSuite, ::testing::Values(&helper));
 
@@ -42,4 +64,9 @@ INSTANTIATE_TEST_CASE_P(
 INSTANTIATE_TEST_CASE_P(
     CudaXth,
     CudaMultiGPUChannelTestSuite,
+    ::testing::Values(&helper));
+
+INSTANTIATE_TEST_CASE_P(
+    CudaXth,
+    CudaXthChannelTestSuite,
     ::testing::Values(&helper));

--- a/tensorpipe/test/channel/mpt/mpt_test.cc
+++ b/tensorpipe/test/channel/mpt/mpt_test.cc
@@ -39,6 +39,25 @@ class MptChannelTestSuite : public ChannelTestSuite {};
 
 } // namespace
 
+class MptCanCommunicateWithRemoteTest : public CanCommunicateWithRemoteTest {
+ public:
+  void checkDeviceDescriptors(
+      const tensorpipe::channel::Context& ctx,
+      const std::unordered_map<tensorpipe::Device, std::string>&
+          localDeviceDescriptors,
+      const std::unordered_map<tensorpipe::Device, std::string>&
+          remoteDeviceDescriptors) const override {
+    for (const auto& localIt : localDeviceDescriptors) {
+      for (const auto& remoteIt : remoteDeviceDescriptors) {
+        EXPECT_TRUE(
+            ctx.canCommunicateWithRemote(localIt.second, remoteIt.second));
+      }
+    }
+  }
+};
+
+CHANNEL_TEST(MptChannelTestSuite, MptCanCommunicateWithRemote);
+
 class ContextIsNotJoinedTest : public ChannelTestCase {
   // Because it's static we must define it out-of-line (until C++-17, where we
   // can mark this inline).

--- a/tensorpipe/test/channel/xth/xth_test.cc
+++ b/tensorpipe/test/channel/xth/xth_test.cc
@@ -23,8 +23,31 @@ class XthChannelTestHelper : public CpuChannelTestHelper {
 
 XthChannelTestHelper helper;
 
+class XthChannelTestSuite : public ChannelTestSuite {};
+
 } // namespace
+
+class XthCanCommunicateWithRemoteTest : public CanCommunicateWithRemoteTest {
+ public:
+  void checkDeviceDescriptors(
+      const tensorpipe::channel::Context& ctx,
+      const std::unordered_map<tensorpipe::Device, std::string>&
+          localDeviceDescriptors,
+      const std::unordered_map<tensorpipe::Device, std::string>&
+          remoteDeviceDescriptors) const override {
+    for (const auto& localIt : localDeviceDescriptors) {
+      for (const auto& remoteIt : remoteDeviceDescriptors) {
+        EXPECT_TRUE(
+            ctx.canCommunicateWithRemote(localIt.second, remoteIt.second));
+      }
+    }
+  }
+};
+
+CHANNEL_TEST(XthChannelTestSuite, XthCanCommunicateWithRemote);
 
 INSTANTIATE_TEST_CASE_P(Xth, ChannelTestSuite, ::testing::Values(&helper));
 
 INSTANTIATE_TEST_CASE_P(Xth, CpuChannelTestSuite, ::testing::Values(&helper));
+
+INSTANTIATE_TEST_CASE_P(Xth, XthChannelTestSuite, ::testing::Values(&helper));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #384 CudaXth: copy from worker thread.
* #383 Add support for CPU-to-GPU/GPU-to-CPU in CudaXth.
* #381 Remove CPU-to-CPU test from XDTT tests.
* **#380 Add tests for channel::Context::canCommunicateWithRemote.**

Differential Revision: [D28255095](https://our.internmc.facebook.com/intern/diff/D28255095)