### PR TITLE
Fix send queue being undersized in IBV

### DIFF
--- a/tensorpipe/channel/cuda_gdr/context_impl.h
+++ b/tensorpipe/channel/cuda_gdr/context_impl.h
@@ -56,14 +56,26 @@ class IbvNic {
     return addr_;
   }
 
+  struct SendInfo {
+    void* addr;
+    size_t length;
+    uint32_t lkey;
+  };
+
   void postSend(
       IbvQueuePair& qp,
-      IbvLib::send_wr& wr,
+      SendInfo info,
       std::function<void(const Error&)> cb);
+
+  struct RecvInfo {
+    void* addr;
+    size_t length;
+    uint32_t lkey;
+  };
 
   void postRecv(
       IbvQueuePair& qp,
-      IbvLib::recv_wr& wr,
+      RecvInfo info,
       std::function<void(const Error&)> cb);
 
   bool pollOnce();
@@ -89,17 +101,13 @@ class IbvNic {
   IbvAddress addr_;
 
   size_t numAvailableRecvSlots_ = kNumRecvs;
-  std::deque<std::tuple<
-      IbvQueuePair&,
-      IbvLib::recv_wr&,
-      std::function<void(const Error&)>>>
+  std::deque<
+      std::tuple<IbvQueuePair&, RecvInfo, std::function<void(const Error&)>>>
       recvsWaitingForSlots_;
 
   size_t numAvailableSendSlots_ = kNumSends;
-  std::deque<std::tuple<
-      IbvQueuePair&,
-      IbvLib::send_wr&,
-      std::function<void(const Error&)>>>
+  std::deque<
+      std::tuple<IbvQueuePair&, SendInfo, std::function<void(const Error&)>>>
       sendsWaitingForSlots_;
 
   // We need one common map for both send and recv requests because in principle

--- a/tensorpipe/transport/ibv/connection_impl.cc
+++ b/tensorpipe/transport/ibv/connection_impl.cc
@@ -135,7 +135,7 @@ void ConnectionImpl::initImplFromLoop() {
     initAttr.qp_type = IbvLib::QPT_RC;
     initAttr.send_cq = context_->getReactor().getIbvCq().get();
     initAttr.recv_cq = context_->getReactor().getIbvCq().get();
-    initAttr.cap.max_send_wr = kNumPendingWriteReqs;
+    initAttr.cap.max_send_wr = kSendQueueSize;
     initAttr.cap.max_send_sge = 1;
     initAttr.srq = context_->getReactor().getIbvSrq().get();
     initAttr.sq_sig_all = 1;

--- a/tensorpipe/transport/ibv/constants.h
+++ b/tensorpipe/transport/ibv/constants.h
@@ -53,4 +53,13 @@ constexpr int kCompletionQueueSize =
 // iteration.
 constexpr int kNumPolledWorkCompletions = 32;
 
+// When the connection gets closed, to avoid leaks, it needs to "reclaim" all
+// the work requests that it had posted, by waiting for their completion. They
+// may however complete with error, which makes it harder to identify and
+// distinguish them from failing incoming requests because, in principle, we
+// cannot access the opcode field of a failed work completion. Therefore, we
+// assign a special ID to those types of requests, to match them later on.
+constexpr uint64_t kWriteRequestId = 1;
+constexpr uint64_t kAckRequestId = 2;
+
 } // namespace

--- a/tensorpipe/transport/ibv/constants.h
+++ b/tensorpipe/transport/ibv/constants.h
@@ -49,6 +49,12 @@ constexpr uint32_t kNumPendingAckReqs = 1024;
 constexpr int kCompletionQueueSize =
     kNumPendingRecvReqs + kNumPendingWriteReqs + kNumPendingAckReqs;
 
+// How many pending outgoing work requests each send queue should be able to
+// hold. The operations we post on a send queue are the RDMA_WRITEs to send
+// outgoing data and the SENDs to acknowledge incoming data, hence we size the
+// queue to the sum of the maximum amount of these two ops.
+constexpr int kSendQueueSize = kNumPendingWriteReqs + kNumPendingAckReqs;
+
 // How many work completions to poll from the completion queue at each reactor
 // iteration.
 constexpr int kNumPolledWorkCompletions = 32;

--- a/tensorpipe/transport/ibv/reactor.cc
+++ b/tensorpipe/transport/ibv/reactor.cc
@@ -168,8 +168,23 @@ void Reactor::unregisterQp(uint32_t qpn) {
   queuePairEventHandler_.erase(qpn);
 }
 
-void Reactor::postWrite(IbvQueuePair& qp, IbvLib::send_wr& wr) {
+void Reactor::postWrite(IbvQueuePair& qp, WriteInfo info) {
   if (numAvailableWrites_ > 0) {
+    IbvLib::sge list;
+    list.addr = reinterpret_cast<uint64_t>(info.addr);
+    list.length = info.length;
+    list.lkey = info.lkey;
+
+    IbvLib::send_wr wr;
+    std::memset(&wr, 0, sizeof(wr));
+    wr.wr_id = kWriteRequestId;
+    wr.sg_list = &list;
+    wr.num_sge = 1;
+    wr.opcode = IbvLib::WR_RDMA_WRITE_WITH_IMM;
+    wr.imm_data = info.length;
+    wr.wr.rdma.remote_addr = info.remoteAddr;
+    wr.wr.rdma.rkey = info.rkey;
+
     IbvLib::send_wr* badWr = nullptr;
     TP_VLOG(9) << "Transport context " << id_ << " posting RDMA write for QP "
                << qp->qp_num;
@@ -179,12 +194,18 @@ void Reactor::postWrite(IbvQueuePair& qp, IbvLib::send_wr& wr) {
   } else {
     TP_VLOG(9) << "Transport context " << id_
                << " queueing up RDMA write for QP " << qp->qp_num;
-    pendingQpWrites_.emplace_back(qp, wr);
+    pendingQpWrites_.emplace_back(qp, info);
   }
 }
 
-void Reactor::postAck(IbvQueuePair& qp, IbvLib::send_wr& wr) {
+void Reactor::postAck(IbvQueuePair& qp, AckInfo info) {
   if (numAvailableAcks_ > 0) {
+    IbvLib::send_wr wr;
+    std::memset(&wr, 0, sizeof(wr));
+    wr.wr_id = kAckRequestId;
+    wr.opcode = IbvLib::WR_SEND_WITH_IMM;
+    wr.imm_data = info.length;
+
     IbvLib::send_wr* badWr = nullptr;
     TP_VLOG(9) << "Transport context " << id_ << " posting send for QP "
                << qp->qp_num;
@@ -194,7 +215,7 @@ void Reactor::postAck(IbvQueuePair& qp, IbvLib::send_wr& wr) {
   } else {
     TP_VLOG(9) << "Transport context " << id_ << " queueing send for QP "
                << qp->qp_num;
-    pendingQpAcks_.emplace_back(qp, wr);
+    pendingQpAcks_.emplace_back(qp, info);
   }
 }
 

--- a/tensorpipe/transport/ibv/reactor.h
+++ b/tensorpipe/transport/ibv/reactor.h
@@ -79,9 +79,21 @@ class Reactor final : public BusyPollingLoop {
 
   void unregisterQp(uint32_t qpn);
 
-  void postWrite(IbvQueuePair& qp, IbvLib::send_wr& wr);
+  struct WriteInfo {
+    void* addr;
+    size_t length;
+    uint32_t lkey;
+    uint64_t remoteAddr;
+    uint32_t rkey;
+  };
 
-  void postAck(IbvQueuePair& qp, IbvLib::send_wr& wr);
+  void postWrite(IbvQueuePair& qp, WriteInfo info);
+
+  struct AckInfo {
+    size_t length;
+  };
+
+  void postAck(IbvQueuePair& qp, AckInfo info);
 
   void setId(std::string id);
 
@@ -121,8 +133,8 @@ class Reactor final : public BusyPollingLoop {
 
   uint32_t numAvailableWrites_{kNumPendingWriteReqs};
   uint32_t numAvailableAcks_{kNumPendingAckReqs};
-  std::deque<std::tuple<IbvQueuePair&, IbvLib::send_wr>> pendingQpWrites_;
-  std::deque<std::tuple<IbvQueuePair&, IbvLib::send_wr>> pendingQpAcks_;
+  std::deque<std::tuple<IbvQueuePair&, WriteInfo>> pendingQpWrites_;
+  std::deque<std::tuple<IbvQueuePair&, AckInfo>> pendingQpAcks_;
 };
 
 } // namespace ibv


### PR DESCRIPTION
Summary: When creating a queue in InfiniBand one must specify its maximum capacity, but by mistake we were assuming that in IBV the send queue only held RDMA_WRITE requests, and had forgotten about the SEND requests (for acknowledgements). This caused the queue to be undersized, thus for some of our `post` calls to fail unexpectedly (because we were convinced the queue still had capacity and thus asserted that the call couldn't fail).

Reviewed By: beauby

Differential Revision: D32102685

