### PR TITLE
Avoid accessing possibly-undefined InfiniBand field in GDR

### DIFF
--- a/tensorpipe/channel/cuda_gdr/context_impl.h
+++ b/tensorpipe/channel/cuda_gdr/context_impl.h
@@ -115,7 +115,9 @@ class IbvNic {
   // match it to its callback. However, we could group them by QP number or, in
   // fact, we could have the QP store these requests and we just wake it up when
   // a completion occurs.
-  std::unordered_map<uint64_t, std::function<void(const Error&)>>
+  std::unordered_map<
+      uint64_t,
+      std::tuple<IbvLib::wc_opcode, std::function<void(const Error&)>>>
       requestsInFlight_;
   uint64_t nextRequestId_ = 0;
 


### PR DESCRIPTION
In case of a Work Completion (WC) that resulted in an error, only some fields are "valid": status, wr_id and qp_num. In particular opcode isn't valid, and yet we were inspecting it to determine whether it was a send or recv request (and increase the corresponding pointer). In case of error, the opcode was neither send nor recv and this triggered an assert. The "solution" is to store the opcode ourselves, separately, in a map indexed by wr_id. We already have such a map, hence we just inster a new field into it.