### PR TITLE
Fix transport benchmark requiring CUDA

### DIFF
--- a/tensorpipe/benchmark/CMakeLists.txt
+++ b/tensorpipe/benchmark/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # TODO: Make those separate CMake projects.
 
-add_executable(benchmark_transport benchmark_transport.cc options.cc transport_registry.cc channel_registry.cc)
+add_executable(benchmark_transport benchmark_transport.cc options.cc transport_registry.cc)
 target_link_libraries(benchmark_transport PRIVATE tensorpipe)
 
 add_executable(benchmark_pipe benchmark_pipe.cc options.cc transport_registry.cc channel_registry.cc)


### PR DESCRIPTION
Transports are CPU-only, thus the transport benchmark was requiring `tensorpipe` but not `tensorpipe_cuda`. However, for no good reason, it was including the `channel_registry.cc` file, which tried to include CUDA channels, which then couldn't be found at linking.