### PR TITLE
Allow automatic address selection for SHM

### DIFF
--- a/tensorpipe/common/socket.cc
+++ b/tensorpipe/common/socket.cc
@@ -119,4 +119,16 @@ Error Socket::connect(const Sockaddr& addr) {
   return Error::kSuccess;
 }
 
+std::tuple<Error, struct sockaddr_storage, socklen_t> Socket::getSockName()
+    const {
+  struct sockaddr_storage addr;
+  socklen_t addrlen = sizeof(addr);
+  int rv = ::getsockname(fd_, reinterpret_cast<sockaddr*>(&addr), &addrlen);
+  if (rv < 0) {
+    return std::make_tuple(
+        TP_CREATE_ERROR(SystemError, "getsockname", errno), addr, addrlen);
+  }
+  return std::make_tuple(Error::kSuccess, addr, addrlen);
+}
+
 } // namespace tensorpipe

--- a/tensorpipe/common/socket.h
+++ b/tensorpipe/common/socket.h
@@ -215,6 +215,9 @@ class Socket final : public Fd {
   // Connect to address.
   [[nodiscard]] Error connect(const Sockaddr& addr);
 
+  [[nodiscard]] std::tuple<Error, struct sockaddr_storage, socklen_t>
+  getSockName() const;
+
   // Send file descriptor.
   template <typename... Fds>
   [[nodiscard]] Error sendFds(const Fds&... fds) {

--- a/tensorpipe/test/CMakeLists.txt
+++ b/tensorpipe/test/CMakeLists.txt
@@ -46,6 +46,7 @@ if(TP_ENABLE_SHM)
     common/shm_segment_test.cc
     transport/shm/reactor_test.cc
     transport/shm/connection_test.cc
+    transport/shm/listener_test.cc
     transport/shm/sockaddr_test.cc
     transport/shm/shm_test.cc
     )

--- a/tensorpipe/test/core/context_test.cc
+++ b/tensorpipe/test/core/context_test.cc
@@ -264,20 +264,11 @@ Message messageFromAllocation(
   return message;
 }
 
-std::string createUniqueShmAddr() {
-  const ::testing::TestInfo* const testInfo =
-      ::testing::UnitTest::GetInstance()->current_test_info();
-  std::ostringstream ss;
-  // Once we upgrade googletest, also use test_info->test_suite_name() here.
-  ss << "shm://tensorpipe_test_" << testInfo->name() << "_" << getpid();
-  return ss.str();
-}
-
 std::vector<std::string> genUrls() {
   std::vector<std::string> res;
 
 #if TENSORPIPE_HAS_SHM_TRANSPORT
-  res.push_back(createUniqueShmAddr());
+  res.push_back("shm://");
 #endif // TENSORPIPE_HAS_SHM_TRANSPORT
   res.push_back("uv://127.0.0.1");
 

--- a/tensorpipe/test/core/pipe_test.h
+++ b/tensorpipe/test/core/pipe_test.h
@@ -279,20 +279,11 @@ inline void expectDescriptorAndStorageMatchMessage(
   }
 }
 
-inline std::string createUniqueShmAddr() {
-  const ::testing::TestInfo* const testInfo =
-      ::testing::UnitTest::GetInstance()->current_test_info();
-  std::ostringstream ss;
-  // Once we upgrade googletest, also use test_info->test_suite_name() here.
-  ss << "shm://tensorpipe_test_" << testInfo->name() << "_" << getpid();
-  return ss.str();
-}
-
 inline std::vector<std::string> genUrls() {
   std::vector<std::string> res;
 
 #if TENSORPIPE_HAS_SHM_TRANSPORT
-  res.push_back(createUniqueShmAddr());
+  res.push_back("shm://");
 #endif // TENSORPIPE_HAS_SHM_TRANSPORT
   res.push_back("uv://127.0.0.1");
 

--- a/tensorpipe/test/transport/shm/listener_test.cc
+++ b/tensorpipe/test/transport/shm/listener_test.cc
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/test/transport/shm/shm_test.h>
+
+#include <chrono>
+#include <future>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <nop/serializer.h>
+#include <nop/structure.h>
+
+using namespace tensorpipe;
+using namespace tensorpipe::transport;
+
+namespace {
+
+class ShmListenerTest : public TransportTest {};
+
+SHMTransportTestHelper helper;
+
+// This value is defined in tensorpipe/transport/shm/connection.h
+static constexpr auto kBufferSize = 2 * 1024 * 1024;
+
+std::string generateUniqueAddr() {
+  const ::testing::TestInfo* const testInfo =
+      ::testing::UnitTest::GetInstance()->current_test_info();
+  std::ostringstream ss;
+  ss << "tensorpipe_test_" << testInfo->test_suite_name() << "."
+     << testInfo->name() << "_" << ::getpid();
+  return ss.str();
+}
+
+} // namespace
+
+TEST_P(ShmListenerTest, ExplicitAbstractSocketName) {
+  std::string expectedAddr = generateUniqueAddr();
+  std::shared_ptr<Context> ctx = GetParam()->getContext();
+  std::shared_ptr<Listener> listener = ctx->listen(expectedAddr);
+  std::string actualAddr = listener->addr();
+  ASSERT_EQ(actualAddr, expectedAddr);
+  std::shared_ptr<Connection> outgoingConnection = ctx->connect(actualAddr);
+  std::promise<void> prom;
+  listener->accept(
+      [&](const Error& error, std::shared_ptr<Connection> /* unused */) {
+        EXPECT_FALSE(error) << error.what();
+        prom.set_value();
+      });
+  std::future_status res = prom.get_future().wait_for(std::chrono::seconds(1));
+  ASSERT_NE(res, std::future_status::timeout);
+}
+
+TEST_P(ShmListenerTest, AutobindAbstractSocketName) {
+  std::shared_ptr<Context> ctx = GetParam()->getContext();
+  std::shared_ptr<Listener> listener = ctx->listen("");
+  std::string addr = listener->addr();
+  ASSERT_NE(addr, "");
+  // Since Linux 2.3.15 (Aug 1999) the address is in this format, see unix(7).
+  ASSERT_THAT(addr, ::testing::MatchesRegex("[0-9a-f]{5}"));
+  std::shared_ptr<Connection> outgoingConnection = ctx->connect(addr);
+  std::promise<void> prom;
+  listener->accept(
+      [&](const Error& error, std::shared_ptr<Connection> /* unused */) {
+        EXPECT_FALSE(error) << error.what();
+        prom.set_value();
+      });
+  std::future_status res = prom.get_future().wait_for(std::chrono::seconds(1));
+  ASSERT_NE(res, std::future_status::timeout);
+}
+
+INSTANTIATE_TEST_CASE_P(Shm, ShmListenerTest, ::testing::Values(&helper));

--- a/tensorpipe/test/transport/shm/shm_test.h
+++ b/tensorpipe/test/transport/shm/shm_test.h
@@ -22,11 +22,6 @@ class SHMTransportTestHelper : public TransportTestHelper {
 
  public:
   std::string defaultAddr() override {
-    const ::testing::TestInfo* const testInfo =
-        ::testing::UnitTest::GetInstance()->current_test_info();
-    std::ostringstream ss;
-    // Once we upgrade googletest, also use test_info->test_suite_name() here.
-    ss << "tensorpipe_test_" << testInfo->name() << "_" << getpid();
-    return ss.str();
+    return "";
   }
 };

--- a/tensorpipe/transport/shm/listener_impl.cc
+++ b/tensorpipe/transport/shm/listener_impl.cc
@@ -90,7 +90,12 @@ void ListenerImpl::acceptImplFromLoop(accept_callback_fn fn) {
 
 std::string ListenerImpl::addrImplFromLoop() const {
   TP_DCHECK(context_->inLoop());
-  return sockaddr_.str();
+  Error error;
+  struct sockaddr_storage addr;
+  socklen_t addrlen;
+  std::tie(error, addr, addrlen) = socket_.getSockName();
+  TP_THROW_ASSERT_IF(error) << error.what();
+  return Sockaddr(reinterpret_cast<struct sockaddr*>(&addr), addrlen).str();
 }
 
 void ListenerImpl::handleEventsFromLoop(int events) {

--- a/tensorpipe/transport/shm/sockaddr.cc
+++ b/tensorpipe/transport/shm/sockaddr.cc
@@ -24,16 +24,25 @@ Sockaddr Sockaddr::createAbstractUnixAddr(const std::string& name) {
   struct sockaddr_un sun;
   sun.sun_family = AF_UNIX;
   std::memset(&sun.sun_path, 0, sizeof(sun.sun_path));
-  constexpr size_t offset = 1;
-  const size_t len = std::min(sizeof(sun.sun_path) - offset, name.size());
-  std::strncpy(&sun.sun_path[offset], name.c_str(), len);
+  // There are three "modes" for binding UNIX domain sockets:
+  // - if len(addr) == 0: it autobinds to an abstract address
+  // - if len(addr) > 0 and addr[0] == 0: it uses an explicit abstract address
+  // - if len(addr) > 0 and addr[0] != 0: it uses a concrete filesystem path
+  if (name == "") {
+    return Sockaddr(
+        reinterpret_cast<struct sockaddr*>(&sun), sizeof(sun.sun_family));
+  } else {
+    constexpr size_t offset = 1;
+    const size_t len = std::min(sizeof(sun.sun_path) - offset, name.size());
+    std::strncpy(&sun.sun_path[offset], name.data(), len);
 
-  // Note: instead of using sizeof(sun) we compute the addrlen from
-  // the string length of the abstract socket name. If we use
-  // sizeof(sun), lsof shows all the trailing NUL characters.
-  return Sockaddr(
-      reinterpret_cast<struct sockaddr*>(&sun),
-      sizeof(sun.sun_family) + offset + len + 1);
+    // Note: instead of using sizeof(sun) we compute the addrlen from
+    // the string length of the abstract socket name. If we use
+    // sizeof(sun), lsof shows all the trailing NUL characters.
+    return Sockaddr(
+        reinterpret_cast<struct sockaddr*>(&sun),
+        sizeof(sun.sun_family) + offset + len);
+  }
 };
 
 Sockaddr::Sockaddr(const struct sockaddr* addr, socklen_t addrlen) {
@@ -48,7 +57,7 @@ std::string Sockaddr::str() const {
   const struct sockaddr_un* sun{
       reinterpret_cast<const struct sockaddr_un*>(&addr_)};
   constexpr size_t offset = 1;
-  const size_t len = addrlen_ - sizeof(sun->sun_family) - offset - 1;
+  const size_t len = addrlen_ - sizeof(sun->sun_family) - offset;
   return std::string(&sun->sun_path[offset], len);
 }
 

--- a/tensorpipe/transport/shm/sockaddr.h
+++ b/tensorpipe/transport/shm/sockaddr.h
@@ -38,9 +38,9 @@ class Sockaddr final : public tensorpipe::Sockaddr {
 
   std::string str() const;
 
- private:
   explicit Sockaddr(const struct sockaddr* addr, socklen_t addrlen);
 
+ private:
   struct sockaddr_storage addr_;
   socklen_t addrlen_;
 };


### PR DESCRIPTION
Summary: Linux supports "autobind" for UNIX domain sockets, where the kernel automatically assigns an available abstract address, just like it does for IP ports. Until now users had to come up with ways to generate unique(-ish) identifiers to use as addresses, to avoid collisions, but with this feature it's now gone.

Differential Revision: D30158584

