### PR TITLE
Rename new channel to Cuda Xdtt.

### DIFF
--- a/tensorpipe/channel/cuda_gdr_xdtt/channel_impl.cc
+++ b/tensorpipe/channel/cuda_gdr_xdtt/channel_impl.cc
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <tensorpipe/channel/cuda_gdr/channel_impl.h>
+#include <tensorpipe/channel/cuda_gdr_xdtt/channel_impl.h>
 
 #include <algorithm>
 #include <cstring>
@@ -15,7 +15,7 @@
 #include <utility>
 #include <vector>
 
-#include <tensorpipe/channel/cuda_gdr/context_impl.h>
+#include <tensorpipe/channel/cuda_gdr_xdtt/context_impl.h>
 #include <tensorpipe/common/cuda_buffer.h>
 #include <tensorpipe/common/defs.h>
 #include <tensorpipe/common/error.h>
@@ -23,7 +23,7 @@
 
 namespace tensorpipe {
 namespace channel {
-namespace cuda_gdr {
+namespace cuda_gdr_xdtt {
 
 namespace {
 
@@ -620,6 +620,6 @@ void ChannelImpl::cleanup() {
   context_->unenroll(*this);
 }
 
-} // namespace cuda_gdr
+} // namespace cuda_gdr_xdtt
 } // namespace channel
 } // namespace tensorpipe

--- a/tensorpipe/channel/cuda_gdr_xdtt/channel_impl.h
+++ b/tensorpipe/channel/cuda_gdr_xdtt/channel_impl.h
@@ -26,7 +26,7 @@
 
 namespace tensorpipe {
 namespace channel {
-namespace cuda_gdr {
+namespace cuda_gdr_xdtt {
 
 class ContextImpl;
 
@@ -245,10 +245,10 @@ class ChannelImpl final
   // This struct is used to bundle the queue pair with some additional metadata.
   struct QueuePair {
     IbvQueuePair queuePair;
-    // The CUDA GDR channel could be asked to transmit arbitrarily large tensors
-    // and in principle it could directly forward them to the NIC as they are.
-    // However IB NICs have limits on the size of each message. Hence we
-    // determine these sizes, one per queue pair (as the minimum of the local
+    // The CUDA GDR XDTT channel could be asked to transmit arbitrarily large
+    // tensors and in principle it could directly forward them to the NIC as
+    // they are. However IB NICs have limits on the size of each message. Hence
+    // we determine these sizes, one per queue pair (as the minimum of the local
     // and remote sizes) and then split our tensors in chunks of that size.
     uint32_t maximumMessageSize;
   };
@@ -297,6 +297,6 @@ class ChannelImpl final
   void callRecvCallback(RecvOpIter opIter);
 };
 
-} // namespace cuda_gdr
+} // namespace cuda_gdr_xdtt
 } // namespace channel
 } // namespace tensorpipe

--- a/tensorpipe/channel/cuda_gdr_xdtt/constants.h
+++ b/tensorpipe/channel/cuda_gdr_xdtt/constants.h
@@ -12,7 +12,7 @@
 
 namespace tensorpipe {
 namespace channel {
-namespace cuda_gdr {
+namespace cuda_gdr_xdtt {
 
 namespace {
 
@@ -41,6 +41,6 @@ constexpr int kNumPolledWorkCompletions = 32;
 
 } // namespace
 
-} // namespace cuda_gdr
+} // namespace cuda_gdr_xdtt
 } // namespace channel
 } // namespace tensorpipe

--- a/tensorpipe/channel/cuda_gdr_xdtt/context_impl.cc
+++ b/tensorpipe/channel/cuda_gdr_xdtt/context_impl.cc
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <tensorpipe/channel/cuda_gdr/context_impl.h>
+#include <tensorpipe/channel/cuda_gdr_xdtt/context_impl.h>
 
 #include <array>
 #include <climits>
@@ -27,15 +27,15 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
-#include <tensorpipe/channel/cuda_gdr/channel_impl.h>
-#include <tensorpipe/channel/cuda_gdr/error.h>
+#include <tensorpipe/channel/cuda_gdr_xdtt/channel_impl.h>
+#include <tensorpipe/channel/cuda_gdr_xdtt/error.h>
 #include <tensorpipe/common/cuda.h>
 #include <tensorpipe/common/defs.h>
 #include <tensorpipe/common/error_macros.h>
 
 namespace tensorpipe {
 namespace channel {
-namespace cuda_gdr {
+namespace cuda_gdr_xdtt {
 
 namespace {
 
@@ -459,7 +459,7 @@ std::shared_ptr<ContextImpl> ContextImpl::create(
   // a way to set the context in an error state, and use that for viability.
   if (error) {
     TP_VLOG(5)
-        << "CUDA GDR channel is not viable because libcuda could not be loaded: "
+        << "CUDA GDR XDTT channel is not viable because libcuda could not be loaded: "
         << error.what();
     return nullptr;
   }
@@ -470,14 +470,14 @@ std::shared_ptr<ContextImpl> ContextImpl::create(
   // a way to set the context in an error state, and use that for viability.
   if (error) {
     TP_VLOG(5)
-        << "CUDA GDR channel is not viable because libibverbs could not be loaded: "
+        << "CUDA GDR XDTT channel is not viable because libibverbs could not be loaded: "
         << error.what();
     return nullptr;
   }
 
   if (!isNvidiaPeerMemoryClientActive()) {
     TP_VLOG(5)
-        << "CUDA GDR channel is not viable because the nv_peer_mem kernel module isn't active";
+        << "CUDA GDR XDTT channel is not viable because the nv_peer_mem kernel module isn't active";
     return nullptr;
   }
 
@@ -486,7 +486,7 @@ std::shared_ptr<ContextImpl> ContextImpl::create(
   if (error && error.isOfType<SystemError>() &&
       error.castToType<SystemError>()->errorCode() == ENOSYS) {
     TP_VLOG(5)
-        << "CUDA GDR channel couldn't get list of InfiniBand devices because the kernel module isn't "
+        << "CUDA GDR XDTT channel couldn't get list of InfiniBand devices because the kernel module isn't "
         << "loaded";
     return nullptr;
   }
@@ -494,7 +494,7 @@ std::shared_ptr<ContextImpl> ContextImpl::create(
       << "Couldn't get list of InfiniBand devices: " << error.what();
   if (deviceList.size() == 0) {
     TP_VLOG(5)
-        << "CUDA GDR channel is not viable because it couldn't find any InfiniBand NICs";
+        << "CUDA GDR XDTT channel is not viable because it couldn't find any InfiniBand NICs";
     return nullptr;
   }
 
@@ -502,7 +502,7 @@ std::shared_ptr<ContextImpl> ContextImpl::create(
   // but keep working with the other ones (if any).
   if (!allGpusHaveEnoughBar1Size()) {
     TP_VLOG(5)
-        << "CUDA GDR channel is not viable because some GPUs don't have a large enough PCIe BAR1 size";
+        << "CUDA GDR XDTT channel is not viable because some GPUs don't have a large enough PCIe BAR1 size";
     return nullptr;
   }
 
@@ -544,7 +544,7 @@ ContextImpl::ContextImpl(
   }
 
   for (int gpuIdx = 0; gpuIdx < actualGpuIdxToNicName.size(); gpuIdx++) {
-    TP_VLOG(5) << "CUDA GDR channel mapped GPU #" << gpuIdx
+    TP_VLOG(5) << "CUDA GDR XDTT channel mapped GPU #" << gpuIdx
                << " to InfiniBand NIC " << actualGpuIdxToNicName[gpuIdx];
   }
 
@@ -562,8 +562,8 @@ ContextImpl::ContextImpl(
     std::string deviceName(TP_CHECK_IBV_PTR(ibvLib.get_device_name(&device)));
     auto iter = nicNames.find(deviceName);
     if (iter != nicNames.end()) {
-      TP_VLOG(5) << "CUDA GDR channel is using InfiniBand NIC " << deviceName
-                 << " as device #" << nicIdx;
+      TP_VLOG(5) << "CUDA GDR XDTT channel is using InfiniBand NIC "
+                 << deviceName << " as device #" << nicIdx;
       ibvNics_.emplace_back(*iter, device, ibvLib_, cudaLib_);
       nicNameToNicIdx[*iter] = nicIdx;
       nicIdx++;
@@ -577,7 +577,7 @@ ContextImpl::ContextImpl(
     gpuToNic_.push_back(nicNameToNicIdx[actualGpuIdxToNicName[gpuIdx]]);
   }
 
-  startThread("TP_CUDA_GDR_loop");
+  startThread("TP_CUDA_GDR_XDTT_loop");
 }
 
 const CudaLib& ContextImpl::getCudaLib() {
@@ -677,6 +677,6 @@ size_t ContextImpl::numConnectionsNeeded() const {
   return 2;
 }
 
-} // namespace cuda_gdr
+} // namespace cuda_gdr_xdtt
 } // namespace channel
 } // namespace tensorpipe

--- a/tensorpipe/channel/cuda_gdr_xdtt/context_impl.h
+++ b/tensorpipe/channel/cuda_gdr_xdtt/context_impl.h
@@ -19,7 +19,7 @@
 #include <vector>
 
 #include <tensorpipe/channel/context_impl_boilerplate.h>
-#include <tensorpipe/channel/cuda_gdr/constants.h>
+#include <tensorpipe/channel/cuda_gdr_xdtt/constants.h>
 #include <tensorpipe/common/busy_polling_loop.h>
 #include <tensorpipe/common/cuda.h>
 #include <tensorpipe/common/cuda_buffer.h>
@@ -32,7 +32,7 @@
 
 namespace tensorpipe {
 namespace channel {
-namespace cuda_gdr {
+namespace cuda_gdr_xdtt {
 
 class ChannelImpl;
 
@@ -188,6 +188,6 @@ class ContextImpl final
       std::function<void(const Error&)> cb);
 };
 
-} // namespace cuda_gdr
+} // namespace cuda_gdr_xdtt
 } // namespace channel
 } // namespace tensorpipe

--- a/tensorpipe/channel/cuda_gdr_xdtt/error.h
+++ b/tensorpipe/channel/cuda_gdr_xdtt/error.h
@@ -14,7 +14,7 @@
 
 namespace tensorpipe {
 namespace channel {
-namespace cuda_gdr {
+namespace cuda_gdr_xdtt {
 
 class IbvError final : public BaseError {
  public:
@@ -28,6 +28,6 @@ class IbvError final : public BaseError {
   std::string error_;
 };
 
-} // namespace cuda_gdr
+} // namespace cuda_gdr_xdtt
 } // namespace channel
 } // namespace tensorpipe

--- a/tensorpipe/channel/cuda_gdr_xdtt/factory.cc
+++ b/tensorpipe/channel/cuda_gdr_xdtt/factory.cc
@@ -6,15 +6,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <tensorpipe/channel/cuda_gdr/factory.h>
+#include <tensorpipe/channel/cuda_gdr_xdtt/factory.h>
 
 #include <tensorpipe/channel/context_boilerplate.h>
-#include <tensorpipe/channel/cuda_gdr/channel_impl.h>
-#include <tensorpipe/channel/cuda_gdr/context_impl.h>
+#include <tensorpipe/channel/cuda_gdr_xdtt/channel_impl.h>
+#include <tensorpipe/channel/cuda_gdr_xdtt/context_impl.h>
 
 namespace tensorpipe {
 namespace channel {
-namespace cuda_gdr {
+namespace cuda_gdr_xdtt {
 
 std::shared_ptr<Context> create(
     optional<std::vector<std::string>> gpuIdxToNicName) {
@@ -22,6 +22,6 @@ std::shared_ptr<Context> create(
       std::move(gpuIdxToNicName));
 }
 
-} // namespace cuda_gdr
+} // namespace cuda_gdr_xdtt
 } // namespace channel
 } // namespace tensorpipe

--- a/tensorpipe/channel/cuda_gdr_xdtt/factory.h
+++ b/tensorpipe/channel/cuda_gdr_xdtt/factory.h
@@ -16,11 +16,11 @@
 
 namespace tensorpipe {
 namespace channel {
-namespace cuda_gdr {
+namespace cuda_gdr_xdtt {
 
 std::shared_ptr<Context> create(
     optional<std::vector<std::string>> gpuIdxToNicName = nullopt);
 
-} // namespace cuda_gdr
+} // namespace cuda_gdr_xdtt
 } // namespace channel
 } // namespace tensorpipe


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #428 Fix test for interleaved zero-length tensors.
* #427 Enable CPU buffers in CUDA GDR XDTT channel.
* #426 Handle CPU buffers in CUDA GDR XDTT.
* #425 Add tests for CUDA GDR XDTT channel.
* #424 Add IbvNic::registerMemory overload for CPU buffers.
* #423 Add CMake declaration for cuda_gdr_xdtt.
* **#422 Rename new channel to Cuda Xdtt.**
* #421 Duplicate CUDA GDR channel for XDTT.

Differential Revision: [D33399437](https://our.internmc.facebook.com/intern/diff/D33399437)