### PR TITLE
Add a helper to auto-detect a node's address like NCCL does

### DIFF
--- a/tensorpipe/test/transport/uv/context_test.cc
+++ b/tensorpipe/test/transport/uv/context_test.cc
@@ -50,4 +50,12 @@ TEST_P(UVTransportContextTest, LookupInterfaceAddress) {
 }
 #endif
 
+TEST_P(UVTransportContextTest, LookupAddressLikeNccl) {
+  Error error;
+  std::string addr;
+  std::tie(error, addr) = transport::uv::lookupAddrLikeNccl();
+  EXPECT_FALSE(error) << error.what();
+  EXPECT_NE(addr, "");
+}
+
 INSTANTIATE_TEST_CASE_P(Uv, UVTransportContextTest, ::testing::Values(&helper));

--- a/tensorpipe/transport/uv/utility.cc
+++ b/tensorpipe/transport/uv/utility.cc
@@ -135,6 +135,85 @@ std::tuple<Error, std::string> lookupAddrForHostname() {
   }
 }
 
+std::tuple<Error, std::string> lookupAddrLikeNccl(
+    optional<sa_family_t> familyFilter) {
+  int rv;
+  InterfaceAddresses addresses;
+  int count;
+  std::tie(rv, addresses, count) = getInterfaceAddresses();
+  if (rv < 0) {
+    return std::make_tuple(TP_CREATE_ERROR(UVError, rv), std::string());
+  }
+
+  // Libuv already only returns the interfaces that are up and running, whose
+  // address is not null, and whose family is IPv4 or IPv6.
+
+  // NCCL prioritizes the interfaces whose name starts with "ib" (for IP over
+  // InfiniBand?), and deprioritizes those that start with "docker" or "lo".
+  optional<std::string> withIbPrefix;
+  optional<std::string> withoutPrefix;
+  optional<std::string> withDockerPrefix;
+  optional<std::string> withLoPrefix;
+
+  for (auto i = 0; i < count; i++) {
+    const uv_interface_address_t& interface = addresses[i];
+    const struct sockaddr* sockaddr =
+        reinterpret_cast<const struct sockaddr*>(&interface.address);
+
+    // NCCL also seems to ignore any IPv6 loopback address.
+    if (sockaddr->sa_family == AF_INET6 && interface.is_internal) {
+      continue;
+    }
+
+    if (familyFilter.has_value() &&
+        sockaddr->sa_family != familyFilter.value()) {
+      continue;
+    }
+
+    std::string addr;
+    switch (sockaddr->sa_family) {
+      case AF_INET:
+        addr = Sockaddr(sockaddr, sizeof(struct sockaddr_in)).str();
+        break;
+      case AF_INET6:
+        addr = Sockaddr(sockaddr, sizeof(struct sockaddr_in6)).str();
+        break;
+    }
+
+    std::string name = interface.name;
+    if (name.find("ib") == 0) {
+      if (!withIbPrefix.has_value()) {
+        withIbPrefix = std::move(addr);
+      }
+    } else if (name.find("docker") == 0) {
+      if (!withDockerPrefix.has_value()) {
+        withDockerPrefix = std::move(addr);
+      }
+    } else if (name.find("lo") == 0) {
+      if (!withLoPrefix.has_value()) {
+        withLoPrefix = std::move(addr);
+      }
+    } else {
+      if (!withoutPrefix.has_value()) {
+        withoutPrefix = std::move(addr);
+      }
+    }
+  }
+
+  if (withIbPrefix.has_value()) {
+    return std::make_tuple(Error::kSuccess, std::move(withIbPrefix).value());
+  } else if (withoutPrefix.has_value()) {
+    return std::make_tuple(Error::kSuccess, std::move(withoutPrefix).value());
+  } else if (withDockerPrefix.has_value()) {
+    return std::make_tuple(
+        Error::kSuccess, std::move(withDockerPrefix).value());
+  } else if (withLoPrefix.has_value()) {
+    return std::make_tuple(Error::kSuccess, std::move(withLoPrefix).value());
+  }
+
+  return std::make_tuple(TP_CREATE_ERROR(NoAddrFoundError), std::string());
+}
+
 } // namespace uv
 } // namespace transport
 } // namespace tensorpipe

--- a/tensorpipe/transport/uv/utility.h
+++ b/tensorpipe/transport/uv/utility.h
@@ -11,7 +11,10 @@
 #include <string>
 #include <tuple>
 
+#include <sys/socket.h>
+
 #include <tensorpipe/common/error.h>
+#include <tensorpipe/common/optional.h>
 
 namespace tensorpipe {
 namespace transport {
@@ -20,6 +23,13 @@ namespace uv {
 std::tuple<Error, std::string> lookupAddrForIface(std::string iface);
 
 std::tuple<Error, std::string> lookupAddrForHostname();
+
+// Try to replicate the same logic used by NCCL to find a node's own address.
+// Roughly, it returns the "first" usable address it can find, and prioritizes
+// the interfaces with an `ib` prefix and de-prioritizes those with a `docker`
+// or `lo` prefix. It can optionally only return only IPv4 or IPv4 addresses.
+std::tuple<Error, std::string> lookupAddrLikeNccl(
+    optional<sa_family_t> familyFilter = nullopt);
 
 } // namespace uv
 } // namespace transport


### PR DESCRIPTION
Summary:
One issue that has been plaguing a lot of users is the way TensorPipe auto-detects a machine's own address, which then PyTorch broadcasts to other machines so that they can connect to each other. TensorPipe chose to imitate what Gloo was doing (i.e., resolve the machine's hostname), though that turned out to not be ideal. We've found that in several cases the users' machines were not properly configured for this to work. I believe part of the reason is that in fact not that many people are using Gloo, and instead they use NCCL (because they do GPU training), thus they have configured their machines to work with NCCL's logic but not for Gloo's or TensorPipe's. While we could ask all users to fix their setup, perhaps it's simpler to just start imitating what NCCL does?

In this diff I start by just adding a helper to TensorPipe that should replicate NCCL's address selection logic. This by itself doesn't do anything, but it allows our users (PyTorch, Herring, ...) to more easily switch to this if they so wish.

 ---

Deep-dive into NCCL's address detection

To see how NCCL does it, let's start from the `bootstrapNetInit()` function [here](https://github.com/NVIDIA/nccl/blob/30ca3fcacf8a73c48d7b8f7aaa54ae8bff89e884/src/bootstrap.cc#L22). What NCCL calls "bootstrap" is the initial handshake phase which always happens over TCP, where nodes do rendezvous and agree whether to use TCP or InfiniBand later. We should assume that the `NCCL_COMM_ID` env var is unset, which means that [this callsite](https://github.com/NVIDIA/nccl/blob/30ca3fcacf8a73c48d7b8f7aaa54ae8bff89e884/src/bootstrap.cc#L38) is what fetches the address. That function is defined [here](https://github.com/NVIDIA/nccl/blob/7e515921295adaab72adf56ea71a0fafb0ecb5f3/src/include/socket.h#L290) and, if we suppose that `NCCL_SOCKET_IFNAME` is also unset, we see that the core logic of that function is:
```
// Try to automatically pick the right one
// Start with IB
nIfs = findInterfaces("ib", ifNames, ifAddrs, sock_family, ifNameMaxSize, maxIfs);
// Then look for anything else (but not docker or lo)
if (nIfs == 0) nIfs = findInterfaces("^docker,lo", ifNames, ifAddrs, sock_family, ifNameMaxSize, maxIfs);
// Finally look for docker, then lo.
if (nIfs == 0) nIfs = findInterfaces("docker", ifNames, ifAddrs, sock_family, ifNameMaxSize, maxIfs);
if (nIfs == 0) nIfs = findInterfaces("lo", ifNames, ifAddrs, sock_family, ifNameMaxSize, maxIfs);
```
Each of these calls just ends up [here](https://github.com/NVIDIA/nccl/blob/7e515921295adaab72adf56ea71a0fafb0ecb5f3/src/include/socket.h#L68), which simply iterates over all interfaces and returns the address of the first one that matches all the criteria (i.e., which is up&running, which is not loopback, whose family corresponds to the requested one, whose name matches the filter, ...).

Differential Revision: D32135340

