### PR TITLE
Add support for CPU-to-GPU/GPU-to-CPU in CudaXth.

### DIFF
--- a/tensorpipe/channel/cuda_xth/channel_impl.h
+++ b/tensorpipe/channel/cuda_xth/channel_impl.h
@@ -34,6 +34,7 @@ struct SendOperation {
   bool doneReadingCompletion{false};
 
   // Arguments at creation
+  bool isCudaBuffer;
   int deviceIdx;
   void* ptr;
   size_t length;
@@ -41,7 +42,7 @@ struct SendOperation {
   TSendCallback callback;
 
   // Other stuff
-  CudaEvent event;
+  optional<CudaEvent> event;
 
   SendOperation(
       int deviceIdx,
@@ -49,6 +50,8 @@ struct SendOperation {
       size_t length,
       cudaStream_t stream,
       TSendCallback callback);
+
+  SendOperation(void* ptr, size_t length, TSendCallback callback);
 };
 
 struct RecvOperation {
@@ -62,25 +65,27 @@ struct RecvOperation {
   bool doneReadingDescriptor{false};
 
   // Arguments at creation
+  bool isCudaBuffer;
   void* const ptr;
   const size_t length;
-  const int deviceIdx;
-  const cudaStream_t stream;
+  int deviceIdx;
+  cudaStream_t stream;
   TRecvCallback callback;
 
   // Other data
+  bool isSrcCudaBuffer;
   cudaEvent_t event;
   const void* srcPtr;
   int srcDeviceIdx;
   cudaStream_t srcStream;
+
+  RecvOperation(CpuBuffer buffer, size_t length, TRecvCallback callback);
 
   RecvOperation(
       int deviceIdx,
       CudaBuffer buffer,
       size_t length,
       TRecvCallback callback);
-
-  void process();
 };
 
 class ChannelImpl final

--- a/tensorpipe/channel/cuda_xth/context_impl.h
+++ b/tensorpipe/channel/cuda_xth/context_impl.h
@@ -34,6 +34,10 @@ class ContextImpl final
 
   size_t numConnectionsNeeded() const override;
 
+  bool canCommunicateWithRemote(
+      const std::string& localDeviceDescriptor,
+      const std::string& remoteDeviceDescriptor) const override;
+
   const CudaLib& getCudaLib();
 
   // Implement the DeferredExecutor interface.

--- a/tensorpipe/test/channel/cuda_xth/cuda_xth_test.cc
+++ b/tensorpipe/test/channel/cuda_xth/cuda_xth_test.cc
@@ -45,8 +45,14 @@ class CudaXthCanCommunicateWithRemoteTest
           remoteDeviceDescriptors) const override {
     for (const auto& localIt : localDeviceDescriptors) {
       for (const auto& remoteIt : remoteDeviceDescriptors) {
-        EXPECT_TRUE(
-            ctx.canCommunicateWithRemote(localIt.second, remoteIt.second));
+        if (localIt.first.type == tensorpipe::kCpuDeviceType &&
+            remoteIt.first.type == tensorpipe::kCpuDeviceType) {
+          EXPECT_FALSE(
+              ctx.canCommunicateWithRemote(localIt.second, remoteIt.second));
+        } else {
+          EXPECT_TRUE(
+              ctx.canCommunicateWithRemote(localIt.second, remoteIt.second));
+        }
       }
     }
   }
@@ -64,6 +70,11 @@ INSTANTIATE_TEST_CASE_P(
 INSTANTIATE_TEST_CASE_P(
     CudaXth,
     CudaMultiGPUChannelTestSuite,
+    ::testing::Values(&helper));
+
+INSTANTIATE_TEST_CASE_P(
+    CudaXth,
+    CudaXDTTChannelTestSuite,
     ::testing::Values(&helper));
 
 INSTANTIATE_TEST_CASE_P(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #384 CudaXth: copy from worker thread.
* **#383 Add support for CPU-to-GPU/GPU-to-CPU in CudaXth.**
* #381 Remove CPU-to-CPU test from XDTT tests.
* #380 Add tests for channel::Context::canCommunicateWithRemote.

Differential Revision: [D28255209](https://our.internmc.facebook.com/intern/diff/D28255209)