### PR TITLE
Select ibv device who has active port_state.

### DIFF
--- a/tensorpipe/common/ibv_lib.h
+++ b/tensorpipe/common/ibv_lib.h
@@ -41,7 +41,8 @@ namespace tensorpipe {
   _(query_gid, int, (IbvLib::context*, uint8_t, int, IbvLib::gid*))   \
   _(query_port, int, (IbvLib::context*, uint8_t, IbvLib::port_attr*)) \
   _(reg_mr, IbvLib::mr*, (IbvLib::pd*, void*, size_t, int))           \
-  _(wc_status_str, const char*, (IbvLib::wc_status))
+  _(wc_status_str, const char*, (IbvLib::wc_status))                  \
+  _(port_state_str, const char*, (IbvLib::port_state))
 
 // Wrapper for libibverbs.
 


### PR DESCRIPTION
If the deviceList contains multiple ibv devices, we want to select the device of the port whose port_state is active, instead of just selecting the first device in the deviceList by default. This is very useful. If we choose the first device without checking, it is likely that the IB runtime can be initialized successfully, but some weird errors will be reported in the ibv_post_send stage. At this time, it is difficult to determine the reason for the error is that we chose a wrong ibv device.

This PR is to fix #455.