### PR TITLE
Add CMake declaration for cuda_gdr_xdtt.

### DIFF
--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -293,6 +293,22 @@ if(TP_USE_CUDA)
     set(TENSORPIPE_HAS_CUDA_GDR_CHANNEL 1)
   endif()
 
+  ### cuda_gdr_xdtt
+
+  tp_conditional_backend(
+    TP_ENABLE_CUDA_GDR_XDTT "Enable CUDA GpuDirect (InfiniBand) XDTT channel" "LINUX")
+  if(TP_ENABLE_CUDA_GDR_XDTT)
+    list(APPEND TP_CUDA_SRCS
+      common/ibv.cc
+      channel/cuda_gdr_xdtt/channel_impl.cc
+      channel/cuda_gdr_xdtt/context_impl.cc
+      channel/cuda_gdr_xdtt/factory.cc)
+    list(APPEND TP_CUDA_PUBLIC_HDRS
+      channel/cuda_gdr_xdtt/error.h
+      channel/cuda_gdr_xdtt/factory.h)
+    set(TENSORPIPE_HAS_CUDA_GDR_XDTT_CHANNEL 1)
+  endif()
+
   configure_file(config_cuda.h.in config_cuda.h)
 
   add_library(tensorpipe_cuda ${TP_STATIC_OR_SHARED} ${TP_CUDA_SRCS})


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #428 Fix test for interleaved zero-length tensors.
* #427 Enable CPU buffers in CUDA GDR XDTT channel.
* #426 Handle CPU buffers in CUDA GDR XDTT.
* #425 Add tests for CUDA GDR XDTT channel.
* #424 Add IbvNic::registerMemory overload for CPU buffers.
* **#423 Add CMake declaration for cuda_gdr_xdtt.**
* #422 Rename new channel to Cuda Xdtt.
* #421 Duplicate CUDA GDR channel for XDTT.

Differential Revision: [D33399433](https://our.internmc.facebook.com/intern/diff/D33399433)