### PR TITLE
Enable CPU buffers in CUDA GDR XDTT channel.

### DIFF
--- a/tensorpipe/channel/cuda_gdr_xdtt/context_impl.cc
+++ b/tensorpipe/channel/cuda_gdr_xdtt/context_impl.cc
@@ -526,6 +526,7 @@ std::shared_ptr<ContextImpl> ContextImpl::create(
   }
 
   std::unordered_map<Device, std::string> deviceDescriptors;
+  deviceDescriptors[Device(kCpuDeviceType, 0)] = "*";
   for (const auto& device : getCudaDevices(cudaLib)) {
     deviceDescriptors[device] = "*";
   }

--- a/tensorpipe/test/channel/cuda_gdr_xdtt/cuda_gdr_xdtt_test.cc
+++ b/tensorpipe/test/channel/cuda_gdr_xdtt/cuda_gdr_xdtt_test.cc
@@ -46,3 +46,8 @@ INSTANTIATE_TEST_CASE_P(
     CudaGdrXdtt,
     CudaMultiGPUChannelTestSuite,
     ::testing::Values(&helper));
+
+INSTANTIATE_TEST_CASE_P(
+    CudaGdrXdtt,
+    CudaXDTTChannelTestSuite,
+    ::testing::Values(&helper));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #428 Fix test for interleaved zero-length tensors.
* **#427 Enable CPU buffers in CUDA GDR XDTT channel.**
* #426 Handle CPU buffers in CUDA GDR XDTT.
* #425 Add tests for CUDA GDR XDTT channel.
* #424 Add IbvNic::registerMemory overload for CPU buffers.
* #423 Add CMake declaration for cuda_gdr_xdtt.
* #422 Rename new channel to Cuda Xdtt.
* #421 Duplicate CUDA GDR channel for XDTT.

Differential Revision: [D33399439](https://our.internmc.facebook.com/intern/diff/D33399439)