### PR TITLE
Remove dependency of transport benchmarks on CUDA

### DIFF
--- a/tensorpipe/benchmark/benchmark_pipe.cc
+++ b/tensorpipe/benchmark/benchmark_pipe.cc
@@ -272,8 +272,8 @@ static void serverPongPingNonBlock(
                           descriptor.payloads[payloadIdx].length),
                       0);
                   message.payloads[payloadIdx] = {
-                      .length = descriptor.payloads[payloadIdx].length,
                       .data = data.expectedPayload[payloadIdx].get(),
+                      .length = descriptor.payloads[payloadIdx].length,
                   };
                 }
               } else {
@@ -303,6 +303,8 @@ static void serverPongPingNonBlock(
                   message.tensors[tensorIdx] = {
                       .buffer = allocation.tensors[tensorIdx].buffer,
                       .length = descriptor.tensors[tensorIdx].length,
+                      .targetDevice =
+                          descriptor.tensors[tensorIdx].sourceDevice,
                   };
                 }
               } else {
@@ -483,11 +485,13 @@ static void clientPingPongNonBlock(
       if (data.tensorType == TensorType::kCpu) {
         tensor.buffer =
             CpuBuffer{.ptr = data.expectedCpuTensor[tensorIdx].get()};
+        tensor.targetDevice = Device(kCpuDeviceType, 0);
       } else if (data.tensorType == TensorType::kCuda) {
         tensor.buffer = CudaBuffer{
             .ptr = data.expectedCudaTensor[tensorIdx].get(),
             .stream = data.cudaStream.get(),
         };
+        tensor.targetDevice = Device(kCudaDeviceType, 0);
       } else {
         TP_THROW_ASSERT() << "Unknown tensor type";
       }

--- a/tensorpipe/benchmark/channel_registry.cc
+++ b/tensorpipe/benchmark/channel_registry.cc
@@ -88,3 +88,17 @@ std::shared_ptr<tensorpipe::channel::Context> makeCudaGdrChannel() {
 
 TP_REGISTER_CREATOR(TensorpipeChannelRegistry, cuda_gdr, makeCudaGdrChannel);
 #endif // TENSORPIPE_HAS_CUDA_GDR_CHANNEL
+
+void validateChannelContext(
+    std::shared_ptr<tensorpipe::channel::Context> context) {
+  if (!context) {
+    auto keys = TensorpipeChannelRegistry().keys();
+    std::cout
+        << "The channel you passed in is not supported. The following channels are valid: ";
+    for (const auto& key : keys) {
+      std::cout << key << ", ";
+    }
+    std::cout << "\n";
+    exit(EXIT_FAILURE);
+  }
+}

--- a/tensorpipe/benchmark/channel_registry.h
+++ b/tensorpipe/benchmark/channel_registry.h
@@ -14,3 +14,6 @@
 TP_DECLARE_SHARED_REGISTRY(
     TensorpipeChannelRegistry,
     tensorpipe::channel::Context);
+
+void validateChannelContext(
+    std::shared_ptr<tensorpipe::channel::Context> context);

--- a/tensorpipe/benchmark/options.cc
+++ b/tensorpipe/benchmark/options.cc
@@ -12,37 +12,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <tensorpipe/benchmark/channel_registry.h>
-#include <tensorpipe/benchmark/transport_registry.h>
-
 namespace tensorpipe {
 namespace benchmark {
-
-void validateTransportContext(std::shared_ptr<transport::Context> context) {
-  if (!context) {
-    auto keys = TensorpipeTransportRegistry().keys();
-    std::cout
-        << "The transport you passed in is not supported. The following transports are valid: ";
-    for (const auto& key : keys) {
-      std::cout << key << ", ";
-    }
-    std::cout << "\n";
-    exit(EXIT_FAILURE);
-  }
-}
-
-void validateChannelContext(std::shared_ptr<channel::Context> context) {
-  if (!context) {
-    auto keys = TensorpipeChannelRegistry().keys();
-    std::cout
-        << "The channel you passed in is not supported. The following channels are valid: ";
-    for (const auto& key : keys) {
-      std::cout << key << ", ";
-    }
-    std::cout << "\n";
-    exit(EXIT_FAILURE);
-  }
-}
 
 static void usage(int status, const char* argv0) {
   if (status != EXIT_SUCCESS) {

--- a/tensorpipe/benchmark/options.h
+++ b/tensorpipe/benchmark/options.h
@@ -38,8 +38,5 @@ struct Options {
 
 struct Options parseOptions(int argc, char** argv);
 
-void validateTransportContext(std::shared_ptr<transport::Context> context);
-void validateChannelContext(std::shared_ptr<channel::Context> context);
-
 } // namespace benchmark
 } // namespace tensorpipe

--- a/tensorpipe/benchmark/transport_registry.cc
+++ b/tensorpipe/benchmark/transport_registry.cc
@@ -41,3 +41,17 @@ std::shared_ptr<tensorpipe::transport::Context> makeUvContext() {
 }
 
 TP_REGISTER_CREATOR(TensorpipeTransportRegistry, uv, makeUvContext);
+
+void validateTransportContext(
+    std::shared_ptr<tensorpipe::transport::Context> context) {
+  if (!context) {
+    auto keys = TensorpipeTransportRegistry().keys();
+    std::cout
+        << "The transport you passed in is not supported. The following transports are valid: ";
+    for (const auto& key : keys) {
+      std::cout << key << ", ";
+    }
+    std::cout << "\n";
+    exit(EXIT_FAILURE);
+  }
+}

--- a/tensorpipe/benchmark/transport_registry.h
+++ b/tensorpipe/benchmark/transport_registry.h
@@ -14,3 +14,6 @@
 TP_DECLARE_SHARED_REGISTRY(
     TensorpipeTransportRegistry,
     tensorpipe::transport::Context);
+
+void validateTransportContext(
+    std::shared_ptr<tensorpipe::transport::Context> context);


### PR DESCRIPTION
Summary:
Transports are CPU-only but the transport benchmark depends on options.cc which depends on channel_registry.cc which depends on tensorpipe_cuda.h which depends on CUDA. We can move stuff around to fix this.

This was causing build problems with CMake.

Reviewed By: beauby

Differential Revision: D30189313

