### PR TITLE
Add tests for CUDA GDR XDTT channel.

### DIFF
--- a/tensorpipe/test/CMakeLists.txt
+++ b/tensorpipe/test/CMakeLists.txt
@@ -96,6 +96,7 @@ if(TP_USE_CUDA)
 
   list(APPEND TP_TEST_SRCS
     channel/cuda_gdr/cuda_gdr_test.cc
+    channel/cuda_gdr_xdtt/cuda_gdr_xdtt_test.cc
     )
 
   cuda_add_library(tensorpipe_cuda_kernel channel/kernel.cu)

--- a/tensorpipe/test/channel/cuda_gdr_xdtt/cuda_gdr_xdtt_test.cc
+++ b/tensorpipe/test/channel/cuda_gdr_xdtt/cuda_gdr_xdtt_test.cc
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <numeric>
+
+#include <tensorpipe/channel/cuda_gdr_xdtt/factory.h>
+#include <tensorpipe/test/channel/channel_test_cuda.h>
+
+namespace {
+
+class CudaGdrXdttChannelTestHelper : public CudaChannelTestHelper {
+ protected:
+  std::shared_ptr<tensorpipe::channel::Context> makeContextInternal(
+      std::string id) override {
+    auto context = tensorpipe::channel::cuda_gdr_xdtt::create();
+    context->setId(std::move(id));
+    return context;
+  }
+
+ public:
+  std::shared_ptr<PeerGroup> makePeerGroup() override {
+    return std::make_shared<ProcessPeerGroup>();
+  }
+};
+
+CudaGdrXdttChannelTestHelper helper;
+
+} // namespace
+
+INSTANTIATE_TEST_CASE_P(
+    CudaGdrXdtt,
+    ChannelTestSuite,
+    ::testing::Values(&helper));
+
+INSTANTIATE_TEST_CASE_P(
+    CudaGdrXdtt,
+    CudaChannelTestSuite,
+    ::testing::Values(&helper));
+
+INSTANTIATE_TEST_CASE_P(
+    CudaGdrXdtt,
+    CudaMultiGPUChannelTestSuite,
+    ::testing::Values(&helper));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #428 Fix test for interleaved zero-length tensors.
* #427 Enable CPU buffers in CUDA GDR XDTT channel.
* #426 Handle CPU buffers in CUDA GDR XDTT.
* **#425 Add tests for CUDA GDR XDTT channel.**
* #424 Add IbvNic::registerMemory overload for CPU buffers.
* #423 Add CMake declaration for cuda_gdr_xdtt.
* #422 Rename new channel to Cuda Xdtt.
* #421 Duplicate CUDA GDR channel for XDTT.

Differential Revision: [D33399438](https://our.internmc.facebook.com/intern/diff/D33399438)