### PR TITLE
Duplicate CUDA GDR channel for XDTT.

### DIFF
--- a/tensorpipe/channel/cuda_gdr_xdtt/channel_impl.cc
+++ b/tensorpipe/channel/cuda_gdr_xdtt/channel_impl.cc
@@ -1,0 +1,625 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/channel/cuda_gdr/channel_impl.h>
+
+#include <algorithm>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <tensorpipe/channel/cuda_gdr/context_impl.h>
+#include <tensorpipe/common/cuda_buffer.h>
+#include <tensorpipe/common/defs.h>
+#include <tensorpipe/common/error.h>
+#include <tensorpipe/transport/connection.h>
+
+namespace tensorpipe {
+namespace channel {
+namespace cuda_gdr {
+
+namespace {
+
+size_t ceilOfRatio(size_t n, size_t d) {
+  return (n + d - 1) / d;
+}
+
+} // namespace
+
+ChannelImpl::ChannelImpl(
+    ConstructorToken token,
+    std::shared_ptr<ContextImpl> context,
+    std::string id,
+    std::shared_ptr<transport::Connection> descriptorConnection,
+    std::shared_ptr<transport::Connection> readyToReceiveConnection)
+    : ChannelImplBoilerplate<ContextImpl, ChannelImpl>(
+          token,
+          std::move(context),
+          std::move(id)),
+      descriptorConnection_(std::move(descriptorConnection)),
+      readyToReceiveConnection_(std::move(readyToReceiveConnection)) {}
+
+void ChannelImpl::initImplFromLoop() {
+  TP_DCHECK(context_->inLoop());
+  TP_DCHECK_EQ(state_, INITIALIZING);
+  TP_DCHECK(!error_);
+
+  context_->enroll(*this);
+
+  localGpuToNic_ = context_->getGpuToNicMapping();
+  numLocalNics_ =
+      *std::max_element(localGpuToNic_.begin(), localGpuToNic_.end()) + 1;
+
+  auto nopHolderOut = std::make_shared<NopHolder<HandshakeNumNics>>();
+  HandshakeNumNics& nopHandshakeNumNics = nopHolderOut->getObject();
+  nopHandshakeNumNics.numNics = numLocalNics_;
+  TP_VLOG(6) << "Channel " << id_
+             << " is writing nop object (handshake num NICs)";
+  readyToReceiveConnection_->write(
+      *nopHolderOut, callbackWrapper_([nopHolderOut](ChannelImpl& impl) {
+        TP_VLOG(6) << "Channel " << impl.id_
+                   << " done writing nop object (handshake num NICs)";
+      }));
+
+  auto nopHolderIn = std::make_shared<NopHolder<HandshakeNumNics>>();
+  TP_VLOG(6) << "Channel " << id_
+             << " is reading nop object (handshake num NICs)";
+  readyToReceiveConnection_->read(
+      *nopHolderIn, callbackWrapper_([nopHolderIn](ChannelImpl& impl) {
+        TP_VLOG(6) << "Channel " << impl.id_
+                   << " done reading nop object (handshake num NICs)";
+        if (!impl.error_) {
+          impl.onReadHandshakeNumNics(nopHolderIn->getObject());
+        }
+      }));
+
+  state_ = WAITING_FOR_HANDSHAKE_NUM_NICS;
+}
+
+void ChannelImpl::onReadHandshakeNumNics(
+    const HandshakeNumNics& nopHandshakeNumNics) {
+  TP_DCHECK(context_->inLoop());
+  TP_DCHECK_EQ(state_, WAITING_FOR_HANDSHAKE_NUM_NICS);
+  TP_DCHECK(!error_);
+
+  numRemoteNics_ = nopHandshakeNumNics.numNics;
+
+  std::vector<std::vector<NopIbvSetupInformation>> allSetupInfo;
+
+  queuePairs_.resize(numLocalNics_);
+  allSetupInfo.resize(numLocalNics_);
+  for (size_t localNicIdx = 0; localNicIdx < numLocalNics_; localNicIdx++) {
+    queuePairs_[localNicIdx].resize(numRemoteNics_);
+    allSetupInfo[localNicIdx].resize(numRemoteNics_);
+    IbvNic& localNic = context_->getIbvNic(localNicIdx);
+    for (size_t remoteNicIdx = 0; remoteNicIdx < numRemoteNics_;
+         remoteNicIdx++) {
+      IbvLib::qp_init_attr initAttr;
+      std::memset(&initAttr, 0, sizeof(initAttr));
+      initAttr.qp_type = IbvLib::QPT_RC;
+      initAttr.send_cq = localNic.getIbvCq().get();
+      initAttr.recv_cq = localNic.getIbvCq().get();
+      initAttr.cap.max_send_wr = kNumSends;
+      initAttr.cap.max_send_sge = 1;
+      initAttr.cap.max_recv_wr = kNumRecvs;
+      initAttr.cap.max_recv_sge = 1;
+      initAttr.sq_sig_all = 1;
+      IbvQueuePair qp = createIbvQueuePair(
+          context_->getIbvLib(), localNic.getIbvPd(), initAttr);
+
+      transitionIbvQueuePairToInit(
+          context_->getIbvLib(), qp, localNic.getIbvAddress());
+
+      IbvSetupInformation setupInfo =
+          makeIbvSetupInformation(localNic.getIbvAddress(), qp);
+
+      // The maximum message size will be filled in later.
+      queuePairs_[localNicIdx][remoteNicIdx] =
+          QueuePair{std::move(qp), /*maximumMessageSize=*/0};
+      allSetupInfo[localNicIdx][remoteNicIdx].fromIbvSetupInformation(
+          setupInfo);
+    }
+  }
+
+  auto nopHolderOut = std::make_shared<NopHolder<HandshakeSetupInfo>>();
+  HandshakeSetupInfo& nopHandshakeSetupInfo = nopHolderOut->getObject();
+  nopHandshakeSetupInfo.setupInfo = std::move(allSetupInfo);
+  TP_VLOG(6) << "Channel " << id_ << " is writing nop object (handshake two)";
+  readyToReceiveConnection_->write(
+      *nopHolderOut, callbackWrapper_([nopHolderOut](ChannelImpl& impl) {
+        TP_VLOG(6) << "Channel " << impl.id_
+                   << " done writing nop object (handshake two)";
+      }));
+
+  auto nopHolderIn = std::make_shared<NopHolder<HandshakeSetupInfo>>();
+  TP_VLOG(6) << "Channel " << id_ << " is reading nop object (handshake two)";
+  readyToReceiveConnection_->read(
+      *nopHolderIn, callbackWrapper_([nopHolderIn](ChannelImpl& impl) {
+        TP_VLOG(6) << "Channel " << impl.id_
+                   << " done reading nop object (handshake two)";
+        if (!impl.error_) {
+          impl.onReadHandshakeSetupInfo(nopHolderIn->getObject());
+        }
+      }));
+
+  state_ = WAITING_FOR_HANDSHAKE_SETUP_INFO;
+}
+
+void ChannelImpl::onReadHandshakeSetupInfo(
+    const HandshakeSetupInfo& nopHandshakeSetupInfo) {
+  TP_DCHECK(context_->inLoop());
+  TP_DCHECK_EQ(state_, WAITING_FOR_HANDSHAKE_SETUP_INFO);
+  TP_DCHECK(!error_);
+
+  const std::vector<std::vector<NopIbvSetupInformation>>& remoteSetupInfo =
+      nopHandshakeSetupInfo.setupInfo;
+
+  TP_DCHECK_EQ(remoteSetupInfo.size(), numRemoteNics_);
+  for (size_t remoteNicIdx = 0; remoteNicIdx < numRemoteNics_; remoteNicIdx++) {
+    TP_DCHECK_EQ(remoteSetupInfo[remoteNicIdx].size(), numLocalNics_);
+    for (size_t localNicIdx = 0; localNicIdx < numLocalNics_; localNicIdx++) {
+      IbvNic& localNic = context_->getIbvNic(localNicIdx);
+      IbvSetupInformation setupInfo =
+          remoteSetupInfo[remoteNicIdx][localNicIdx].toIbvSetupInformation();
+      const IbvAddress& localAddress = localNic.getIbvAddress();
+
+      transitionIbvQueuePairToReadyToReceive(
+          context_->getIbvLib(),
+          queuePairs_[localNicIdx][remoteNicIdx].queuePair,
+          localAddress,
+          setupInfo);
+      transitionIbvQueuePairToReadyToSend(
+          context_->getIbvLib(),
+          queuePairs_[localNicIdx][remoteNicIdx].queuePair);
+
+      queuePairs_[localNicIdx][remoteNicIdx].maximumMessageSize = std::min(
+          localAddress.maximumMessageSize, setupInfo.maximumMessageSize);
+    }
+  }
+
+  state_ = ESTABLISHED;
+  sendOps_.advanceAllOperations();
+  recvOps_.advanceAllOperations();
+}
+
+void ChannelImpl::sendImplFromLoop(
+    uint64_t sequenceNumber,
+    Buffer buffer,
+    size_t length,
+    TSendCallback callback) {
+  size_t localGpuIdx = cudaDeviceForPointer(
+      context_->getCudaLib(), buffer.unwrap<CudaBuffer>().ptr);
+  size_t localNicIdx = context_->getGpuToNicMapping()[localGpuIdx];
+
+  SendOpIter opIter = sendOps_.emplaceBack(
+      sequenceNumber,
+      buffer.unwrap<CudaBuffer>(),
+      length,
+      std::move(callback),
+      localGpuIdx,
+      localNicIdx);
+  opIter->event.record(buffer.unwrap<CudaBuffer>().stream);
+
+  sendOps_.advanceOperation(opIter);
+}
+
+void ChannelImpl::advanceSendOperation(
+    SendOpIter opIter,
+    SendOperation::State prevOpState) {
+  TP_DCHECK(context_->inLoop());
+
+  SendOperation& op = *opIter;
+
+  sendOps_.attemptTransition(
+      opIter,
+      /*from=*/SendOperation::UNINITIALIZED,
+      /*to=*/SendOperation::FINISHED,
+      /*cond=*/error_ || op.length == 0,
+      /*actions=*/{&ChannelImpl::callSendCallback});
+
+  // Needs to go after previous op to ensure predictable and consistent ordering
+  // of write calls on the descriptor control connection and read calls on the
+  // completion control connection.
+  sendOps_.attemptTransition(
+      opIter,
+      /*from=*/SendOperation::UNINITIALIZED,
+      /*to=*/SendOperation::READING_READY_TO_RECEIVE,
+      /*cond=*/!error_ && state_ == ESTABLISHED &&
+          prevOpState >= SendOperation::READING_READY_TO_RECEIVE,
+      /*actions=*/
+      {&ChannelImpl::writeDescriptor, &ChannelImpl::readReadyToReceive});
+
+  sendOps_.attemptTransition(
+      opIter,
+      /*from=*/SendOperation::READING_READY_TO_RECEIVE,
+      /*to=*/SendOperation::FINISHED,
+      /*cond=*/error_ && op.doneReadingReadyToReceive,
+      /*actions=*/{&ChannelImpl::callSendCallback});
+
+  // This doesn't strictly need to go after the previous op, but it doesn't make
+  // sense to busy poll multiple events if only one of them is actually able to
+  // then make progress.
+  sendOps_.attemptTransition(
+      opIter,
+      /*from=*/SendOperation::READING_READY_TO_RECEIVE,
+      /*to=*/SendOperation::WAITING_FOR_CUDA_EVENT,
+      /*cond=*/!error_ && op.doneReadingReadyToReceive &&
+          prevOpState >= SendOperation::SENDING_OVER_IB,
+      /*actions=*/{&ChannelImpl::waitForSendCudaEvent});
+
+  sendOps_.attemptTransition(
+      opIter,
+      /*from=*/SendOperation::WAITING_FOR_CUDA_EVENT,
+      /*to=*/SendOperation::FINISHED,
+      /*cond=*/error_ && op.doneWaitingForCudaEvent,
+      /*actions=*/{&ChannelImpl::callSendCallback});
+
+  // Needs to go after previous op to ensure predictable and consistent ordering
+  // of send calls on InfiniBand queue pair.
+  sendOps_.attemptTransition(
+      opIter,
+      /*from=*/SendOperation::WAITING_FOR_CUDA_EVENT,
+      /*to=*/SendOperation::SENDING_OVER_IB,
+      /*cond=*/!error_ && op.doneWaitingForCudaEvent &&
+          prevOpState >= SendOperation::SENDING_OVER_IB,
+      /*actions=*/{&ChannelImpl::sendOverIb});
+
+  sendOps_.attemptTransition(
+      opIter,
+      /*from=*/SendOperation::SENDING_OVER_IB,
+      /*to=*/SendOperation::FINISHED,
+      /*cond=*/op.numChunksBeingSent == 0,
+      /*actions=*/{&ChannelImpl::callSendCallback});
+}
+
+void ChannelImpl::writeDescriptor(SendOpIter opIter) {
+  TP_DCHECK(context_->inLoop());
+  SendOperation& op = *opIter;
+
+  auto nopHolder = std::make_shared<NopHolder<Descriptor>>();
+  Descriptor& nopDescriptor = nopHolder->getObject();
+  nopDescriptor.originNicIdx = op.localNicIdx;
+
+  TP_VLOG(6) << "Channel " << id_ << " is writing descriptor (#"
+             << op.sequenceNumber << ")";
+  descriptorConnection_->write(
+      *nopHolder,
+      callbackWrapper_([sequenceNumber{op.sequenceNumber},
+                        nopHolder](ChannelImpl& impl) {
+        TP_VLOG(6) << "Channel " << impl.id_ << " done writing descriptor (# "
+                   << sequenceNumber << ")";
+      }));
+}
+
+void ChannelImpl::readReadyToReceive(SendOpIter opIter) {
+  TP_DCHECK(context_->inLoop());
+  SendOperation& op = *opIter;
+
+  auto nopHolderIn = std::make_shared<NopHolder<ReadyToReceive>>();
+  TP_VLOG(6) << "Channel " << id_ << " is reading ready-to-receive (#"
+             << op.sequenceNumber << ")";
+  readyToReceiveConnection_->read(
+      *nopHolderIn, callbackWrapper_([opIter, nopHolderIn](ChannelImpl& impl) {
+        TP_VLOG(6) << "Channel " << impl.id_
+                   << " done reading ready-to-receive (# "
+                   << opIter->sequenceNumber << ")";
+        opIter->doneReadingReadyToReceive = true;
+        if (!impl.error_) {
+          const auto& readyToReceive = nopHolderIn->getObject();
+          opIter->remoteNicIdx = readyToReceive.destinationNicIdx;
+        }
+        impl.sendOps_.advanceOperation(opIter);
+      }));
+}
+
+void ChannelImpl::waitForSendCudaEvent(SendOpIter opIter) {
+  TP_DCHECK(context_->inLoop());
+
+  SendOperation& op = *opIter;
+
+  TP_VLOG(6) << "Channel " << id_ << " is waiting for CUDA event to send (#"
+             << op.sequenceNumber << ")";
+  context_->waitForCudaEvent(
+      op.event, callbackWrapper_([opIter](ChannelImpl& impl) {
+        TP_VLOG(6) << "Channel " << impl.id_
+                   << " done waiting for CUDA event to send (# "
+                   << opIter->sequenceNumber << ")";
+        opIter->doneWaitingForCudaEvent = true;
+        impl.sendOps_.advanceOperation(opIter);
+      }));
+}
+
+void ChannelImpl::sendOverIb(SendOpIter opIter) {
+  TP_DCHECK(context_->inLoop());
+
+  SendOperation& op = *opIter;
+
+  IbvNic& localNic = context_->getIbvNic(op.localNicIdx);
+  IbvQueuePair& qp = queuePairs_[op.localNicIdx][op.remoteNicIdx].queuePair;
+  size_t chunkSize =
+      queuePairs_[op.localNicIdx][op.remoteNicIdx].maximumMessageSize;
+
+  // This could be VEEERY slow the first time we encounter the buffer, but the
+  // result will be cached and subsequent calls will be much faster.
+  IbvMemoryRegion& mr = localNic.registerMemory(op.buffer);
+
+  size_t numChunks = ceilOfRatio(op.length, chunkSize);
+  for (size_t chunkIdx = 0; chunkIdx < numChunks; chunkIdx++) {
+    IbvNic::SendInfo info;
+    info.addr =
+        reinterpret_cast<uint8_t*>(op.buffer.ptr) + chunkIdx * chunkSize;
+    info.length = std::min(op.length - chunkIdx * chunkSize, chunkSize);
+    info.lkey = mr->lkey;
+
+    TP_VLOG(6) << "Channel " << id_ << " is sending chunk #" << chunkIdx
+               << " (out of " << numChunks << ") of tensor #"
+               << op.sequenceNumber << " on QP " << qp->qp_num;
+    localNic.postSend(
+        qp, info, callbackWrapper_([opIter, chunkIdx](ChannelImpl& impl) {
+          TP_VLOG(6) << "Channel " << impl.id_ << " done sending chunk #"
+                     << chunkIdx << " of tensor #" << opIter->sequenceNumber;
+          opIter->numChunksBeingSent--;
+          impl.sendOps_.advanceOperation(opIter);
+
+          impl.numSendsInFlight_--;
+          impl.tryCleanup();
+        }));
+    op.numChunksBeingSent++;
+    numSendsInFlight_++;
+  }
+}
+
+void ChannelImpl::callSendCallback(SendOpIter opIter) {
+  TP_DCHECK(context_->inLoop());
+
+  SendOperation& op = *opIter;
+
+  op.callback(error_);
+  // Reset callback to release the resources it was holding.
+  op.callback = nullptr;
+}
+
+void ChannelImpl::recvImplFromLoop(
+    uint64_t sequenceNumber,
+    Buffer buffer,
+    size_t length,
+    TRecvCallback callback) {
+  size_t localGpuIdx = cudaDeviceForPointer(
+      context_->getCudaLib(), buffer.unwrap<CudaBuffer>().ptr);
+  size_t localNicIdx = context_->getGpuToNicMapping()[localGpuIdx];
+
+  RecvOpIter opIter = recvOps_.emplaceBack(
+      sequenceNumber,
+      buffer.unwrap<CudaBuffer>(),
+      length,
+      std::move(callback),
+      localGpuIdx,
+      localNicIdx);
+  opIter->event.record(buffer.unwrap<CudaBuffer>().stream);
+
+  recvOps_.advanceOperation(opIter);
+}
+
+void ChannelImpl::advanceRecvOperation(
+    RecvOpIter opIter,
+    RecvOperation::State prevOpState) {
+  TP_DCHECK(context_->inLoop());
+
+  RecvOperation& op = *opIter;
+
+  recvOps_.attemptTransition(
+      opIter,
+      /*from=*/RecvOperation::UNINITIALIZED,
+      /*to=*/RecvOperation::FINISHED,
+      /*cond=*/error_ || op.length == 0,
+      /*actions=*/{&ChannelImpl::callRecvCallback});
+
+  // Needs to go after previous op to ensure predictable and consistent ordering
+  // of write calls on the descriptor control connection.
+  recvOps_.attemptTransition(
+      opIter,
+      /*from=*/RecvOperation::UNINITIALIZED,
+      /*to=*/RecvOperation::READING_DESCRIPTOR,
+      /*cond=*/!error_ && state_ == ESTABLISHED &&
+          prevOpState >= RecvOperation::READING_DESCRIPTOR,
+      /*actions=*/{&ChannelImpl::readDescriptor});
+
+  recvOps_.attemptTransition(
+      opIter,
+      /*from=*/RecvOperation::READING_DESCRIPTOR,
+      /*to=*/RecvOperation::FINISHED,
+      /*cond=*/error_ && op.doneReadingDescriptor,
+      /*actions=*/{&ChannelImpl::callRecvCallback});
+
+  // This doesn't strictly need to go after the previous op, but it doesn't make
+  // sense to busy poll multiple events if only one of them is actually able to
+  // then make progress.
+  recvOps_.attemptTransition(
+      opIter,
+      /*from=*/RecvOperation::READING_DESCRIPTOR,
+      /*to=*/RecvOperation::WAITING_FOR_CUDA_EVENT,
+      /*cond=*/!error_ && op.doneReadingDescriptor &&
+          prevOpState >= RecvOperation::RECEIVING_OVER_IB,
+      /*actions=*/{&ChannelImpl::waitForRecvCudaEvent});
+
+  recvOps_.attemptTransition(
+      opIter,
+      /*from=*/RecvOperation::WAITING_FOR_CUDA_EVENT,
+      /*to=*/RecvOperation::FINISHED,
+      /*cond=*/error_ && op.doneWaitingForCudaEvent,
+      /*actions=*/{&ChannelImpl::callRecvCallback});
+
+  // Needs to go after previous op to ensure predictable and consistent ordering
+  // of recv calls on InfiniBand queue pair and write calls on the completion
+  // control connection.
+  recvOps_.attemptTransition(
+      opIter,
+      /*from=*/RecvOperation::WAITING_FOR_CUDA_EVENT,
+      /*to=*/RecvOperation::RECEIVING_OVER_IB,
+      /*cond=*/!error_ && op.doneWaitingForCudaEvent &&
+          prevOpState >= RecvOperation::RECEIVING_OVER_IB,
+      /*actions=*/{&ChannelImpl::recvOverIbAndWriteReadyToRecive});
+
+  recvOps_.attemptTransition(
+      opIter,
+      /*from=*/RecvOperation::RECEIVING_OVER_IB,
+      /*to=*/RecvOperation::FINISHED,
+      /*cond=*/op.numChunksBeingReceived == 0,
+      /*actions=*/{&ChannelImpl::callRecvCallback});
+}
+
+void ChannelImpl::readDescriptor(RecvOpIter opIter) {
+  TP_DCHECK(context_->inLoop());
+
+  RecvOperation& op = *opIter;
+
+  TP_VLOG(6) << "Channel " << id_ << " is reading descriptor (#"
+             << op.sequenceNumber << ")";
+  auto nopHolderIn = std::make_shared<NopHolder<Descriptor>>();
+  descriptorConnection_->read(
+      *nopHolderIn, callbackWrapper_([opIter, nopHolderIn](ChannelImpl& impl) {
+        TP_VLOG(6) << "Channel " << impl.id_ << " done reading descriptor (# "
+                   << opIter->sequenceNumber << ")";
+        opIter->doneReadingDescriptor = true;
+        if (!impl.error_) {
+          Descriptor& nopDescriptor = nopHolderIn->getObject();
+          opIter->remoteNicIdx = nopDescriptor.originNicIdx;
+        }
+        impl.recvOps_.advanceOperation(opIter);
+      }));
+}
+
+void ChannelImpl::waitForRecvCudaEvent(RecvOpIter opIter) {
+  TP_DCHECK(context_->inLoop());
+
+  RecvOperation& op = *opIter;
+
+  TP_VLOG(6) << "Channel " << id_ << " is waiting for CUDA event to recv (#"
+             << op.sequenceNumber << ")";
+  context_->waitForCudaEvent(
+      op.event, callbackWrapper_([opIter](ChannelImpl& impl) {
+        TP_VLOG(6) << "Channel " << impl.id_
+                   << " done waiting for CUDA event to recv (# "
+                   << opIter->sequenceNumber << ")";
+        opIter->doneWaitingForCudaEvent = true;
+        impl.recvOps_.advanceOperation(opIter);
+      }));
+}
+
+void ChannelImpl::recvOverIbAndWriteReadyToRecive(RecvOpIter opIter) {
+  TP_DCHECK(context_->inLoop());
+
+  RecvOperation& op = *opIter;
+
+  IbvNic& localNic = context_->getIbvNic(op.localNicIdx);
+  IbvQueuePair& qp = queuePairs_[op.localNicIdx][op.remoteNicIdx].queuePair;
+  size_t chunkSize =
+      queuePairs_[op.localNicIdx][op.remoteNicIdx].maximumMessageSize;
+
+  // This could be VEEERY slow the first time we encounter the buffer, but the
+  // result will be cached and subsequent calls will be much faster.
+  IbvMemoryRegion& mr = localNic.registerMemory(op.buffer);
+
+  size_t numChunks = ceilOfRatio(op.length, chunkSize);
+  for (size_t chunkIdx = 0; chunkIdx < numChunks; chunkIdx++) {
+    IbvNic::RecvInfo info;
+    info.addr =
+        reinterpret_cast<uint8_t*>(op.buffer.ptr) + chunkIdx * chunkSize;
+    info.length = std::min(op.length - chunkIdx * chunkSize, chunkSize);
+    info.lkey = mr->lkey;
+
+    TP_VLOG(6) << "Channel " << id_ << " is receiving chunk #" << chunkIdx
+               << " (out of " << numChunks << ") of tensor #"
+               << op.sequenceNumber << " on QP " << qp->qp_num;
+    localNic.postRecv(
+        qp, info, callbackWrapper_([opIter, chunkIdx](ChannelImpl& impl) {
+          TP_VLOG(6) << "Channel " << impl.id_ << " done receiving chunk #"
+                     << chunkIdx << " of tensor #" << opIter->sequenceNumber;
+          opIter->numChunksBeingReceived--;
+          impl.recvOps_.advanceOperation(opIter);
+
+          impl.numRecvsInFlight_--;
+          impl.tryCleanup();
+        }));
+    op.numChunksBeingReceived++;
+    numRecvsInFlight_++;
+  }
+
+  auto nopHolderOut = std::make_shared<NopHolder<ReadyToReceive>>();
+  ReadyToReceive& nopReadyToReceive = nopHolderOut->getObject();
+  nopReadyToReceive.destinationNicIdx = op.localNicIdx;
+  TP_VLOG(6) << "Channel " << id_ << " is writing ready-to-receive (#"
+             << op.sequenceNumber << ")";
+  readyToReceiveConnection_->write(
+      *nopHolderOut,
+      callbackWrapper_([sequenceNumber{opIter->sequenceNumber},
+                        nopHolderOut](ChannelImpl& impl) {
+        TP_VLOG(6) << "Channel " << impl.id_
+                   << " done writing ready-to-receive (#" << sequenceNumber
+                   << ")";
+      }));
+}
+
+void ChannelImpl::callRecvCallback(RecvOpIter opIter) {
+  TP_DCHECK(context_->inLoop());
+
+  RecvOperation& op = *opIter;
+
+  op.callback(error_);
+  // Reset callback to release the resources it was holding.
+  op.callback = nullptr;
+}
+
+void ChannelImpl::handleErrorImpl() {
+  sendOps_.advanceAllOperations();
+  recvOps_.advanceAllOperations();
+
+  for (size_t localNicIdx = 0; localNicIdx < numLocalNics_; localNicIdx++) {
+    for (size_t remoteNicIdx = 0; remoteNicIdx < numRemoteNics_;
+         remoteNicIdx++) {
+      transitionIbvQueuePairToError(
+          context_->getIbvLib(),
+          queuePairs_[localNicIdx][remoteNicIdx].queuePair);
+    }
+  }
+
+  tryCleanup();
+
+  descriptorConnection_->close();
+  readyToReceiveConnection_->close();
+}
+
+void ChannelImpl::tryCleanup() {
+  TP_DCHECK(context_->inLoop());
+
+  if (error_) {
+    if (numSendsInFlight_ == 0 && numRecvsInFlight_ == 0) {
+      cleanup();
+    } else {
+      TP_VLOG(9) << "Connection " << id_
+                 << " cannot proceed to cleanup because it has "
+                 << numSendsInFlight_ << " pending send requests and "
+                 << numRecvsInFlight_ << " pending recv requests";
+    }
+  }
+}
+
+void ChannelImpl::cleanup() {
+  TP_DCHECK(context_->inLoop());
+  TP_VLOG(8) << "Connection " << id_ << " is cleaning up";
+
+  queuePairs_.clear();
+
+  context_->unenroll(*this);
+}
+
+} // namespace cuda_gdr
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/cuda_gdr_xdtt/channel_impl.h
+++ b/tensorpipe/channel/cuda_gdr_xdtt/channel_impl.h
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <list>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <nop/serializer.h>
+#include <nop/structure.h>
+
+#include <tensorpipe/channel/channel_impl_boilerplate.h>
+#include <tensorpipe/common/cuda.h>
+#include <tensorpipe/common/cuda_buffer.h>
+#include <tensorpipe/common/ibv.h>
+#include <tensorpipe/common/state_machine.h>
+#include <tensorpipe/transport/context.h>
+
+namespace tensorpipe {
+namespace channel {
+namespace cuda_gdr {
+
+class ContextImpl;
+
+// Ideally we would use NOP_EXTERNAL_STRUCTURE instead of defining the following
+// two structs, but we tried so in D26460332 and failed because a bug in GCC 5.5
+// (and probably other versions) requires every nop structure used inside a
+// std::vector to have an explicit non-defaulted default constructor, which is
+// something we cannot do with NOP_EXTERNAL_STRUCTURE and forces us to re-define
+// separate structs.
+
+// Replicate the IbvLib::gid struct so we can serialize it with libnop.
+struct NopIbvGid {
+  uint64_t subnetPrefix;
+  uint64_t interfaceId;
+  NOP_STRUCTURE(NopIbvGid, subnetPrefix, interfaceId);
+
+  void fromIbvGid(const IbvLib::gid& globalIdentifier) {
+    subnetPrefix = globalIdentifier.global.subnet_prefix;
+    interfaceId = globalIdentifier.global.interface_id;
+  }
+
+  IbvLib::gid toIbvGid() const {
+    IbvLib::gid globalIdentifier;
+    globalIdentifier.global.subnet_prefix = subnetPrefix;
+    globalIdentifier.global.interface_id = interfaceId;
+    return globalIdentifier;
+  }
+};
+
+// Replicate the IbvSetupInformation struct so we can serialize it with libnop.
+struct NopIbvSetupInformation {
+  // This pointless constructor is needed to work around a bug in GCC 5.5 (and
+  // possibly other versions). It appears to be needed in the nop types that
+  // are used inside std::vectors.
+  NopIbvSetupInformation() {}
+
+  uint32_t localIdentifier;
+  NopIbvGid globalIdentifier;
+  uint32_t queuePairNumber;
+  IbvLib::mtu maximumTransmissionUnit;
+  uint32_t maximumMessageSize;
+  NOP_STRUCTURE(
+      NopIbvSetupInformation,
+      localIdentifier,
+      globalIdentifier,
+      queuePairNumber,
+      maximumTransmissionUnit,
+      maximumMessageSize);
+
+  void fromIbvSetupInformation(const IbvSetupInformation& setupInfo) {
+    localIdentifier = setupInfo.localIdentifier;
+    globalIdentifier.fromIbvGid(setupInfo.globalIdentifier);
+    queuePairNumber = setupInfo.queuePairNumber;
+    maximumTransmissionUnit = setupInfo.maximumTransmissionUnit;
+    maximumMessageSize = setupInfo.maximumMessageSize;
+  }
+
+  IbvSetupInformation toIbvSetupInformation() const {
+    IbvSetupInformation setupInfo;
+    setupInfo.localIdentifier = localIdentifier;
+    setupInfo.globalIdentifier = globalIdentifier.toIbvGid();
+    setupInfo.queuePairNumber = queuePairNumber;
+    setupInfo.maximumTransmissionUnit = maximumTransmissionUnit;
+    setupInfo.maximumMessageSize = maximumMessageSize;
+    return setupInfo;
+  }
+};
+
+struct SendOperation {
+  enum State {
+    UNINITIALIZED,
+    READING_READY_TO_RECEIVE,
+    WAITING_FOR_CUDA_EVENT,
+    SENDING_OVER_IB,
+    FINISHED
+  };
+
+  // Fields used by the state machine
+  uint64_t sequenceNumber{0};
+  State state{UNINITIALIZED};
+
+  // Progress flags
+  bool doneReadingReadyToReceive{false};
+  bool doneWaitingForCudaEvent{false};
+  uint64_t numChunksBeingSent{0};
+
+  // Arguments at creation
+  const CudaBuffer buffer;
+  const size_t length;
+  const size_t localNicIdx;
+  TSendCallback callback;
+
+  // Other stuff
+  CudaEvent event;
+  size_t remoteNicIdx;
+
+  SendOperation(
+      CudaBuffer buffer,
+      size_t length,
+      TSendCallback callback,
+      size_t localGpuIdx,
+      size_t localNicIdx)
+      : buffer(buffer),
+        length(length),
+        localNicIdx(localNicIdx),
+        callback(std::move(callback)),
+        event(localGpuIdx) {}
+};
+
+struct RecvOperation {
+  enum State {
+    UNINITIALIZED,
+    READING_DESCRIPTOR,
+    WAITING_FOR_CUDA_EVENT,
+    RECEIVING_OVER_IB,
+    FINISHED
+  };
+
+  // Fields used by the state machine
+  uint64_t sequenceNumber{0};
+  State state{UNINITIALIZED};
+
+  // Progress flags
+  bool doneReadingDescriptor{false};
+  bool doneWaitingForCudaEvent{false};
+  uint64_t numChunksBeingReceived{0};
+
+  // Arguments at creation
+  const CudaBuffer buffer;
+  const size_t length;
+  const size_t localNicIdx;
+  TSendCallback callback;
+
+  // Other stuff
+  size_t remoteNicIdx;
+  CudaEvent event;
+
+  RecvOperation(
+      CudaBuffer buffer,
+      size_t length,
+      TSendCallback callback,
+      size_t deviceIdx,
+      size_t localNicIdx)
+      : buffer(buffer),
+        length(length),
+        localNicIdx(localNicIdx),
+        callback(std::move(callback)),
+        event(deviceIdx) {}
+};
+
+// First "round" of handshake.
+struct HandshakeNumNics {
+  size_t numNics;
+  NOP_STRUCTURE(HandshakeNumNics, numNics);
+};
+
+// Second "round" of handshake.
+struct HandshakeSetupInfo {
+  std::vector<std::vector<NopIbvSetupInformation>> setupInfo;
+  NOP_STRUCTURE(HandshakeSetupInfo, setupInfo);
+};
+
+// From sender to receiver (through pipe).
+struct Descriptor {
+  size_t originNicIdx;
+  NOP_STRUCTURE(Descriptor, originNicIdx);
+};
+
+// From receiver to sender (through channel's connection).
+struct ReadyToReceive {
+  size_t destinationNicIdx;
+  NOP_STRUCTURE(ReadyToReceive, destinationNicIdx);
+};
+
+class ChannelImpl final
+    : public ChannelImplBoilerplate<ContextImpl, ChannelImpl> {
+ public:
+  ChannelImpl(
+      ConstructorToken token,
+      std::shared_ptr<ContextImpl> context,
+      std::string id,
+      std::shared_ptr<transport::Connection> descriptorConnection,
+      std::shared_ptr<transport::Connection> readyToReceiveConnection);
+
+ protected:
+  // Implement the entry points called by ChannelImplBoilerplate.
+  void initImplFromLoop() override;
+  void sendImplFromLoop(
+      uint64_t sequenceNumber,
+      Buffer buffer,
+      size_t length,
+      TSendCallback callback) override;
+  void recvImplFromLoop(
+      uint64_t sequenceNumber,
+      Buffer buffer,
+      size_t length,
+      TRecvCallback callback) override;
+  void handleErrorImpl() override;
+
+ private:
+  const std::shared_ptr<transport::Connection> descriptorConnection_;
+  const std::shared_ptr<transport::Connection> readyToReceiveConnection_;
+
+  enum State {
+    INITIALIZING = 1,
+    WAITING_FOR_HANDSHAKE_NUM_NICS,
+    WAITING_FOR_HANDSHAKE_SETUP_INFO,
+    ESTABLISHED,
+  };
+  State state_{INITIALIZING};
+
+  std::vector<size_t> localGpuToNic_;
+  size_t numLocalNics_{0};
+  size_t numRemoteNics_{0};
+
+  // This struct is used to bundle the queue pair with some additional metadata.
+  struct QueuePair {
+    IbvQueuePair queuePair;
+    // The CUDA GDR channel could be asked to transmit arbitrarily large tensors
+    // and in principle it could directly forward them to the NIC as they are.
+    // However IB NICs have limits on the size of each message. Hence we
+    // determine these sizes, one per queue pair (as the minimum of the local
+    // and remote sizes) and then split our tensors in chunks of that size.
+    uint32_t maximumMessageSize;
+  };
+  std::vector<std::vector<QueuePair>> queuePairs_;
+
+  OpsStateMachine<ChannelImpl, SendOperation> sendOps_{
+      *this,
+      &ChannelImpl::advanceSendOperation};
+  using SendOpIter = decltype(sendOps_)::Iter;
+  OpsStateMachine<ChannelImpl, RecvOperation> recvOps_{
+      *this,
+      &ChannelImpl::advanceRecvOperation};
+  using RecvOpIter = decltype(recvOps_)::Iter;
+
+  uint32_t numSendsInFlight_{0};
+  uint32_t numRecvsInFlight_{0};
+
+  // Callbacks for the initial handshake phase.
+  void onReadHandshakeNumNics(const HandshakeNumNics& nopHandshakeNumNics);
+  void onReadHandshakeSetupInfo(
+      const HandshakeSetupInfo& nopHandshakeSetupInfo);
+
+  // Cleanup methods for teardown.
+  void tryCleanup();
+  void cleanup();
+
+  // State machines for send and recv ops.
+  void advanceSendOperation(
+      SendOpIter opIter,
+      SendOperation::State prevOpState);
+  void advanceRecvOperation(
+      RecvOpIter opIter,
+      RecvOperation::State prevOpState);
+
+  // Actions (i.e., methods that begin a state transition).
+  // For send operations:
+  void writeDescriptor(SendOpIter opIter);
+  void readReadyToReceive(SendOpIter opIter);
+  void waitForSendCudaEvent(SendOpIter opIter);
+  void sendOverIb(SendOpIter opIter);
+  void callSendCallback(SendOpIter opIter);
+  // For recv operations:
+  void readDescriptor(RecvOpIter opIter);
+  void waitForRecvCudaEvent(RecvOpIter opIter);
+  void recvOverIbAndWriteReadyToRecive(RecvOpIter opIter);
+  void callRecvCallback(RecvOpIter opIter);
+};
+
+} // namespace cuda_gdr
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/cuda_gdr_xdtt/constants.h
+++ b/tensorpipe/channel/cuda_gdr_xdtt/constants.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace tensorpipe {
+namespace channel {
+namespace cuda_gdr {
+
+namespace {
+
+// We should probably allow these to be user-configured. But, for now, we'll set
+// them to the lowest value they can have, the rationale being that this way
+// they will always be valid.
+constexpr uint8_t kPortNum = 1;
+constexpr uint8_t kGlobalIdentifierIndex = 0;
+
+// FIXME Instead of hardcoding the next three values, we could use
+// ibv_query_device to obtain max_cqe, max_qp_wr and max_srq_wr and deduce from
+// them the maximum allowed values for these parameters.
+
+constexpr uint32_t kNumRecvs = 1024;
+constexpr uint32_t kNumSends = 1024;
+
+// How many elements the completion queue should be able to hold. These elements
+// will be either the completed receive requests of the SRQ, or the completed
+// send requests from a connection's queue pair. We can bound the former value
+// but not the latter, so we try to add some margin.
+constexpr int kCompletionQueueSize = kNumRecvs + kNumSends;
+
+// How many work completions to poll from the completion queue at each reactor
+// iteration.
+constexpr int kNumPolledWorkCompletions = 32;
+
+} // namespace
+
+} // namespace cuda_gdr
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/cuda_gdr_xdtt/context_impl.cc
+++ b/tensorpipe/channel/cuda_gdr_xdtt/context_impl.cc
@@ -1,0 +1,682 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/channel/cuda_gdr/context_impl.h>
+
+#include <array>
+#include <climits>
+#include <cstdlib>
+#include <functional>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <tensorpipe/channel/cuda_gdr/channel_impl.h>
+#include <tensorpipe/channel/cuda_gdr/error.h>
+#include <tensorpipe/common/cuda.h>
+#include <tensorpipe/common/defs.h>
+#include <tensorpipe/common/error_macros.h>
+
+namespace tensorpipe {
+namespace channel {
+namespace cuda_gdr {
+
+namespace {
+
+// NOTE: This is an incomplete implementation of C++17's `std::apply`.
+// It's intended to only work for methods of IbvNic.
+template <class TMethod, class TArgsTuple, std::size_t... I>
+auto applyFuncImpl(
+    IbvNic& subject,
+    TMethod&& method,
+    TArgsTuple&& args,
+    std::index_sequence<I...> /* unused */) {
+  return ((subject).*(method))(std::get<I>(std::forward<TArgsTuple>(args))...);
+}
+
+template <class TMethod, class TArgsTuple>
+auto applyFunc(IbvNic& subject, TMethod&& method, TArgsTuple&& args) {
+  return applyFuncImpl(
+      subject,
+      std::forward<TMethod>(method),
+      std::forward<TArgsTuple>(args),
+      std::make_index_sequence<
+          std::tuple_size<std::remove_reference_t<TArgsTuple>>::value>{});
+}
+
+// We can only pass CUDA pointers to InfiniBand (for example when registering
+// some memory) if InfiniBand "knows about" CUDA. Those pointers refer to the
+// section of the process's virtual address space that is being used by CUDA to
+// represent device memory (as part of CUDA's unified memory approach). Thus
+// InfiniBand needs to talk to CUDA to translate those pointers to physical PCIe
+// hardware addresses.
+// This is achieved by CUDA providing a so-called "peer memory client" and
+// registering it with the InfiniBand kernel module. The peer memory client is
+// itself a kernel module, see https://github.com/Mellanox/nv_peer_memory.
+// The "catch" is that the whole "peer memory client" system is not part of the
+// official Linux InfiniBand. It's provided by a Mellanox extension, and it's
+// part of their "OpenFabrics Enterprise Distribution" (MLNX_OFED), see
+// https://www.mellanox.com/products/infiniband-drivers/linux/mlnx_ofed. (In
+// particular, on Ubuntu, this seems to be provided by the mlnx-ofed-kernel-dkms
+// package). Note that this difference between "vanilla" InfiniBand and OFED is
+// only in kernel space; from our perspective the two have the same API. Also
+// note that Mellanox has tried at least a couple of time to upstream this, but
+// apparently without success:
+// https://lore.kernel.org/linux-rdma/1412602019-30659-1-git-send-email-yishaih@mellanox.com/
+// https://lore.kernel.org/linux-rdma/1455207177-11949-1-git-send-email-artemyko@mellanox.com/
+// The check we use to verify if the peer memory client is active is the same as
+// NCCL's one, see
+// https://github.com/NVIDIA/nccl/blob/ca8485b0d01ca6dfa02f4454932011e68b461175/src/transport/net_ib.cc#L216-L230
+// Whereas TensorFlow does it slightly differently, see
+// https://github.com/tensorflow/networking/blob/671e2548b602f93a6c6502432b8bc131b5cc4914/tensorflow_networking/gdr/gdr_memory_manager.cc#L43-L60
+static std::string kNvMemModulePath =
+    "/sys/kernel/mm/memory_peers/nv_mem/version";
+static std::string kNvidiaPeermemModulePath =
+    "/sys/kernel/mm/memory_peers/nvidia-peermem/version";
+
+bool isNvidiaPeerMemoryClientActive() {
+  int rv1 = ::access(kNvMemModulePath.c_str(), F_OK);
+  int rv2 = ::access(kNvidiaPeermemModulePath.c_str(), F_OK);
+  return rv1 >= 0 || rv2 >= 0;
+}
+
+// The PCI topology is a tree, with the root being the host bridge, the leaves
+// being the devices, and the other nodes being switches. We want to match each
+// GPU to the InfiniBand NIC with which it shares the longest "prefix" in this
+// tree, as that will route the data transfer away from the most "central"
+// switches and from the host bridge. We extract the "path" of a device in the
+// PCI tree by obtaining its "canonical" path in Linux's sysfs, which contains
+// one component for each other device that is traversed. The format of such a
+// path is /sys/devices/pci0123:45(/0123:45:67.8)+");
+// See https://www.kernel.org/doc/ols/2005/ols2005v1-pages-321-334.pdf for more
+// info on sysfs.
+
+const std::string kPciPathPrefix = "/sys/devices/pci";
+
+std::string getPciPathForIbvNic(const std::string& nicName) {
+  std::array<char, PATH_MAX> pciPath;
+  char* rv = ::realpath(
+      ("/sys/class/infiniband/" + nicName + "/device").c_str(), pciPath.data());
+  TP_THROW_SYSTEM_IF(rv == nullptr, errno);
+  TP_DCHECK(rv == pciPath.data());
+
+  std::string res(pciPath.data());
+  TP_DCHECK(res.substr(0, kPciPathPrefix.size()) == kPciPathPrefix)
+      << "Bad PCI path for InfiniBand NIC " << nicName << ": " << res;
+  return res;
+}
+
+std::string getPciPathForGpu(int gpuIdx) {
+  // The CUDA documentation says the ID will consist of a domain (16 bits), a
+  // bus (8 bits), a device (5 bits) and a function (3 bits). When represented
+  // as hex, including the separators and the null terminator, this takes up 13
+  // bytes. However NCCL seems to suggests that sometimes the domain takes twice
+  // that size, and hence 17 bytes are necessary.
+  // https://github.com/NVIDIA/nccl/blob/c6dbdb00849027b4e2c277653cbef53729f7213d/src/misc/utils.cc#L49-L53
+  std::array<char, 17> pciDeviceId;
+  TP_CUDA_CHECK(
+      cudaDeviceGetPCIBusId(pciDeviceId.data(), pciDeviceId.size(), gpuIdx));
+
+  // Fun fact: CUDA seems to format hex letters as uppercase, but Linux's sysfs
+  // expects them as lowercase.
+  for (char& c : pciDeviceId) {
+    if ('A' <= c && c <= 'F') {
+      c = c - 'A' + 'a';
+    }
+  }
+
+  std::array<char, PATH_MAX> pciPath;
+  char* rv = ::realpath(
+      ("/sys/bus/pci/devices/" + std::string(pciDeviceId.data())).c_str(),
+      pciPath.data());
+  TP_THROW_SYSTEM_IF(rv == nullptr, errno);
+  TP_DCHECK(rv == pciPath.data());
+
+  std::string res(pciPath.data());
+  TP_DCHECK(res.substr(0, kPciPathPrefix.size()) == kPciPathPrefix)
+      << "Bad PCI path for GPU #" << gpuIdx << ": " << res;
+  return res;
+}
+
+size_t commonPrefixLength(const std::string& a, const std::string& b) {
+  // The length of the longest common prefix is the index of the first char on
+  // which the two strings differ.
+  size_t maxLength = std::min(a.size(), b.size());
+  for (size_t idx = 0; idx < maxLength; idx++) {
+    if (a[idx] != b[idx]) {
+      return idx;
+    }
+  }
+  return maxLength;
+}
+
+std::vector<std::string> matchGpusToIbvNics(
+    IbvLib& ibvLib,
+    IbvDeviceList& deviceList) {
+  struct NicInfo {
+    std::string name;
+    std::string pciPath;
+  };
+  std::vector<NicInfo> nicInfos;
+  for (size_t deviceIdx = 0; deviceIdx < deviceList.size(); deviceIdx++) {
+    IbvLib::device& device = deviceList[deviceIdx];
+    std::string deviceName(TP_CHECK_IBV_PTR(ibvLib.get_device_name(&device)));
+    std::string pciPath = getPciPathForIbvNic(deviceName);
+    TP_VLOG(5) << "Resolved InfiniBand NIC " << deviceName << " to PCI path "
+               << pciPath;
+    nicInfos.push_back(NicInfo{std::move(deviceName), std::move(pciPath)});
+  }
+
+  int numGpus;
+  TP_CUDA_CHECK(cudaGetDeviceCount(&numGpus));
+
+  std::vector<std::string> gpuIdxToIbvNicName;
+  for (int gpuIdx = 0; gpuIdx < numGpus; gpuIdx++) {
+    std::string gpuPciPath = getPciPathForGpu(gpuIdx);
+    TP_VLOG(5) << "Resolved GPU #" << gpuIdx << " to PCI path " << gpuPciPath;
+    ssize_t bestMatchLength = -1;
+    const std::string* bestMatchName = nullptr;
+    for (const auto& nicInfo : nicInfos) {
+      ssize_t matchLength = commonPrefixLength(gpuPciPath, nicInfo.pciPath);
+      if (matchLength > bestMatchLength) {
+        bestMatchLength = matchLength;
+        bestMatchName = &nicInfo.name;
+      }
+    }
+    TP_DCHECK_GE(bestMatchLength, 0);
+    TP_DCHECK(bestMatchName != nullptr);
+    gpuIdxToIbvNicName.push_back(*bestMatchName);
+  }
+
+  return gpuIdxToIbvNicName;
+}
+
+// In GpuDirect, the way an InfiniBand NIC accesses the GPU's memory is by
+// issuing a PCIe read to some address within the GPU's "base address register"
+// (BAR), i.e., a slice of the "physical" PCIe address space that belongs to the
+// GPU. BARs in principle provide only "windows" into a device's memory, and
+// could be re-mapped over time. When a CUDA allocation is registered on
+// InfiniBand, its backing memory is mapped into the BAR and its address is
+// given to the InfiniBand driver. That mapping must remain in place until the
+// registration is destroyed. See
+// https://docs.nvidia.com/cuda/gpudirect-rdma/index.html#how-gpudirect-rdma-works.
+// CUDA GDR doesn't work well with that, because:
+// - It attempts to register the entire user allocation with InfiniBand, hence
+//   allocations that exceed the BAR's size can never be transferred.
+// - It "caches" (or "leaks") the InfiniBand registration, because creating it
+//   is expensive, so that this can be done once and then reused. This means
+//   that even if each tensor that is sent is smaller than the BAR, we'd start
+//   seeing failures if their cumulative size exceeded the one of the BAR.
+// On some GPUs though the BAR size spans the entire GPU memory. In such cases
+// what CUDA GDR is doing should be "safe". In all other cases, however, it
+// isn't, and it's better to thus disable CUDA GDR entirely in these scenarios,
+// so that users end up using a fully functioning (but slower) CUDA channel.
+// There are multiple BARs for each GPU, but from an experimental investigation
+// it seems the one that maps to the device's memory is BAR1. The programmatic
+// way that the Linux kernel offers to access information about PCIe and its
+// BARs is through sysfs. See
+// https://www.kernel.org/doc/html/latest/PCI/sysfs-pci.html.
+
+size_t getBar1SizeOfGpu(int gpuIdx) {
+  std::string pciPath = getPciPathForGpu(gpuIdx);
+  pciPath += "/resource1";
+
+  struct stat bar1Stats;
+  int rv = ::stat(pciPath.c_str(), &bar1Stats);
+  TP_THROW_SYSTEM_IF(rv < 0, errno);
+
+  return bar1Stats.st_size;
+}
+
+bool allGpusHaveEnoughBar1Size() {
+  int numGpus;
+  TP_CUDA_CHECK(cudaGetDeviceCount(&numGpus));
+  for (int gpuIdx = 0; gpuIdx < numGpus; gpuIdx++) {
+    cudaDeviceProp gpuProps;
+    TP_CUDA_CHECK(cudaGetDeviceProperties(&gpuProps, gpuIdx));
+    size_t memorySize = gpuProps.totalGlobalMem;
+    size_t bar1Size = getBar1SizeOfGpu(gpuIdx);
+    TP_VLOG(5) << "GPU #" << gpuIdx << " has " << memorySize
+               << " bytes of memory and the size of its PCIe BAR1 is "
+               << bar1Size << " bytes";
+    if (bar1Size < memorySize) {
+      return false;
+    }
+  }
+  return true;
+}
+
+} // namespace
+
+IbvNic::IbvNic(
+    std::string name,
+    IbvLib::device& device,
+    const IbvLib& ibvLib,
+    const CudaLib& cudaLib)
+    : name_(std::move(name)), cudaLib_(cudaLib), ibvLib_(ibvLib) {
+  ctx_ = createIbvContext(ibvLib_, device);
+  pd_ = createIbvProtectionDomain(ibvLib_, ctx_);
+  cq_ = createIbvCompletionQueue(
+      ibvLib_,
+      ctx_,
+      kCompletionQueueSize,
+      /*cq_context=*/nullptr,
+      /*channel=*/nullptr,
+      /*comp_vector=*/0);
+  addr_ = makeIbvAddress(ibvLib_, ctx_, kPortNum, kGlobalIdentifierIndex);
+}
+
+bool IbvNic::pollOnce() {
+  std::array<IbvLib::wc, kNumPolledWorkCompletions> wcs;
+  auto rv = ibvLib_.poll_cq(cq_.get(), wcs.size(), wcs.data());
+
+  if (rv == 0) {
+    return false;
+  }
+  TP_THROW_SYSTEM_IF(rv < 0, errno);
+
+  int numSends = 0;
+  int numRecvs = 0;
+  for (int wcIdx = 0; wcIdx < rv; wcIdx++) {
+    IbvLib::wc& wc = wcs[wcIdx];
+
+    TP_VLOG(6) << "Channel context " << id_ << " got work completion on device "
+               << name_ << " for request " << wc.wr_id << " for QP "
+               << wc.qp_num << " with status "
+               << ibvLib_.wc_status_str(wc.status) << " and opcode "
+               << ibvWorkCompletionOpcodeToStr(wc.opcode)
+               << " (byte length: " << wc.byte_len << ")";
+
+    auto iter = requestsInFlight_.find(wc.wr_id);
+    TP_THROW_ASSERT_IF(iter == requestsInFlight_.end())
+        << "Got work completion with unknown ID " << wc.wr_id;
+
+    IbvLib::wc_opcode opcode = std::move(std::get<0>(iter->second));
+    std::function<void(const Error&)> cb = std::move(std::get<1>(iter->second));
+    requestsInFlight_.erase(iter);
+
+    if (wc.status != IbvLib::WC_SUCCESS) {
+      cb(TP_CREATE_ERROR(IbvError, ibvLib_.wc_status_str(wc.status)));
+    } else {
+      cb(Error::kSuccess);
+    }
+
+    switch (opcode) {
+      case IbvLib::WC_RECV:
+        numRecvs++;
+        break;
+      case IbvLib::WC_SEND:
+        numSends++;
+        break;
+      default:
+        TP_THROW_ASSERT() << "Unknown opcode: " << opcode;
+    }
+  }
+
+  numAvailableSendSlots_ += numSends;
+  while (!sendsWaitingForSlots_.empty() && numAvailableSendSlots_ > 0) {
+    applyFunc(
+        *this, &IbvNic::postSend, std::move(sendsWaitingForSlots_.front()));
+    sendsWaitingForSlots_.pop_front();
+  }
+
+  numAvailableRecvSlots_ += numRecvs;
+  while (!recvsWaitingForSlots_.empty() && numAvailableRecvSlots_ > 0) {
+    applyFunc(
+        *this, &IbvNic::postRecv, std::move(recvsWaitingForSlots_.front()));
+    recvsWaitingForSlots_.pop_front();
+  }
+
+  return true;
+}
+
+void IbvNic::postSend(
+    IbvQueuePair& qp,
+    SendInfo info,
+    std::function<void(const Error&)> cb) {
+  if (numAvailableSendSlots_ > 0) {
+    IbvLib::sge list;
+    list.addr = reinterpret_cast<uint64_t>(info.addr);
+    list.length = info.length;
+    list.lkey = info.lkey;
+
+    IbvLib::send_wr wr;
+    std::memset(&wr, 0, sizeof(wr));
+    wr.wr_id = nextRequestId_++;
+    wr.sg_list = &list;
+    wr.num_sge = 1;
+    wr.opcode = IbvLib::WR_SEND;
+
+    IbvLib::send_wr* badWr = nullptr;
+    TP_VLOG(6) << "Channel context " << id_ << " posting send on device "
+               << name_ << " for QP " << qp->qp_num;
+    TP_CHECK_IBV_INT(ibvLib_.post_send(qp.get(), &wr, &badWr));
+    TP_THROW_ASSERT_IF(badWr != nullptr);
+    numAvailableSendSlots_--;
+    requestsInFlight_.emplace(
+        wr.wr_id, std::make_tuple(IbvLib::WC_SEND, std::move(cb)));
+  } else {
+    TP_VLOG(6) << "Channel context " << id_ << " queueing up send on device "
+               << name_ << " for QP " << qp->qp_num;
+    sendsWaitingForSlots_.emplace_back(qp, info, std::move(cb));
+  }
+}
+
+void IbvNic::postRecv(
+    IbvQueuePair& qp,
+    RecvInfo info,
+    std::function<void(const Error&)> cb) {
+  if (numAvailableRecvSlots_ > 0) {
+    IbvLib::sge list;
+    list.addr = reinterpret_cast<uint64_t>(info.addr);
+    list.length = info.length;
+    list.lkey = info.lkey;
+
+    IbvLib::recv_wr wr;
+    std::memset(&wr, 0, sizeof(wr));
+    wr.wr_id = nextRequestId_++;
+    wr.sg_list = &list;
+    wr.num_sge = 1;
+
+    IbvLib::recv_wr* badWr = nullptr;
+    TP_VLOG(6) << "Channel context " << id_ << " posting recv on device "
+               << name_ << " for QP " << qp->qp_num;
+    TP_CHECK_IBV_INT(ibvLib_.post_recv(qp.get(), &wr, &badWr));
+    TP_THROW_ASSERT_IF(badWr != nullptr);
+    numAvailableRecvSlots_--;
+    requestsInFlight_.emplace(
+        wr.wr_id, std::make_tuple(IbvLib::WC_RECV, std::move(cb)));
+  } else {
+    TP_VLOG(6) << "Channel context " << id_ << " queueing up recv on device "
+               << name_ << " for QP " << qp->qp_num;
+    recvsWaitingForSlots_.emplace_back(qp, info, std::move(cb));
+  }
+}
+
+IbvMemoryRegion& IbvNic::registerMemory(CudaBuffer buffer) {
+  // FIXME Instead of re-querying the device, have the caller provide it.
+  CudaDeviceGuard guard(cudaDeviceForPointer(cudaLib_, buffer.ptr));
+
+  CUdeviceptr basePtr;
+  size_t allocSize;
+  TP_CUDA_DRIVER_CHECK(
+      cudaLib_,
+      cudaLib_.memGetAddressRange(
+          &basePtr, &allocSize, reinterpret_cast<CUdeviceptr>(buffer.ptr)));
+
+  unsigned long long bufferId;
+  TP_CUDA_DRIVER_CHECK(
+      cudaLib_,
+      cudaLib_.pointerGetAttribute(
+          &bufferId, CU_POINTER_ATTRIBUTE_BUFFER_ID, basePtr));
+
+  auto iter = memoryRegions_.find(bufferId);
+  if (iter != memoryRegions_.end()) {
+    return iter->second;
+  }
+  std::tie(iter, std::ignore) = memoryRegions_.emplace(
+      bufferId,
+      createIbvMemoryRegion(
+          ibvLib_,
+          pd_,
+          reinterpret_cast<void*>(basePtr),
+          allocSize,
+          IbvLib::ACCESS_LOCAL_WRITE));
+  return iter->second;
+}
+
+bool IbvNic::readyToClose() const {
+  return requestsInFlight_.empty();
+}
+
+void IbvNic::setId(std::string id) {
+  id_ = std::move(id);
+}
+
+std::shared_ptr<ContextImpl> ContextImpl::create(
+    optional<std::vector<std::string>> gpuIdxToNicName) {
+  Error error;
+
+  CudaLib cudaLib;
+  std::tie(error, cudaLib) = CudaLib::create();
+  // FIXME Instead of throwing away the error and setting a bool, we should have
+  // a way to set the context in an error state, and use that for viability.
+  if (error) {
+    TP_VLOG(5)
+        << "CUDA GDR channel is not viable because libcuda could not be loaded: "
+        << error.what();
+    return nullptr;
+  }
+
+  IbvLib ibvLib;
+  std::tie(error, ibvLib) = IbvLib::create();
+  // FIXME Instead of throwing away the error and setting a bool, we should have
+  // a way to set the context in an error state, and use that for viability.
+  if (error) {
+    TP_VLOG(5)
+        << "CUDA GDR channel is not viable because libibverbs could not be loaded: "
+        << error.what();
+    return nullptr;
+  }
+
+  if (!isNvidiaPeerMemoryClientActive()) {
+    TP_VLOG(5)
+        << "CUDA GDR channel is not viable because the nv_peer_mem kernel module isn't active";
+    return nullptr;
+  }
+
+  IbvDeviceList deviceList;
+  std::tie(error, deviceList) = IbvDeviceList::create(ibvLib);
+  if (error && error.isOfType<SystemError>() &&
+      error.castToType<SystemError>()->errorCode() == ENOSYS) {
+    TP_VLOG(5)
+        << "CUDA GDR channel couldn't get list of InfiniBand devices because the kernel module isn't "
+        << "loaded";
+    return nullptr;
+  }
+  TP_THROW_ASSERT_IF(error)
+      << "Couldn't get list of InfiniBand devices: " << error.what();
+  if (deviceList.size() == 0) {
+    TP_VLOG(5)
+        << "CUDA GDR channel is not viable because it couldn't find any InfiniBand NICs";
+    return nullptr;
+  }
+
+  // FIXME In principle we could just exclude the GPUs that violate this check
+  // but keep working with the other ones (if any).
+  if (!allGpusHaveEnoughBar1Size()) {
+    TP_VLOG(5)
+        << "CUDA GDR channel is not viable because some GPUs don't have a large enough PCIe BAR1 size";
+    return nullptr;
+  }
+
+  std::unordered_map<Device, std::string> deviceDescriptors;
+  for (const auto& device : getCudaDevices(cudaLib)) {
+    deviceDescriptors[device] = "*";
+  }
+
+  return std::make_shared<ContextImpl>(
+      std::move(deviceDescriptors),
+      std::move(cudaLib),
+      std::move(ibvLib),
+      std::move(deviceList),
+      std::move(gpuIdxToNicName));
+}
+
+ContextImpl::ContextImpl(
+    std::unordered_map<Device, std::string> deviceDescriptors,
+    CudaLib cudaLib,
+    IbvLib ibvLib,
+    IbvDeviceList deviceList,
+    optional<std::vector<std::string>> gpuIdxToNicName)
+    : ContextImplBoilerplate<ContextImpl, ChannelImpl>(
+          std::move(deviceDescriptors)),
+      cudaLib_(std::move(cudaLib)),
+      ibvLib_(std::move(ibvLib)) {
+  std::vector<std::string> actualGpuIdxToNicName;
+  if (gpuIdxToNicName.has_value()) {
+    int numGpus;
+    TP_CUDA_CHECK(cudaGetDeviceCount(&numGpus));
+    TP_THROW_ASSERT_IF(numGpus != gpuIdxToNicName->size())
+        << "The mapping from GPUs to InfiniBand NICs contains an unexpected "
+        << "number of items: found " << gpuIdxToNicName->size() << ", expected "
+        << numGpus;
+
+    actualGpuIdxToNicName = std::move(gpuIdxToNicName.value());
+  } else {
+    actualGpuIdxToNicName = matchGpusToIbvNics(ibvLib, deviceList);
+  }
+
+  for (int gpuIdx = 0; gpuIdx < actualGpuIdxToNicName.size(); gpuIdx++) {
+    TP_VLOG(5) << "CUDA GDR channel mapped GPU #" << gpuIdx
+               << " to InfiniBand NIC " << actualGpuIdxToNicName[gpuIdx];
+  }
+
+  std::unordered_set<std::string> nicNames;
+  for (const auto& nicName : actualGpuIdxToNicName) {
+    nicNames.insert(nicName);
+  }
+
+  std::unordered_map<std::string, size_t> nicNameToNicIdx;
+  // The device index is among all available devices, the NIC index is among the
+  // ones we will use.
+  size_t nicIdx = 0;
+  for (size_t deviceIdx = 0; deviceIdx < deviceList.size(); deviceIdx++) {
+    IbvLib::device& device = deviceList[deviceIdx];
+    std::string deviceName(TP_CHECK_IBV_PTR(ibvLib.get_device_name(&device)));
+    auto iter = nicNames.find(deviceName);
+    if (iter != nicNames.end()) {
+      TP_VLOG(5) << "CUDA GDR channel is using InfiniBand NIC " << deviceName
+                 << " as device #" << nicIdx;
+      ibvNics_.emplace_back(*iter, device, ibvLib_, cudaLib_);
+      nicNameToNicIdx[*iter] = nicIdx;
+      nicIdx++;
+      nicNames.erase(iter);
+    }
+  }
+  TP_THROW_ASSERT_IF(!nicNames.empty())
+      << "Couldn't find all the devices I was supposed to use";
+
+  for (size_t gpuIdx = 0; gpuIdx < actualGpuIdxToNicName.size(); gpuIdx++) {
+    gpuToNic_.push_back(nicNameToNicIdx[actualGpuIdxToNicName[gpuIdx]]);
+  }
+
+  startThread("TP_CUDA_GDR_loop");
+}
+
+const CudaLib& ContextImpl::getCudaLib() {
+  return cudaLib_;
+}
+
+const std::vector<size_t>& ContextImpl::getGpuToNicMapping() {
+  return gpuToNic_;
+}
+
+const IbvLib& ContextImpl::getIbvLib() {
+  return ibvLib_;
+}
+
+IbvNic& ContextImpl::getIbvNic(size_t nicIdx) {
+  TP_DCHECK_LT(nicIdx, ibvNics_.size());
+  return ibvNics_[nicIdx];
+}
+
+bool ContextImpl::pollOnce() {
+  for (IbvNic& ibvNic : ibvNics_) {
+    if (ibvNic.pollOnce()) {
+      return true;
+    }
+  }
+  return pollCudaOnce();
+}
+
+bool ContextImpl::pollCudaOnce() {
+  bool any = false;
+  for (auto iter = pendingCudaEvents_.begin(); iter != pendingCudaEvents_.end();
+       iter++) {
+    const CudaEvent& event = std::get<0>(*iter);
+
+    if (event.query()) {
+      std::function<void(const Error&)> cb = std::move(std::get<1>(*iter));
+      cb(Error::kSuccess);
+      iter = pendingCudaEvents_.erase(iter);
+      any = true;
+    }
+  }
+  return any;
+}
+
+void ContextImpl::waitForCudaEvent(
+    const CudaEvent& event,
+    std::function<void(const Error&)> cb) {
+  deferToLoop([this, &event, cb{std::move(cb)}]() mutable {
+    waitForCudaEventFromLoop(event, std::move(cb));
+  });
+}
+
+void ContextImpl::waitForCudaEventFromLoop(
+    const CudaEvent& event,
+    std::function<void(const Error&)> cb) {
+  TP_DCHECK(inLoop());
+
+  pendingCudaEvents_.emplace_back(event, std::move(cb));
+}
+
+bool ContextImpl::readyToClose() {
+  for (const IbvNic& ibvNic : ibvNics_) {
+    if (!ibvNic.readyToClose()) {
+      return false;
+    }
+  }
+  return pendingCudaEvents_.empty();
+}
+
+void ContextImpl::handleErrorImpl() {
+  stopBusyPolling();
+}
+
+void ContextImpl::joinImpl() {
+  joinThread();
+
+  // FIXME It would be nice if this could be done by the thread itself just
+  // before it returns, rather than by the user.
+  ibvNics_.clear();
+}
+
+void ContextImpl::setIdImpl() {
+  for (IbvNic& ibvNic : ibvNics_) {
+    ibvNic.setId(id_);
+  }
+}
+
+std::shared_ptr<Channel> ContextImpl::createChannel(
+    std::vector<std::shared_ptr<transport::Connection>> connections,
+    Endpoint /* unused */) {
+  TP_DCHECK_EQ(numConnectionsNeeded(), connections.size());
+  return createChannelInternal(
+      std::move(connections[0]), std::move(connections[1]));
+}
+
+size_t ContextImpl::numConnectionsNeeded() const {
+  return 2;
+}
+
+} // namespace cuda_gdr
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/cuda_gdr_xdtt/context_impl.h
+++ b/tensorpipe/channel/cuda_gdr_xdtt/context_impl.h
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <deque>
+#include <functional>
+#include <list>
+#include <map>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+#include <tensorpipe/channel/context_impl_boilerplate.h>
+#include <tensorpipe/channel/cuda_gdr/constants.h>
+#include <tensorpipe/common/busy_polling_loop.h>
+#include <tensorpipe/common/cuda.h>
+#include <tensorpipe/common/cuda_buffer.h>
+#include <tensorpipe/common/cuda_lib.h>
+#include <tensorpipe/common/device.h>
+#include <tensorpipe/common/error.h>
+#include <tensorpipe/common/ibv.h>
+#include <tensorpipe/common/optional.h>
+#include <tensorpipe/transport/context.h>
+
+namespace tensorpipe {
+namespace channel {
+namespace cuda_gdr {
+
+class ChannelImpl;
+
+class IbvNic {
+ public:
+  IbvNic(
+      std::string name,
+      IbvLib::device& device,
+      const IbvLib& ibvLib,
+      const CudaLib& cudaLib);
+
+  IbvProtectionDomain& getIbvPd() {
+    return pd_;
+  }
+
+  IbvCompletionQueue& getIbvCq() {
+    return cq_;
+  }
+
+  const IbvAddress& getIbvAddress() {
+    return addr_;
+  }
+
+  struct SendInfo {
+    void* addr;
+    size_t length;
+    uint32_t lkey;
+  };
+
+  void postSend(
+      IbvQueuePair& qp,
+      SendInfo info,
+      std::function<void(const Error&)> cb);
+
+  struct RecvInfo {
+    void* addr;
+    size_t length;
+    uint32_t lkey;
+  };
+
+  void postRecv(
+      IbvQueuePair& qp,
+      RecvInfo info,
+      std::function<void(const Error&)> cb);
+
+  bool pollOnce();
+
+  IbvMemoryRegion& registerMemory(CudaBuffer buffer);
+
+  bool readyToClose() const;
+
+  void setId(std::string id);
+
+ private:
+  // The ID of the context, for use in verbose logging.
+  std::string id_{"N/A"};
+  // The name of the InfiniBand device.
+  const std::string name_;
+
+  const CudaLib& cudaLib_;
+
+  const IbvLib& ibvLib_;
+  IbvContext ctx_;
+  IbvProtectionDomain pd_;
+  IbvCompletionQueue cq_;
+  IbvAddress addr_;
+
+  size_t numAvailableRecvSlots_ = kNumRecvs;
+  std::deque<
+      std::tuple<IbvQueuePair&, RecvInfo, std::function<void(const Error&)>>>
+      recvsWaitingForSlots_;
+
+  size_t numAvailableSendSlots_ = kNumSends;
+  std::deque<
+      std::tuple<IbvQueuePair&, SendInfo, std::function<void(const Error&)>>>
+      sendsWaitingForSlots_;
+
+  // We need one common map for both send and recv requests because in principle
+  // we cannot access the opcode of a failed operation, meaning we couldn't
+  // match it to its callback. However, we could group them by QP number or, in
+  // fact, we could have the QP store these requests and we just wake it up when
+  // a completion occurs.
+  std::unordered_map<
+      uint64_t,
+      std::tuple<IbvLib::wc_opcode, std::function<void(const Error&)>>>
+      requestsInFlight_;
+  uint64_t nextRequestId_ = 0;
+
+  // The ibverbs memory regions are indexed by the CUDA driver's buffer ID for
+  // the GPU allocation, which is unique (within the process) and never reused.
+  // This will prevent us from re-using the memory region if a buffer gets
+  // deallocated and reallocated (although we will not clean up the old memory
+  // region until we close the context).
+  std::map<unsigned long long, IbvMemoryRegion> memoryRegions_;
+};
+
+class ContextImpl final
+    : public BusyPollingLoop,
+      public ContextImplBoilerplate<ContextImpl, ChannelImpl> {
+ public:
+  static std::shared_ptr<ContextImpl> create(
+      optional<std::vector<std::string>> gpuIdxToNicName = nullopt);
+
+  ContextImpl(
+      std::unordered_map<Device, std::string> deviceDescriptors,
+      CudaLib cudaLib,
+      IbvLib ibvLib,
+      IbvDeviceList deviceList,
+      optional<std::vector<std::string>> gpuIdxToNicName);
+
+  std::shared_ptr<Channel> createChannel(
+      std::vector<std::shared_ptr<transport::Connection>> connections,
+      Endpoint endpoint);
+
+  size_t numConnectionsNeeded() const override;
+
+  const CudaLib& getCudaLib();
+
+  const std::vector<size_t>& getGpuToNicMapping();
+
+  const IbvLib& getIbvLib();
+
+  IbvNic& getIbvNic(size_t nicIdx);
+
+  void waitForCudaEvent(
+      const CudaEvent& event,
+      std::function<void(const Error&)> cb);
+
+ protected:
+  // Implement BusyPollingLoop hooks.
+  bool pollOnce() override;
+  bool readyToClose() override;
+
+  // Implement the entry points called by ContextImplBoilerplate.
+  void handleErrorImpl() override;
+  void joinImpl() override;
+  void setIdImpl() override;
+
+ private:
+  const CudaLib cudaLib_;
+  const IbvLib ibvLib_;
+
+  std::vector<IbvNic> ibvNics_;
+  std::vector<size_t> gpuToNic_;
+
+  std::list<std::tuple<const CudaEvent&, std::function<void(const Error&)>>>
+      pendingCudaEvents_;
+
+  bool pollCudaOnce();
+
+  void waitForCudaEventFromLoop(
+      const CudaEvent& event,
+      std::function<void(const Error&)> cb);
+};
+
+} // namespace cuda_gdr
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/cuda_gdr_xdtt/error.h
+++ b/tensorpipe/channel/cuda_gdr_xdtt/error.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+
+#include <tensorpipe/channel/error.h>
+
+namespace tensorpipe {
+namespace channel {
+namespace cuda_gdr {
+
+class IbvError final : public BaseError {
+ public:
+  explicit IbvError(std::string error) : error_(error) {}
+
+  std::string what() const override {
+    return error_;
+  }
+
+ private:
+  std::string error_;
+};
+
+} // namespace cuda_gdr
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/cuda_gdr_xdtt/factory.cc
+++ b/tensorpipe/channel/cuda_gdr_xdtt/factory.cc
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/channel/cuda_gdr/factory.h>
+
+#include <tensorpipe/channel/context_boilerplate.h>
+#include <tensorpipe/channel/cuda_gdr/channel_impl.h>
+#include <tensorpipe/channel/cuda_gdr/context_impl.h>
+
+namespace tensorpipe {
+namespace channel {
+namespace cuda_gdr {
+
+std::shared_ptr<Context> create(
+    optional<std::vector<std::string>> gpuIdxToNicName) {
+  return std::make_shared<ContextBoilerplate<ContextImpl, ChannelImpl>>(
+      std::move(gpuIdxToNicName));
+}
+
+} // namespace cuda_gdr
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/cuda_gdr_xdtt/factory.h
+++ b/tensorpipe/channel/cuda_gdr_xdtt/factory.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include <tensorpipe/channel/context.h>
+#include <tensorpipe/common/optional.h>
+
+namespace tensorpipe {
+namespace channel {
+namespace cuda_gdr {
+
+std::shared_ptr<Context> create(
+    optional<std::vector<std::string>> gpuIdxToNicName = nullopt);
+
+} // namespace cuda_gdr
+} // namespace channel
+} // namespace tensorpipe


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #428 Fix test for interleaved zero-length tensors.
* #427 Enable CPU buffers in CUDA GDR XDTT channel.
* #426 Handle CPU buffers in CUDA GDR XDTT.
* #425 Add tests for CUDA GDR XDTT channel.
* #424 Add IbvNic::registerMemory overload for CPU buffers.
* #423 Add CMake declaration for cuda_gdr_xdtt.
* #422 Rename new channel to Cuda Xdtt.
* **#421 Duplicate CUDA GDR channel for XDTT.**

Differential Revision: [D33399434](https://our.internmc.facebook.com/intern/diff/D33399434)