### PR TITLE
[CUDA] Use cudaDeviceGetAttribute to get cudaComputeMode attribute

### DIFF
--- a/tensorpipe/channel/cuda_ipc/context_impl.cc
+++ b/tensorpipe/channel/cuda_ipc/context_impl.cc
@@ -233,7 +233,9 @@ std::shared_ptr<ContextImpl> ContextImpl::create() {
 
     // The other two compute modes are "exclusive" and "prohibited", both of
     // which prevent access from an other process.
-    if (props.computeMode != cudaComputeModeDefault) {
+    int computeMode = -1;
+    TP_CUDA_CHECK(cudaDeviceGetAttribute(&computeMode, cudaDevAttrComputeMode, device.index));
+    if (computeMode != cudaComputeModeDefault) {
       TP_VLOG(4) << "CUDA IPC channel is not viable because CUDA device "
                  << device.index << " is not in default compute mode";
       return nullptr;


### PR DESCRIPTION
According to the [documentation](https://docs.nvidia.com/cuda/cuda-runtime-api/structcudaDeviceProp.html#structcudaDeviceProp_15458a603dcbca1dd361ac5b99c07675b) `cudaDeviceProp::computeMode` is deprecated, so in future versions it will not be accessible through `cudaGetDeviceProperties`. The best alternative is to use `cudaDeviceGetAttribute(&computeMode, cudaDevAttrComputeMode, device_index)` call, which is available since before CUDA 11.

cc @malfet 