### PR TITLE
Make listeners return an address even when closed

### DIFF
--- a/tensorpipe/test/transport/listener_test.cc
+++ b/tensorpipe/test/transport/listener_test.cc
@@ -8,6 +8,7 @@
 
 #include <tensorpipe/test/transport/transport_test.h>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 using namespace tensorpipe;
@@ -114,6 +115,95 @@ TEST_P(TransportTest, Listener_IncomingConnectionsAreQueued) {
     }
 
     donePromise.get_future().get();
+  }
+
+  context->join();
+}
+
+TEST_P(TransportTest, Listener_CreateThenCloseAndThenGetAddress) {
+  auto context = GetParam()->getContext();
+
+  auto listener = context->listen(GetParam()->defaultAddr());
+  listener->close();
+  auto addr = listener->addr();
+
+  std::promise<void> acceptPromise;
+  listener->accept(
+      [&](const Error& error, std::shared_ptr<Connection> /*unused*/) {
+        if (error) {
+          acceptPromise.set_exception(
+              std::make_exception_ptr(std::runtime_error(error.what())));
+        } else {
+          acceptPromise.set_value();
+        }
+      });
+
+  auto connection = context->connect(addr);
+  std::promise<void> writePromise;
+  connection->write(nullptr, 0, [&](const Error& error) {
+    if (error) {
+      writePromise.set_exception(
+          std::make_exception_ptr(std::runtime_error(error.what())));
+    } else {
+      writePromise.set_value();
+    }
+  });
+
+  try {
+    acceptPromise.get_future().get();
+  } catch (const std::runtime_error&) {
+    // Expected
+  }
+
+  try {
+    writePromise.get_future().get();
+  } catch (const std::runtime_error&) {
+    // Expected
+  }
+
+  context->join();
+}
+
+TEST_P(TransportTest, Listener_CreateAfterClosingContextAndThenGetAddress) {
+  auto context = GetParam()->getContext();
+
+  // This means the listener will be created in an already-closed state.
+  context->close();
+  auto listener = context->listen(GetParam()->defaultAddr());
+  auto addr = listener->addr();
+
+  std::promise<void> acceptPromise;
+  listener->accept(
+      [&](const Error& error, std::shared_ptr<Connection> /*unused*/) {
+        if (error) {
+          acceptPromise.set_exception(
+              std::make_exception_ptr(std::runtime_error(error.what())));
+        } else {
+          acceptPromise.set_value();
+        }
+      });
+
+  auto connection = context->connect(addr);
+  std::promise<void> writePromise;
+  connection->write(nullptr, 0, [&](const Error& error) {
+    if (error) {
+      writePromise.set_exception(
+          std::make_exception_ptr(std::runtime_error(error.what())));
+    } else {
+      writePromise.set_value();
+    }
+  });
+
+  try {
+    acceptPromise.get_future().get();
+  } catch (const std::runtime_error&) {
+    // Expected
+  }
+
+  try {
+    writePromise.get_future().get();
+  } catch (const std::runtime_error&) {
+    // Expected
   }
 
   context->join();

--- a/tensorpipe/transport/shm/sockaddr.cc
+++ b/tensorpipe/transport/shm/sockaddr.cc
@@ -54,11 +54,17 @@ Sockaddr::Sockaddr(const struct sockaddr* addr, socklen_t addrlen) {
 }
 
 std::string Sockaddr::str() const {
-  const struct sockaddr_un* sun{
-      reinterpret_cast<const struct sockaddr_un*>(&addr_)};
-  constexpr size_t offset = 1;
-  const size_t len = addrlen_ - sizeof(sun->sun_family) - offset;
-  return std::string(&sun->sun_path[offset], len);
+  TP_DCHECK_GE(addrlen_, sizeof(sockaddr_un::sun_family));
+  if (addrlen_ == sizeof(sockaddr_un::sun_family)) {
+    return "";
+  } else {
+    const struct sockaddr_un* sun{
+        reinterpret_cast<const struct sockaddr_un*>(&addr_)};
+    TP_DCHECK_EQ(sun->sun_path[0], '\0');
+    constexpr size_t offset = 1;
+    const size_t len = addrlen_ - sizeof(sun->sun_family) - offset;
+    return std::string(&sun->sun_path[offset], len);
+  }
 }
 
 } // namespace shm

--- a/tensorpipe/transport/uv/listener_impl.cc
+++ b/tensorpipe/transport/uv/listener_impl.cc
@@ -46,6 +46,8 @@ void ListenerImpl::initImplFromLoop() {
       [this]() { this->closeCallbackFromLoop(); });
   handle_->listenFromLoop(
       [this](int status) { this->connectionCallbackFromLoop(status); });
+
+  sockaddr_ = handle_->sockNameFromLoop();
 }
 
 void ListenerImpl::acceptImplFromLoop(accept_callback_fn fn) {
@@ -53,7 +55,7 @@ void ListenerImpl::acceptImplFromLoop(accept_callback_fn fn) {
 }
 
 std::string ListenerImpl::addrImplFromLoop() const {
-  return handle_->sockNameFromLoop().str();
+  return sockaddr_.str();
 }
 
 void ListenerImpl::connectionCallbackFromLoop(int status) {


### PR DESCRIPTION
Summary:
In D30220352, as I was enabling the automatic SHM address assignment in PyTorch (see D30158584 (https://github.com/pytorch/tensorpipe/commit/e45b2338d0a31192a7e413f3fbbfa7fd90504a37)), I encountered failures in the faulty RPC agent, because it was closing the listener and/or the context very early and _after that_ still requesting the listener's address. This was failing, for example because the file descriptor at that point was closed.

I added tests for these scenarios, and fixed our transports, by having them retrieve and cache the address during init.

Reviewed By: beauby

Differential Revision: D30541085

