### PR TITLE
[ROCm] Hipify changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,3 +11,6 @@
 [submodule "third_party/libnop"]
 	path = third_party/libnop
 	url = https://github.com/google/libnop.git
+[submodule "third_party/hipify"]
+	path = third_party/hipify
+	url = https://github.com/ROCmSoftwarePlatform/hipify-torch.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,11 @@ include(Sanitize)
 # Misc checks to cope with various compiler modes.
 include(MiscCheck)
 
+# ROCm related
+if (TP_USE_ROCM)
+  include(Hipify)
+endif()
+
 add_subdirectory(tensorpipe)
 
 install(EXPORT TensorpipeTargets

--- a/cmake/Hipify.cmake
+++ b/cmake/Hipify.cmake
@@ -1,0 +1,23 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# cmake file to trigger hipify
+
+set(HIPIFY_SCRIPTS_DIR ${PROJECT_SOURCE_DIR}/tools/amd_build)
+set(HIPIFY_COMMAND
+  ${HIPIFY_SCRIPTS_DIR}/build_amd.py
+  --project-directory ${PROJECT_SOURCE_DIR}
+  --output-directory ${PROJECT_SOURCE_DIR}
+)
+
+execute_process(
+  COMMAND ${HIPIFY_COMMAND}
+  RESULT_VARIABLE hipify_return_value
+)
+if (NOT hipify_return_value EQUAL 0)
+  message(FATAL_ERROR "Failed to hipify files!")
+endif()
+

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -31,6 +31,12 @@ endmacro()
 
 # TODO: Default to ON if CUDA available.
 option(TP_USE_CUDA "Enable support for CUDA tensors" OFF)
+option(TP_USE_ROCM "Enable support for ROCM tensors" OFF)
+
+# if both TP_USE_CUDA and TP_USE_ROCM is set then break
+if(TP_USE_CUDA AND TP_USE_ROCM)
+  message(FATAL_ERROR "Tensorpipe can be built either for CUDA or ROCm, TP_USE_CUDA and TP_USE_ROCM both are set, erroring out!!!!")
+endif()
 
 # Optional features
 option(TP_BUILD_BENCHMARK "Build benchmarks" OFF)

--- a/tools/amd_build/build_amd.py
+++ b/tools/amd_build/build_amd.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import sys
+import argparse
+
+sys.path.append(os.path.realpath(os.path.join(
+    os.path.dirname(__file__),
+    os.path.pardir,
+    os.path.pardir,
+    'third_party')))
+
+from hipify import hipify_python
+
+parser = argparse.ArgumentParser(description='Top-level script for HIPifying, filling in most common parameters')
+parser.add_argument(
+    '--project-directory',
+    type=str,
+    help="The root of the project. (default: %(default)s)",
+    required=True)
+
+parser.add_argument(
+    '--output-directory',
+    type=str,
+    help="The Directory to Store the Hipified Project",
+    required=True)
+
+args = parser.parse_args()
+
+includes = [
+    '*'
+]
+
+ignores = [
+]
+
+# capturing the return value which is a dict[filename]:HipifyResult
+HipifyFinalResult = hipify_python.hipify(
+    project_directory=args.project_directory,
+    output_directory=args.output_directory,
+    includes=includes,
+    ignores=ignores,
+    is_pytorch_extension=True)


### PR DESCRIPTION
- Add Hipify as a git submodule
- Trigger hipify from cmake build
- TP_USE_ROCM controls the trigger, which will be set to ON
  when building on ROCm