### PR TITLE
CMake: support find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,5 +24,16 @@ include(MiscCheck)
 add_subdirectory(tensorpipe)
 
 install(EXPORT TensorpipeTargets
-        DESTINATION share/cmake/Tensorpipe
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cmake/Tensorpipe
         FILE TensorpipeTargets.cmake)
+
+# Create TensorpipeConfig.cmake for find_package(Tensorpipe CONFIG)
+include(CMakePackageConfigHelpers)
+get_filename_component(CONFIG_FILE_PATH ${CMAKE_CURRENT_BINARY_DIR}/TensorpipeConfig.cmake ABSOLUTE)
+configure_package_config_file(
+  cmake/TensorpipeConfig.cmake.in ${CONFIG_FILE_PATH}
+  INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cmake/Tensorpipe)
+
+# Install the generated config file
+install(FILES ${CONFIG_FILE_PATH}
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cmake/Tensorpipe)

--- a/cmake/TensorpipeConfig.cmake.in
+++ b/cmake/TensorpipeConfig.cmake.in
@@ -1,0 +1,12 @@
+@PACKAGE_INIT@
+
+get_filename_component(_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+file(GLOB CONFIG_FILES "${_DIR}/TensorpipeConfig-*.cmake")
+foreach(f ${CONFIG_FILES})
+  include(${f})
+endforeach()
+
+# import targets 
+include("${_DIR}/TensorpipeTargets.cmake")
+
+check_required_components(@PROJECT_NAME@)

--- a/tensorpipe/python/CMakeLists.txt
+++ b/tensorpipe/python/CMakeLists.txt
@@ -14,3 +14,8 @@ endif()
 set(PYBIND11_CPP_STANDARD -std=c++14)
 pybind11_add_module(pytensorpipe tensorpipe.cc)
 target_link_libraries(pytensorpipe PRIVATE tensorpipe)
+
+install(TARGETS pytensorpipe
+        EXPORT TensorpipeTargets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Resolves #320 

### Changes

* Create TensorpipeConfig.cmake from the template
* Use CMAKE_INSTALL_DATAROOTDIR for share/Tensorpipe
* Add `pytensorpipe` to install targets

```cmake
find_package(Tensorpipe CONFIG REQUIRED)
```

```console
$ cmake -Bbuild -DTensorpipe_DIR=/path/to/install/share/cmake/Tensorpipe # ...
```

Install result should be like this.

```console
$ tree .
.
├── include
│   └── tensorpipe
├── lib
│   ├── libtensorpipe.so
│   ├── libtensorpipe_cuda.so
│   ├── libtensorpipe_uv.a
│   └── pytensorpipe.cpython-38-x86_64-linux-gnu.so
└── share
    └── cmake
        └── Tensorpipe
            ├── TensorpipeConfig.cmake
            ├── TensorpipeTargets-debug.cmake
            └── TensorpipeTargets.cmake

``` 

### Related Works

* https://github.com/microsoft/vcpkg/pull/23569

