### PR TITLE
Add IbvNic::registerMemory overload for CPU buffers.

### DIFF
--- a/tensorpipe/channel/cuda_gdr_xdtt/context_impl.h
+++ b/tensorpipe/channel/cuda_gdr_xdtt/context_impl.h
@@ -80,6 +80,7 @@ class IbvNic {
 
   bool pollOnce();
 
+  IbvMemoryRegion& registerMemory(CpuBuffer buffer, size_t allocSize);
   IbvMemoryRegion& registerMemory(CudaBuffer buffer);
 
   bool readyToClose() const;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #428 Fix test for interleaved zero-length tensors.
* #427 Enable CPU buffers in CUDA GDR XDTT channel.
* #426 Handle CPU buffers in CUDA GDR XDTT.
* #425 Add tests for CUDA GDR XDTT channel.
* **#424 Add IbvNic::registerMemory overload for CPU buffers.**
* #423 Add CMake declaration for cuda_gdr_xdtt.
* #422 Rename new channel to Cuda Xdtt.
* #421 Duplicate CUDA GDR channel for XDTT.

Differential Revision: [D33399436](https://our.internmc.facebook.com/intern/diff/D33399436)